### PR TITLE
Small typo fixes in documentation

### DIFF
--- a/R/wrapper_functions.R
+++ b/R/wrapper_functions.R
@@ -1452,19 +1452,19 @@ markBackground <- function(object, species) {
 #' 
 #' @param params A \linkS4class{MizerParams} object
 #' @param t_max The maximum number of years to run the simulation. Default is 100.
-#' @param t_per The simulation is broken up into shorter runs of t_per years,
+#' @param t_per The simulation is broken up into shorter runs of `t_per` years,
 #'   after each of which we check for convergence. Default value is 7.5. This
 #'   should be chosen as an odd multiple of the timestep `dt` in order to be
 #'   able to detect period 2 cycles.
 #' @param tol The simulation stops when the relative change in the egg
-#'   production RDI over t_per years is less than tol for every background
+#'   production RDI over `t_per years` is less than `tol` for every background
 #'   species. Default value is 1/100.
-#' @param dt The time step to use in `project()`
+#' @param dt The time step to use in `project()`.
 #' @param return_sim If TRUE, the function returns the MizerSim object holding
 #'   the result of the simulation run. If FALSE (default) the function returns
 #'   a MizerParams object with the "initial" slots set to the steady state.
-#' @param progress_bar A shiny progress object to implement 
-#'   a progress bar in a shiny app. Default FALSE
+#' @param progress_bar A shiny progress object to implement
+#'   a progress bar in a shiny app. Default FALSE.
 #' @export
 #' @md
 #' @examples

--- a/vignettes/build_model_2.Rmd
+++ b/vignettes/build_model_2.Rmd
@@ -65,7 +65,7 @@ higher growth rate. There is also a change in the size distributions of the
 other species, due to the increased predation from species 5.
 
 One thing that has not changed much is the number of small individuals. This may
-surpise you. Given that there is so much more spawning stock biomass for species
+surprise you. Given that there is so much more spawning stock biomass for species
 5, shouldn't there be many more eggs? Yes, and as a consequence species 5 would
 have led to the competitive exclusion of other, less fast-growing species. We
 however wanted a coexistence steady state. Therefore the `steady()` function

--- a/vignettes/build_model_3.Rmd
+++ b/vignettes/build_model_3.Rmd
@@ -78,7 +78,7 @@ abundance there is very little backreaction from the background species, and
 therefore we are in a regime where we understand the steady-state size
 distribution of the species analytically. Therefore mizer was able to find
 initial values for the size distributions that are close to steady state
-values. Wh see that little changes as we run the system to steady state:
+values. We see that little changes as we run the system to steady state:
 ```{r}
 params <- steady(params)
 plotSpectra(params, power = 2, total = TRUE, 


### PR DESCRIPTION
Redo of pull request #114.

Sorry for the beginner mistake of committing dozens of RStudio's automatic whitespace changes along with the substantial edits.