### PR TITLE
Fix typo in setColours warning

### DIFF
--- a/R/setColours.R
+++ b/R/setColours.R
@@ -100,7 +100,7 @@ validLinetypes <- function(linetypes) {
     valid <- linetypes %in% list_of_types
 
     if (!all(valid)) {
-        warning("The following are not valid lineypes and will be ",
+        warning("The following are not valid linetypes and will be ",
                 "ignored: ",
                 paste(linetypes[!valid], collapse = ", "),
                 ". The valid values are: ",


### PR DESCRIPTION
## Summary
- fix typo `lineypes` -> `linetypes` in `validLinetypes` warning message

## Testing
- `Rscript -e 'print("hello")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ce0ce3d48327be0e87bbdb67b98a