### PR TITLE
Mizer does not work on all machines.

### DIFF
--- a/R/project.r
+++ b/R/project.r
@@ -80,8 +80,8 @@ setMethod('project', signature(object='MizerParams', effort='missing'),
 setMethod('project', signature(object='MizerParams', effort='numeric'),
     function(object, effort,  t_max = 100, dt = 0.1, ...){
     #if (!all.equal(t_max %% dt, 0))
-	if (!all((t_max %% dt) == 0))
-	    stop("t_max must be divisible by dt with no remainder")
+# 	if (!all((t_max %% dt) == 0))
+# 	    stop("t_max must be divisible by dt with no remainder")
 	no_gears <- dim(object@catchability)[1]
 	if ((length(effort)>1) & (length(effort) != no_gears))
 	    stop("Effort vector must be the same length as the number of fishing gears\n")
@@ -141,8 +141,8 @@ setMethod('project', signature(object='MizerParams', effort='array'),
 
         # Make the MizerSim object with the right size
         # We only save every t_save steps
-        if (!all((t_save %% dt)  == 0))
-            stop("t_save must be divisible by dt with no remainder")
+#         if (!all((t_save %% dt)  == 0))
+#             stop("t_save must be divisible by dt with no remainder")
         t_dimnames_index <- as.integer(seq(from = 1+ ((t_save-1) / dt), to = length(time_effort_dt), by = t_save/dt))
         t_dimnames_index <- t_dimnames_index[t_dimnames_index>0]
         t_dimnames <- time_effort_dt[t_dimnames_index]


### PR DESCRIPTION
I was quite surprised when mizer was not working on my home PC even though it worked so nicely in the office. I have the same version of R 3.0.2 on both machines, so I was a bit puzzled. It turns out that the %% operator is machine dependent when used with non-integer divisor. On my PC for example 50 %% 0.1 evaluates to 0.1, not to 0 as expected. This has the consequence that the checks that t_max and t_save are divisible by dt sometimes fail unexpectedly.

This machine dependence of the result of %% is actually documented in the R help. It says there:
"%% and x %/% y can be used for non-integer y, e.g. 1 %/% 0.2, but the results are subject to representation error and so may be platform-dependent. Because the IEC 60059 representation of 0.2 is a binary fraction slightly larger than 0.2, the answer to 1 %/% 0.2 should be 4 but most platforms give 5."

I do not know how to check divisibility in such a way that it is not machine dependent, so I just commented out the checks. The rest of the code seems to work fine.
