### PR TITLE
Fix plotSpectra axis limits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -297,6 +297,11 @@ the mathematical details.
 - `getFMort.MizerSim()` was not passing the time argument `t` to user-defined
   fishing mortality functions.
 
+- `plotSpectra()` was incorrectly forcing the y-axis lower limit to 1e-20
+  (instead of auto-scaling to the data) and was using `min(params@w) / 100`
+  as the default lower w-axis limit even when `resource = FALSE`, where
+  `min(params@w)` is more appropriate.
+
 - `upgradeParams()` was silently dropping some slots (e.g. `resource_dynamics`)
   and was not preserving `MizerParams` subclasses and their extra slots when
   upgrading older objects.

--- a/R/plots.R
+++ b/R/plots.R
@@ -600,12 +600,15 @@ plotlyYieldGear <- function(sim, species = NULL,
 #'   If TRUE then the average of the abundances over the
 #'   time range is a geometric mean instead of the default arithmetic mean.
 #' @param wlim A numeric vector of length two providing lower and upper limits
-#'   for the w axis. Use NA to refer to the existing minimum or maximum. Data
-#'   is filtered to this range and the axis limits are set accordingly.
+#'   for the w axis. Use NA for the default: the lower default is
+#'   `min(params@w) / 100` when `resource = TRUE` (to show some resource below
+#'   the fish grid) or `min(params@w)` when `resource = FALSE`; the upper
+#'   default is `max(params@w_full)`. Data is filtered to this range and the
+#'   axis limits are set accordingly.
 #' @param ylim A numeric vector of length two providing lower and upper limits
-#'   for the y axis. Use NA to refer to the existing minimum or maximum. Any
-#'   values below 1e-20 are always cut off. Data is filtered to this range and
-#'   the axis limits are set accordingly.
+#'   for the y axis. Use NA to auto-scale to the data range. Values below 1e-20
+#'   are always filtered out from the data regardless of `ylim[1]`. Data above
+#'   `ylim[2]` is filtered and the upper axis limit is set accordingly.
 #' @param power The abundance is plotted as the number density times the weight
 #' raised to `power`. The default \code{power = 1} gives the biomass
 #' density, whereas \code{power = 2} gives the biomass density with respect
@@ -732,7 +735,7 @@ plot_spectra <- function(params, n, n_pp,
                          highlight, return_data) {
     params <- validParams(params)
     if (is.na(wlim[1])) {
-        wlim[1] <- min(params@w) / 100
+        wlim[1] <- if (resource) min(params@w) / 100 else min(params@w)
     }
     if (is.na(wlim[2])) {
         wlim[2] <- max(params@w_full)
@@ -804,10 +807,8 @@ plot_spectra <- function(params, n, n_pp,
     if (!is.na(ylim[2])) {
         plot_dat <- plot_dat[plot_dat$value <= ylim[2], ]
     }
-    if (is.na(ylim[1])) {
-        ylim[1] <- 1e-20
-    }
-    plot_dat <- plot_dat[plot_dat$value > ylim[1], ]
+    filter_min <- if (is.na(ylim[1])) 1e-20 else ylim[1]
+    plot_dat <- plot_dat[plot_dat$value > filter_min, ]
 
     if (return_data) return(plot_dat)
 

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -283,8 +283,14 @@ test_that("axis limits are set correctly", {
     p <- plotSpectra(sim, species = species, wlim = c(10, NA), ylim = c(NA, 1e8))
     expect_equal(p$scales$scales[[2]]$limits[1], 1)
     expect_equal(p$scales$scales[[2]]$limits[2], log10(max(params@w_full)))
-    expect_equal(p$scales$scales[[1]]$limits[1], -20)
+    expect_true(is.na(p$scales$scales[[1]]$limits[1]))
     expect_equal(p$scales$scales[[1]]$limits[2], 8)
+
+    # Default wlim lower depends on resource argument
+    p_res <- plotSpectra(sim, species = species, return_data = TRUE)
+    p_nores <- plotSpectra(sim, species = species, resource = FALSE, return_data = TRUE)
+    expect_true(min(p_res$w) < min(params@w))
+    expect_equal(min(p_nores$w), min(params@w))
 })
 
 test_that("plotDiet works with MizerSim", {


### PR DESCRIPTION
## Summary

Fixes #340.

- `plotSpectra()` was pinning the y-axis lower limit to `1e-20` even when `ylim[1]` was not specified, causing a large empty region below the data on the log-scale plot. The `1e-20` threshold is now used only to filter near-zero values from the data; the y-axis auto-scales to the data range when `ylim[1]` is `NA`.
- The default lower x-axis limit (`wlim[1]`) now depends on the `resource` argument: `min(params@w) / 100` when `resource = TRUE` (existing behaviour, to show some resource below the fish grid) and `min(params@w)` when `resource = FALSE`.
- Documentation for `wlim` and `ylim` parameters updated to describe this behaviour.

## Test plan

- [ ] Existing axis-limit test updated: y-axis lower limit is now `NA` (auto-scale) when `ylim[1]` is not specified.
- [ ] New test verifies that default `wlim[1]` extends below `min(params@w)` with `resource = TRUE` and equals `min(params@w)` with `resource = FALSE`.
- [ ] Full plot test suite passes: `testthat::test_file("tests/testthat/test-plots.R")` — 72 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)