### PR TITLE
Second-order reproduction integral via bin-averaged investment (#376)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,15 @@
   mortality sink consistent with the finite-volume scheme. The default
   (point sampling) is unchanged.
 
+- When the `bin_average` entry of the `second_order_w` slot is `TRUE`, the
+  reproduction integral in `mizerRDI()` now trapezoidally bin-averages the
+  per-capita reproductive investment \eqn{\psi(w) E_r(w)} against the
+  cell-average abundance instead of taking its left-bin-edge value, making the
+  density-independent reproduction rate second order in the bin size. The full
+  per-capita investment is averaged together (not `psi` alone) to capture the
+  variation of both factors across the bin. The default (left-edge) behaviour
+  is unchanged.
+
 - `project()` gains a new time-stepping option `method = "tr_bdf2"`. This is an
   L-stable, second-order TR-BDF2 scheme that retains the second-order accuracy
   of `method = "predictor_corrector"` while damping the oscillations that the

--- a/R/reproduction.R
+++ b/R/reproduction.R
@@ -57,6 +57,12 @@ projectRDI <- function(params, n, n_pp, n_other, t = 0,
 projectRDI.MizerParams <- function(params, n, n_pp, n_other, t = 0,
                                    e_growth, mort, e_repro,
                                    diffusion = NULL, ...) {
+    # The reproduction integral \eqn{\int N(w) e_repro(w) dw} is discretised as
+    # \eqn{\sum_j N_j \bar e_repro,j \Delta w_j}. To be second order in the bin
+    # width the per-capita investment is bin-averaged (trapezoidally) when the
+    # `bin_average` entry of `second_order_w` is set; otherwise the left-edge
+    # point value is used, reproducing the previous behaviour byte-for-byte.
+    e_repro <- bin_average_summary_weight(e_repro, params)
     # Calculate total energy from per capita energy
     e_repro_pop <- drop((e_repro * n) %*% params@dw)
     # Assume sex_ratio = 0.5

--- a/tests/testthat/test-reproduction.R
+++ b/tests/testthat/test-reproduction.R
@@ -97,6 +97,39 @@ test_that("mizerRDI integrates reproductive energy with erepro and egg size", {
                  expected)
 })
 
+test_that("mizerRDI default path is unchanged (first-order left-edge sum)", {
+    # With second_order_w off (the default) the reproduction integral must be
+    # the plain left-edge Riemann sum, byte-for-byte with previous mizer.
+    e_repro <- getERepro(params)
+    expected <- 0.5 * drop((e_repro * params@initial_n) %*% params@dw) *
+        params@species_params$erepro / params@w[params@w_min_idx]
+    expect_identical(
+        mizerRDI(params, n = params@initial_n, n_pp = params@initial_n_pp,
+                 n_other = params@initial_n_other, t = 0,
+                 e_growth = getEGrowth(params), mort = getMort(params),
+                 e_repro = e_repro),
+        expected)
+})
+
+test_that("mizerRDI bin-averages the investment when second_order_w is on", {
+    p2 <- params
+    second_order_w(p2) <- c(bin_average = TRUE)
+    e_repro <- getERepro(p2)
+    # Expected: trapezoidal bin-average of e_repro against the cell-average n.
+    e_bar <- bin_average_weight(e_repro)
+    expected <- 0.5 * drop((e_bar * p2@initial_n) %*% p2@dw) *
+        p2@species_params$erepro / p2@w[p2@w_min_idx]
+    got <- mizerRDI(p2, n = p2@initial_n, n_pp = p2@initial_n_pp,
+                    n_other = p2@initial_n_other, t = 0,
+                    e_growth = getEGrowth(p2), mort = getMort(p2),
+                    e_repro = e_repro)
+    expect_equal(got, expected)
+    # And it must differ from the left-edge sum (the smooth weight varies).
+    left_edge <- 0.5 * drop((e_repro * p2@initial_n) %*% p2@dw) *
+        p2@species_params$erepro / p2@w[p2@w_min_idx]
+    expect_false(isTRUE(all.equal(got, left_edge)))
+})
+
 test_that("BevertonHoltRDD works", {
     rdd <- BevertonHoltRDD(rdi, sp)
     expect_identical(rdd, rdi / (1 + rdi/sp$R_max))


### PR DESCRIPTION
Closes #376.

Makes the reproduction integral (`e_repro_pop` in `mizerRDI()`) **second order**
in the bin width when the `bin_average` entry of the `second_order_w` slot is
set, opt-in and parallel to the bin-integrated kernel (#374), bin-averaged
selectivity (#375) and summary integrals (#380).

## Change

`projectRDI.MizerParams()` now wraps the per-capita investment in
`bin_average_summary_weight()` before the integral:

```r
e_repro <- bin_average_summary_weight(e_repro, params)
e_repro_pop <- drop((e_repro * n) %*% params@dw)
```

- **Off (default):** `bin_average_summary_weight()` returns `e_repro`
  unchanged, so the result is the previous left-edge Riemann sum,
  byte-for-byte.
- **On:** the weight is trapezoidally bin-averaged,
  `e_bar,j = ½(e_repro_j + e_repro_{j+1})`, reusing the
  `bin_average_weight()` helper added for #380.

## Why this design

- **Average the product, not `psi` alone.** `e_repro = psi·E_repro`;
  bin-averaging the static `psi` at setup while keeping nodal `E_repro` is only
  first order. Averaging the full per-capita investment at the nodes captures
  the variation of both factors → `O(Δw²)`.
- **Confined to the reproduction integral.** `e` stays a point value for the
  growth flux velocity (`g = e − e_repro`); only its reproduction use-site is
  bin-averaged. This point-value-vs-bin-average split is already documented in
  the numerical-details vignette.
- **Runtime, but cheap:** one vectorised adjacent-bin average per call, no new
  arrays, no change to the time-stepping path.

## Tests

`test-reproduction.R` gains two tests: the default path stays the exact
left-edge sum (`expect_identical`), and with `second_order_w` on the result
equals the trapezoidal bin-average and differs from the left-edge sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)