### PR TITLE
Fixing some typos in the vignette

### DIFF
--- a/vignettes/mizer_vignette.Rnw
+++ b/vignettes/mizer_vignette.Rnw
@@ -22,7 +22,6 @@
 %\setkeys{Gin}{width=0.4\textwidth}
 %after \begin{document} to get smaller plots.
 
-
 \documentclass{article}
 \setlength{\parindent}{0pt}	% Eliminate the indent at the beginning of a new paragraph
 %\setcounter{secnumdepth}{0}	% Elimate the section numbering starting from a specific depth (see WikiBook)
@@ -72,7 +71,6 @@
 \newcommand{\args}[1]{{\texttt{#1}}}
 
 \begin{document}
-\SweaveOpts{concordance=TRUE}
 % Makes the ACTUAL images the same width as the text
 \setkeys{Gin}{width=0.95\textwidth}
 % width = x, in the <<>>= affects the R plot (i.e. label size) but not the actual image width


### PR DESCRIPTION
Finlay, I have begun looking at mizer and I am impressed. The vignette is extremely well written and useful and I am working myself through the examples. While reading I came across some trivial typos. I thought fixing them would be a good pretext for getting in touch. It is not worth your time looking at them in detail, except perhaps the changes in equation (3.4) and (3.9).

One other thing: the function $\mu_p(w)$ in equation (3.15) appears not to be defined anywhere. One might guess that it is defined similar to the $\mu_p.i$ in (3.12), but what to use in place of the $f_i$ that appears in that equation?
