### PR TITLE
For backwards compatibility, accept also r_max as variable name

### DIFF
--- a/R/MizerParams-class.R
+++ b/R/MizerParams-class.R
@@ -820,6 +820,12 @@ set_multispecies_model <- function(species_params,
                                    # setFishing
                                    initial_effort = NULL) {
     
+    ## For backwards compatibility, allow r_max instead of R_max
+    if (!("R_max" %in% names(species_params)) &&
+        "r_max" %in% names(species_params)) {
+        names(species_params)[names(species_params) == "r_max"] <- "R_max"
+    }
+    
     ## Create MizerParams object ----
     params <- emptyParams(species_params,
                           no_w = no_w, 


### PR DESCRIPTION
The name of the species parameter was recently changed from r_max to R_max. Many people will still have species params tables with the old variable name. This patch allows them to continue using them without having to rename the column first.