### PR TITLE
Adding some diagnostics to steady()

### DIFF
--- a/R/gadgets.R
+++ b/R/gadgets.R
@@ -516,6 +516,7 @@ tuneParams <- function(p, catch = NULL) { #, stomach = NULL) {
         output$general_params <- renderUI({
             
             p <- isolate(params())
+            log_r_pp <- log10(p@rr_pp[1] / p@w_full[1]^(p@n - 1))
             
             l1 <- list(
                 tags$h3(tags$a(id = "general"), "General"),
@@ -534,7 +535,7 @@ tuneParams <- function(p, catch = NULL) { #, stomach = NULL) {
                 numericInput("kappa", "Plankton coefficient kappa",
                              value = p@kappa),
                 sliderInput("log_r_pp", "log10 Plankton replenishment rate",
-                            value = 1, min = -1, max = 4, step = 0.05),
+                            value = log_r_pp, min = -1, max = 4, step = 0.05),
                 numericInput("w_pp_cutoff", "Largest plankton",
                              value = p@w_full[which.min(p@cc_pp > 0)],
                              min = 1e-10,

--- a/R/wrapper_functions.R
+++ b/R/wrapper_functions.R
@@ -1518,6 +1518,7 @@ steady <- function(params, t_max = 100, t_per = 7.5, tol = 10^(-2),
         n_pp[] <- sim@n_pp[no_t, ]
         B[] <- sim@B[no_t, ]
         new_rdi <- getRDI(p, n, n_pp, B)
+        deviation <- max(abs((new_rdi - old_rdi)/old_rdi))
         if (any(new_rdi < rdi_limit)) {
             if (return_sim) {
                 message("One of the species is going extinct.")
@@ -1527,7 +1528,6 @@ steady <- function(params, t_max = 100, t_per = 7.5, tol = 10^(-2),
             stop(paste(extinct, collapse = ", "),
                  "are going extinct.")
         }
-        deviation <- max(abs((new_rdi - old_rdi)/old_rdi))
         if (deviation < tol) {
             break
         }


### PR DESCRIPTION
If steady() runs into a problem when run with return_sim = TRUE, it returns the simulation up to that point.