### PR TITLE
Updated URL to https://sizespectrum.org/mizer/

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,5 +62,5 @@ VignetteBuilder: knitr
 RoxygenNote: 6.1.1.9000
 Encoding: UTF-8
 LazyData: true
-URL: https://sizespectrum.github.io/mizer/, https://github.com/sizespectrum/mizer
+URL: https://sizespectrum.org/mizer/, https://github.com/sizespectrum/mizer
 BugReports: https://github.com/sizespectrum/mizer/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -130,8 +130,8 @@ and is also used when setting up a new model with `set_multispecies_model()`.
   
 ## Documentation
 
-* Mizer now has a documentation website at <https://sizespectrum.github.io/mizer>
-  for the latest released version and at <https://sizespectrum.github.io/mizer/dev>
+* Mizer now has a documentation website at <https://sizespectrum.org/mizer/>
+  for the latest released version and at <https://sizespectrum.org/mizer/dev>
   for the development version. (#48)
 * The help pages of mizer functions has been extended massively, see for
   example the help for `set_multispecies_model()`.
@@ -249,7 +249,7 @@ and is also used when setting up a new model with `set_multispecies_model()`.
   removing the bottlenecks in `getPhiPrey()` and `getPredRate()`.
 * Using C++ for the inner loop in the project method for extra speed.
 * Minor corrections to vignette and documentation to bring them into alignment
-  and to document the new home on github and new maintainers.
+  and to document the new home on GitHub and new maintainers.
 
 
 # mizer 0.3

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,5 +75,5 @@ plot(sim)
 ```
 
 See the accompanying
-[Get started](http://sizespectrum.github.io/mizer/dev/articles/mizer.html) page
+[Get started](articles/mizer.html) page
 for more details on how the package works, including detailed examples.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ plot(sim)
 ![](docs/dev/reference/figures/unnamed-chunk-4-1.png)<!-- -->
 
 See the accompanying [Get
-started](http://sizespectrum.github.io/mizer/dev/articles/mizer.html)
+started](https://sizespectrum.org/mizer/dev/articles/mizer.html)
 page for more details on how the package works, including detailed
 examples.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,6 @@
 # This is the configuration for the mizer website using the pkgdown package.
 
-url: https://sizespectrum.github.io/mizer/
+url: https://sizespectrum.org/mizer/
 
 authors:
   Julia Blanchard:

--- a/vignettes/developer_vignette.Rmd
+++ b/vignettes/developer_vignette.Rmd
@@ -62,18 +62,18 @@ You are now all set to develop R packages, and
 
 
 
-## Installing git
-In case git is not already installed on your system, you need to 
+## Installing Git
+In case Git is not already installed on your system, you need to 
 [install it](http://happygitwithr.com/install-git.html). You do not need to install
 any GUI for git because RStudio has 
 [built-in support for git](https://support.rstudio.com/hc/en-us/articles/200532077-Version-Control-with-Git-and-SVN). 
-A good place to learn about using git and github is 
+A good place to learn about using Git and GitHub is 
 [this chapter](http://r-pkgs.had.co.nz/git.html) 
 in the guide by Hadley on R package development.
 
-## Forking mizer from github
+## Forking mizer from GitHub
 
-Mizer is developed using the version control system _git_ and the code is hosted on github.
+Mizer is developed using the version control system _Git_ and the code is hosted on GitHub.
 To work with the code you will create your own git repository with a copy of the mizer code.
 
 Go to https://github.com/sizespectrum/mizer and fork it into your own repository. 

--- a/vignettes/editing_website.Rmd
+++ b/vignettes/editing_website.Rmd
@@ -17,8 +17,8 @@ knitr::opts_chunk$set(
 
 
 ## Website built from package documentation
-The mizer website at [http://sizespectrum.github.io/mizer/] is created
-programmatically from the documentation included in the mizer github
+The mizer website at [https://sizespectrum.org/mizer/] is created
+programmatically from the documentation included in the mizer GitHub
 repository. Thus to edit the website just means editing this documentation.
 The website creation is performed by the 
 [`pkgdown`](https://pkgdown.r-lib.org/index.html) package. You can trigger
@@ -106,8 +106,8 @@ pkgdown::build_reference()
 ```
 
 To change the homepage you edit index.md. This file is very similar to 
-README.md that is used on the mizer homepage on github, but can contain
-extra content like embedded videos that the github homepage does not
+README.md that is used on the mizer homepage on GitHub, but can contain
+extra content like embedded videos that the GitHub homepage does not
 support. After changes to index.md you can update your local copy of
 the website with
 ```{r eval=FALSE}
@@ -120,9 +120,9 @@ a pull request for your changed files against the master branch of the upstream
 repository. 
 
 
-## Github pages
+## GitHub pages
 The website is hosted with [GitHubPages](https://pages.github.com/). In the
-settings pages of the mizer repository on github the source is set to
+settings pages of the mizer repository on GitHub the source is set to
 "master branch/docs folder". This means that only the master branch controls
 the website.
 
@@ -144,5 +144,5 @@ into the source of this page produced the following embedded video:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0RlXqLbFbWc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-The github site itself (as opposed to GitHub Pages) does not support
+The GitHub site itself (as opposed to GitHub Pages) does not support
 embedded videos. 

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -50,7 +50,7 @@ together mizer). If you have not yet installed devtools, do
 ```{r, eval=FALSE}
 install.packages("devtools")
 ```
-Then you can install the latest version from github using
+Then you can install the latest version from GitHub using
 ```{r, eval=FALSE}
 devtools::install_github("sizespectrum/mizer")
 ```

--- a/vignettes/mizer_vignette.Rnw
+++ b/vignettes/mizer_vignette.Rnw
@@ -131,7 +131,7 @@ After installing \pkg{mizer}, to actually use it you need to load the package us
 library(mizer)
 @
 
-The source code for \pkg{mizer} is hosted on Github (\url{https://github.com/sizespectrum/mizer}). If you are feeling brave and wish to try out a development version of \pkg{mizer} you can install the package from here using the \R package \pkg{devtools} (which was used extensively in putting together \pkg{mizer}).
+The source code for \pkg{mizer} is hosted on GitHub (\url{https://github.com/sizespectrum/mizer}). If you are feeling brave and wish to try out a development version of \pkg{mizer} you can install the package from here using the \R package \pkg{devtools} (which was used extensively in putting together \pkg{mizer}).
 
 \subsection{Getting help}
 


### PR DESCRIPTION
and fixed capitalisation of Git and GitHub