### PR TITLE
Second-order fishing mortality via bin-averaged selectivity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,13 @@
   or a named vector for individual control. It re-runs `setParams()` to rebuild
   precomputed arrays.
 
+- When `second_order_w()[["bin_average"]]` is `TRUE`, `calc_selectivity()` now
+  stores the bin average of the selectivity over each size bin instead of its
+  value at the left bin edge, making the fishing mortality second order in the
+  bin size. A knife-edge gear then gets the exact fraction of the straddling bin
+  that lies above the knife edge. The default (point-sampled) behaviour is
+  unchanged.
+
 
 # mizer 3.0.0
 

--- a/R/setFishing.R
+++ b/R/setFishing.R
@@ -717,6 +717,21 @@ validEffortVector <- function(effort, params) {
 #' with `w = params@w`, the corresponding species parameters, and the
 #' selectivity parameters from the matching row in `gear_params(params)`.
 #'
+#' @section Bin-averaged selectivity:
+#' By default the selectivity is point-sampled at the grid nodes `params@w`,
+#' i.e. at the left edge of each size bin. This is only first-order accurate in
+#' the bin size when the selectivity is used in the finite-volume update of the
+#' size spectrum. When the `bin_average` entry of the [second_order_w()] slot is
+#' `TRUE`, each selectivity function is instead integrated over its size bin,
+#' so that `selectivity[g, i, j]` holds the bin average
+#' \deqn{\bar S_{g,i,j} = \frac{1}{\Delta w_j} \int_{w_j}^{w_{j+1}} S_{g,i}(w)\, dw.}
+#' The integral is evaluated with a composite-midpoint rule on a log-spaced
+#' sub-grid of each bin, mirroring the bin-integrated predation kernel. This
+#' lifts the fishing mortality towards second order at no extra runtime cost
+#' (the integration happens once here, the rate functions are unchanged). A
+#' welcome side effect is that a knife-edge gear then gets the exact fraction of
+#' the straddling bin that lies above the knife edge, removing a grid artefact.
+#'
 #' @param params A MizerParams object
 #' @return An array (gear x species x size) with the selectivity values
 #' @concept helper
@@ -737,6 +752,19 @@ calc_selectivity <- function(params) {
     gear_names <- unique(gear_params$gear)
     no_gears <- length(gear_names)
 
+    bin_average <- isTRUE(params@second_order_w[["bin_average"]])
+    if (bin_average) {
+        # Log-spaced sub-grid for the composite-midpoint bin average. For bin j
+        # spanning [w_j, w_{j+1}] the ratio is beta_j = w_{j+1}/w_j = 1 + dw_j/w_j
+        # (constant on a geometric grid). Sub-cell q sits at
+        # w_{j,q} = w_j * beta_j^{(q-1/2)/Q}. The weight w_{j,q} is the linear-w
+        # Jacobian, so the weighted mean is (1/Delta w_j) integral S dw.
+        Q <- 100L
+        q_frac <- (seq_len(Q) - 0.5) / Q
+        beta_j <- 1 + params@dw / params@w
+        # w_sub[j, q] = w_j * beta_j^{(q-1/2)/Q}; matrix no_w x Q
+        w_sub <- params@w * outer(beta_j, q_frac, `^`)
+    }
     selectivity <-
         array(0, dim = c(no_gears, no_sp, no_w),
               dimnames = list(gear = gear_names,
@@ -761,10 +789,24 @@ calc_selectivity <- function(params) {
             stop("Some selectivity parameters are NA.")
         }
         # Call selectivity function with selectivity parameters
-        par <- c(list(w = params@w,
-                      species_params = as.list(species_params[species, ])),
-                 as.list(gear_params[g, arg]))
-        sel <- do.call(sel_func, args = par)
+        if (bin_average) {
+            # Evaluate the selectivity on the refined sub-grid and take the
+            # linear-w (finite-volume) bin average over each bin. Because the
+            # sub-cells are log-uniformly spaced, the linear-w integral picks up
+            # the Jacobian factor w_{j,q}, so we weight S by w_sub:
+            #   S_bar_j = sum_q S(w_{j,q}) w_{j,q} / sum_q w_{j,q}.
+            par <- c(list(w = as.vector(w_sub),
+                          species_params = as.list(species_params[species, ])),
+                     as.list(gear_params[g, arg]))
+            sel_sub <- matrix(do.call(sel_func, args = par),
+                              nrow = no_w, ncol = ncol(w_sub))
+            sel <- rowSums(sel_sub * w_sub) / rowSums(w_sub)
+        } else {
+            par <- c(list(w = params@w,
+                          species_params = as.list(species_params[species, ])),
+                     as.list(gear_params[g, arg]))
+            sel <- do.call(sel_func, args = par)
+        }
         selectivity[gear, species, ] <- sel
     }
     return(selectivity)

--- a/man/calc_selectivity.Rd
+++ b/man/calc_selectivity.Rd
@@ -21,6 +21,23 @@ zero. For each listed combination the function named in \code{sel_func} is calle
 with \code{w = params@w}, the corresponding species parameters, and the
 selectivity parameters from the matching row in \code{gear_params(params)}.
 }
+\section{Bin-averaged selectivity}{
+
+By default the selectivity is point-sampled at the grid nodes \code{params@w},
+i.e. at the left edge of each size bin. This is only first-order accurate in
+the bin size when the selectivity is used in the finite-volume update of the
+size spectrum. When the \code{bin_average} entry of the \code{\link[=second_order_w]{second_order_w()}} slot is
+\code{TRUE}, each selectivity function is instead integrated over its size bin,
+so that \code{selectivity[g, i, j]} holds the bin average
+\deqn{\bar S_{g,i,j} = \frac{1}{\Delta w_j} \int_{w_j}^{w_{j+1}} S_{g,i}(w)\, dw.}
+The integral is evaluated with a composite-midpoint rule on a log-spaced
+sub-grid of each bin, mirroring the bin-integrated predation kernel. This
+lifts the fishing mortality towards second order at no extra runtime cost
+(the integration happens once here, the rate functions are unchanged). A
+welcome side effect is that a knife-edge gear then gets the exact fraction of
+the straddling bin that lies above the knife edge, removing a grid artefact.
+}
+
 \examples{
 params <- NS_params
 str(calc_selectivity(params))

--- a/tests/testthat/test-setFishing.R
+++ b/tests/testthat/test-setFishing.R
@@ -294,3 +294,79 @@ test_that("Can get and set initial_effort slot", {
     expect_identical(initial_effort(params), new)
     expect_identical(getInitialEffort(params), new)
 })
+
+# Bin-averaged (second-order) selectivity ----
+test_that("Default path leaves selectivity point-sampled", {
+    params <- NS_params_small
+    # The default flag is off, so calc_selectivity must reproduce a direct
+    # point evaluation of the selectivity functions at params@w.
+    expect_false(isTRUE(second_order_w(params)[["bin_average"]]))
+    sel <- calc_selectivity(params)
+    expect_identical(sel, params@selectivity[])
+})
+
+test_that("Bin-averaging changes selectivity and persists through setParams", {
+    params <- NS_params_small
+    sel_point <- calc_selectivity(params)
+    second_order_w(params) <- c(bin_average = TRUE)
+    # The flag is recorded
+    expect_true(second_order_w(params)[["bin_average"]])
+    sel_avg <- calc_selectivity(params)
+    expect_equal(dim(sel_avg), dim(sel_point))
+    # It really differs from the point-sampled version
+    expect_gt(max(abs(sel_avg - sel_point)), 1e-3)
+    # The setParams pipeline (re-run by the setter) stored the bin average
+    expect_equal(params@selectivity[], sel_avg)
+    # Still a valid selectivity (in [0, 1])
+    expect_true(all(sel_avg >= 0 & sel_avg <= 1))
+})
+
+test_that("Knife-edge bin average is the analytic partial-bin fraction", {
+    params <- NS_params_small
+    w <- params@w
+    dw <- params@dw
+    j <- 8
+    # Knife edge strictly inside bin j
+    edge <- w[j] + 0.37 * dw[j]
+    gp <- gear_params(params)
+    gp$sel_func <- "knife_edge"
+    gp$knife_edge_size <- edge
+    gear_params(params) <- gp
+    second_order_w(params) <- c(bin_average = TRUE)
+    sel <- calc_selectivity(params)["Pelagic", "Herring", ]
+    # Zero below the straddling bin, one above it
+    expect_true(all(sel[seq_len(j - 1)] == 0))
+    expect_true(all(abs(sel[(j + 1):length(sel)] - 1) < 1e-12))
+    # In the straddling bin: fraction of the (linear-w) bin above the edge
+    wjp1 <- w[j] + dw[j]
+    frac <- (wjp1 - edge) / (wjp1 - w[j])
+    # Composite-midpoint rule converges to the analytic fraction
+    expect_equal(sel[j], frac, tolerance = 1e-2, ignore_attr = TRUE)
+})
+
+test_that("Smooth selectivity bin average matches a fine reference", {
+    params <- NS_params_small
+    gp <- gear_params(params)
+    gp$sel_func <- "sigmoid_weight"
+    gp$sigmoidal_weight <- 50
+    gp$sigmoidal_sigma <- 3
+    gear_params(params) <- gp
+    second_order_w(params) <- c(bin_average = TRUE)
+    sel <- calc_selectivity(params)["Pelagic", "Herring", ]
+    w <- params@w
+    dw <- params@dw
+    ref <- vapply(seq_along(w), function(jj) {
+        wjp1 <- w[jj] + dw[jj]
+        ww <- seq(w[jj], wjp1, length.out = 4000)
+        Sv <- sigmoid_weight(ww, sigmoidal_weight = 50, sigmoidal_sigma = 3)
+        mean((Sv[-1] + Sv[-length(Sv)]) / 2)
+    }, numeric(1))
+    expect_equal(sel, ref, tolerance = 1e-4, ignore_attr = TRUE)
+})
+
+test_that("Projection with bin-averaged selectivity runs finite", {
+    params <- NS_params_small
+    second_order_w(params) <- c(bin_average = TRUE)
+    sim <- project(params, t_max = 2)
+    expect_true(all(is.finite(sim@n)))
+})


### PR DESCRIPTION
Closes #375. Part of the second-order-in-Δw programme (#377).

## Summary

Fishing mortality `F = catchability·selectivity·effort` multiplies `N` and is integrated over each size bin, so to be second order in Δw the **selectivity** should be the bin average over `[w_j, w_{j+1}]` rather than point-sampled at the left bin edge. As a side benefit, knife-edge gears get the exact partial-bin selectivity. Gated on the `second_order_w[["bin_average"]]` slot.

## Design

- Bin-averaging added in `calc_selectivity()` (`R/setFishing.R`), gated on `isTRUE(params@second_order_w[["bin_average"]])`. The default path is **byte-identical** (point-sampled at `params@w`).
- A single generic quadrature is used for all selectivity functions: for bin `j` spanning `[w_j, w_{j+1}]`, sub-cells sit at `w_{j,q} = w_j · beta_j^{(q-1/2)/Q}` (Q = 100, composite-midpoint) and the bin average is `S̄_j = Σ_q S(w_{j,q})·w_{j,q} / Σ_q w_{j,q}` (the `w_{j,q}` weight is the linear-`w` Jacobian, realising `(1/Δw_j)∫S dw`).
  - **knife_edge** → converges to the exact partial-bin fraction above the edge.
  - **smooth functions** (e.g. sigmoid) → consistent midpoint bin average.
- Integration happens at setup only — no runtime cost; `mizerFMort()` is untouched.

## Scope note

This covers the finite-volume update quantity (`getFMort`). `getYield`-style diagnostics weight by `w` and would need a separately precomputed `w`-weighted bin integral to be second order — out of scope here (tracked with the summary-integral work, #380).

## Tests

- New tests in `tests/testthat/test-setFishing.R` (default unchanged; knife-edge exact partial-bin straddle; smooth-selectivity bin-average vs a fine trapezoid reference; finite projection).
- Full suite: **0 fail, 0 warn**, no snapshot churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)