### PR TITLE
Second-order resource rate and capacity via bin averages (#379)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,19 @@
   mortality sink consistent with the finite-volume scheme. The default
   (point sampling) is unchanged.
 
+- When the `bin_average` entry of the `second_order_w` slot is `TRUE`,
+  `setResource()` now builds the auto-calculated resource rate
+  \eqn{r_p w^{n-1}} and carrying capacity \eqn{\kappa w^{-\lambda}} from their
+  exact bin averages over each size bin instead of point-sampling at the left
+  bin edge, with the bin straddling `w_pp_cutoff` getting the partial average.
+  This makes the unpredated semichemostat equilibrium equal to the cell-average
+  of the background spectrum that the bin-integrated encounter convolution (#374)
+  consumes. Only auto-calculated (scalar) rates and capacities are affected;
+  user-supplied full vectors are left untouched, and the default
+  (point-sampled) behaviour is unchanged. Note that enabling this shifts the
+  resource spectrum by `O(Δw)` (more on coarse grids), so calibrated models may
+  need recalibrating.
+
 - `project()` gains a new time-stepping option `method = "tr_bdf2"`. This is an
   L-stable, second-order TR-BDF2 scheme that retains the second-order accuracy
   of `method = "predictor_corrector"` while damping the oscillations that the

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -31,20 +31,34 @@ different <- function(a, b) {
 #'
 #' This is used by the bin-averaged (second-order) code paths that need the
 #' average of a power-law rate over each bin, for example [setExtMort()] and
-#' the resource semichemostat. The grid does not need to be geometric; only the
-#' left bin edges `w` and the bin widths `dw` are used, with
-#' \eqn{w_{j+1} = w_j + \Delta w_j}.
+#' the resource capacity and rate in [setResource()]. The grid does not need to
+#' be geometric; only the left bin edges `w` and the bin widths `dw` are used,
+#' with \eqn{w_{j+1} = w_j + \Delta w_j}.
+#'
+#' An optional upper cutoff `w_max` handles a knife-edge truncation of the power
+#' law (for example the resource carrying capacity, which is \eqn{\kappa
+#' w^{-\lambda}} below `w_pp_cutoff` and zero above it). The bin straddling the
+#' cutoff then receives the *partial* bin-average — the power-law average over
+#' the part of the bin below `w_max`, divided by the full bin width — and bins
+#' entirely above the cutoff get zero.
 #'
 #' @param w Numeric vector of left bin edges \eqn{w_j}.
 #' @param dw Numeric vector of bin widths \eqn{\Delta w_j} (same length as `w`).
 #' @param d Single numeric exponent of the power law.
+#' @param w_max Optional upper cutoff. The power law is taken to be zero above
+#'   `w_max`, with the straddling bin getting the partial average. Defaults to
+#'   `Inf` (no cutoff), in which case the result is identical to the uncut
+#'   formula.
 #'
 #' @return A numeric vector (same length as `w`) of bin averages of
-#'   \eqn{w^d}.
+#'   \eqn{w^d} (truncated at `w_max` when supplied).
 #' @concept helper
 #' @keywords internal
-power_law_bin_average <- function(w, dw, d) {
-    w_next <- w + dw
+power_law_bin_average <- function(w, dw, d, w_max = Inf) {
+    # Upper integration edge of each bin, clipped at the cutoff. The pmax keeps
+    # bins lying entirely above the cutoff from contributing a negative (they
+    # collapse to a zero-width interval and so average to zero).
+    w_next <- pmax(pmin(w + dw, w_max), w)
     if (d == -1) {
         log(w_next / w) / dw
     } else {

--- a/R/setResource.R
+++ b/R/setResource.R
@@ -186,7 +186,17 @@ setResource.MizerParams <- function(params,
         assert_that(is.numeric(resource_rate))
         if (length(resource_rate) == 1) {
             co <- comment(resource_rate)
-            resource_rate <- resource_rate * w_full ^ (n - 1)
+            if (isTRUE(params@second_order_w[["bin_average"]])) {
+                # Exact bin average of the power law r_pp * w^(n-1) over each
+                # bin, so the relaxation rate is consistent with the
+                # finite-volume cell-average resource density. See the
+                # "Point values and bin averages" section of the
+                # numerical-details vignette.
+                resource_rate <- resource_rate *
+                    power_law_bin_average(w_full, params@dw_full, n - 1)
+            } else {
+                resource_rate <- resource_rate * w_full ^ (n - 1)
+            }
             comment(resource_rate) <- co
         } else if (length(resource_rate) != no_w_full) {
             stop("The 'resource_rate' should have length 1 or length ",
@@ -202,8 +212,22 @@ setResource.MizerParams <- function(params,
         assert_that(is.numeric(resource_capacity))
         if (length(resource_capacity) == 1) {
             co <- comment(resource_capacity)
-            resource_capacity <- resource_capacity * w_full ^ (-lambda)
-            resource_capacity[w_full >= params@resource_params$w_pp_cutoff] <- 0
+            if (isTRUE(params@second_order_w[["bin_average"]])) {
+                # Exact bin average of kappa * w^(-lambda), truncated at the
+                # cutoff. The unpredated semichemostat equilibrium is N_R* = c_p,
+                # so the stored capacity must be the cell average of the
+                # background spectrum for it to match the bin-averaged resource
+                # consumed by the (bin-integrated) encounter convolution. The bin
+                # straddling w_pp_cutoff gets the partial average; bins above it
+                # are zero.
+                resource_capacity <- resource_capacity *
+                    power_law_bin_average(
+                        w_full, params@dw_full, -lambda,
+                        w_max = params@resource_params$w_pp_cutoff)
+            } else {
+                resource_capacity <- resource_capacity * w_full ^ (-lambda)
+                resource_capacity[w_full >= params@resource_params$w_pp_cutoff] <- 0
+            }
             comment(resource_capacity) <- co
         } else if (length(resource_capacity) != no_w_full) {
             stop("The 'resource_rate' should have length 1 or length ",

--- a/man/power_law_bin_average.Rd
+++ b/man/power_law_bin_average.Rd
@@ -4,7 +4,7 @@
 \alias{power_law_bin_average}
 \title{Bin average of a power law over geometric bins}
 \usage{
-power_law_bin_average(w, dw, d)
+power_law_bin_average(w, dw, d, w_max = Inf)
 }
 \arguments{
 \item{w}{Numeric vector of left bin edges \eqn{w_j}.}
@@ -12,10 +12,15 @@ power_law_bin_average(w, dw, d)
 \item{dw}{Numeric vector of bin widths \eqn{\Delta w_j} (same length as \code{w}).}
 
 \item{d}{Single numeric exponent of the power law.}
+
+\item{w_max}{Optional upper cutoff. The power law is taken to be zero above
+\code{w_max}, with the straddling bin getting the partial average. Defaults to
+\code{Inf} (no cutoff), in which case the result is identical to the uncut
+formula.}
 }
 \value{
 A numeric vector (same length as \code{w}) of bin averages of
-\eqn{w^d}.
+\eqn{w^d} (truncated at \code{w_max} when supplied).
 }
 \description{
 Computes the exact average of the power law \eqn{w^d} over each bin
@@ -32,9 +37,16 @@ order):
 
 This is used by the bin-averaged (second-order) code paths that need the
 average of a power-law rate over each bin, for example \code{\link[=setExtMort]{setExtMort()}} and
-the resource semichemostat. The grid does not need to be geometric; only the
-left bin edges \code{w} and the bin widths \code{dw} are used, with
-\eqn{w_{j+1} = w_j + \Delta w_j}.
+the resource capacity and rate in \code{\link[=setResource]{setResource()}}. The grid does not need to
+be geometric; only the left bin edges \code{w} and the bin widths \code{dw} are used,
+with \eqn{w_{j+1} = w_j + \Delta w_j}.
+
+An optional upper cutoff \code{w_max} handles a knife-edge truncation of the power
+law (for example the resource carrying capacity, which is \eqn{\kappa
+w^{-\lambda}} below \code{w_pp_cutoff} and zero above it). The bin straddling the
+cutoff then receives the \emph{partial} bin-average — the power-law average over
+the part of the bin below \code{w_max}, divided by the full bin width — and bins
+entirely above the cutoff get zero.
 }
 \concept{helper}
 \keyword{internal}

--- a/tests/testthat/test-setResource.R
+++ b/tests/testthat/test-setResource.R
@@ -172,3 +172,79 @@ test_that("w_pp_cutoff can be changed when providing carrying_capacity", {
     w_full <- params_new@w_full
     expect_true(all(params_new@cc_pp[w_full >= new_cutoff] == 0))
 })
+
+test_that("second_order_w bin-averages the resource rate and capacity", {
+    rr <- 12
+    cc <- 13
+    lambda <- 2.05
+    n <- 0.68
+    w_pp_cutoff <- 0.5
+
+    base <- setResource(NS_params_small, resource_rate = rr,
+                        resource_capacity = cc, lambda = lambda, n = n,
+                        w_pp_cutoff = w_pp_cutoff, balance = FALSE)
+    p2 <- base
+    second_order_w(p2) <- c(bin_average = TRUE)
+    p2 <- setResource(p2, resource_rate = rr, resource_capacity = cc,
+                      lambda = lambda, n = n, w_pp_cutoff = w_pp_cutoff,
+                      balance = FALSE)
+
+    w <- p2@w_full
+    dw <- p2@dw_full
+
+    # Rate: exact bin average of rr * w^(n-1).
+    rate_expected <- rr * power_law_bin_average(w, dw, n - 1)
+    expect_equal(unname(p2@rr_pp), rate_expected)
+    # Capacity: exact bin average of cc * w^(-lambda), cut at w_pp_cutoff.
+    cap_expected <- cc * power_law_bin_average(w, dw, -lambda,
+                                               w_max = w_pp_cutoff)
+    expect_equal(unname(p2@cc_pp), cap_expected)
+
+    # The bin averages differ from the left-edge point values (the power law
+    # varies across the bin).
+    expect_false(isTRUE(all.equal(unname(p2@rr_pp), unname(base@rr_pp))))
+    expect_false(isTRUE(all.equal(unname(p2@cc_pp), unname(base@cc_pp))))
+})
+
+test_that("second_order_w capacity straddling-bin gets the partial average", {
+    cc <- 13
+    lambda <- 2.05
+    w_pp_cutoff <- 0.5
+    p2 <- NS_params_small
+    second_order_w(p2) <- c(bin_average = TRUE)
+    p2 <- setResource(p2, resource_capacity = cc, lambda = lambda,
+                      w_pp_cutoff = w_pp_cutoff, balance = FALSE)
+    w <- p2@w_full
+    dw <- p2@dw_full
+
+    # Bins entirely above the cutoff are zero.
+    expect_true(all(p2@cc_pp[w >= w_pp_cutoff] == 0))
+    # The straddling bin (cutoff strictly inside) gets the partial power-law
+    # average over the part below the cutoff, not the full-bin average.
+    straddle <- which(w < w_pp_cutoff & (w + dw) > w_pp_cutoff)
+    if (length(straddle) == 1) {
+        partial <- cc * (w_pp_cutoff^(1 - lambda) - w[straddle]^(1 - lambda)) /
+            ((1 - lambda) * dw[straddle])
+        expect_equal(unname(p2@cc_pp[straddle]), partial)
+        full <- cc * power_law_bin_average(w[straddle], dw[straddle], -lambda)
+        expect_lt(unname(p2@cc_pp[straddle]), full)
+    }
+})
+
+test_that("default resource construction is byte-identical (first order)", {
+    # With second_order_w off (default) the rate and capacity are the plain
+    # left-edge power laws, unchanged from previous mizer.
+    rr <- 12
+    cc <- 13
+    lambda <- 2.05
+    n <- 0.68
+    w_pp_cutoff <- 0.5
+    p <- setResource(NS_params_small, resource_rate = rr,
+                     resource_capacity = cc, lambda = lambda, n = n,
+                     w_pp_cutoff = w_pp_cutoff, balance = FALSE)
+    w <- p@w_full
+    expect_equal(unname(p@rr_pp), rr * w^(n - 1))
+    cap <- cc * w^(-lambda)
+    cap[w >= w_pp_cutoff] <- 0
+    expect_equal(unname(p@cc_pp), cap)
+})


### PR DESCRIPTION
Part of #377; addresses the `setResource()` portion of #379.

When the `bin_average` entry of the `second_order_w` slot is set, `setResource()`
builds the auto-calculated resource **rate** \eqn{r_p w^{n-1}} and **capacity**
\eqn{\kappa w^{-\lambda}} from their exact closed-form bin averages over each
size bin instead of point-sampling at the left bin edge. Opt-in and gated on the
same slot as #374/#375/#376/#378.

## Why

The resource has no transport in `w`, so nothing on the resource side forces a
representation — but `N_{R,j}` is consumed by the encounter convolution, where
(with the bin-integrated kernel, #374) it is the **cell average** of the
resource density over bin `j`. For consistency the semichemostat must *produce*
cell averages. Since the unpredated equilibrium is `N_R* = c_p`, the stored
capacity must be the cell average of the background spectrum, and the rate
(which sets the relaxation timescale and the predated equilibrium) likewise.

`λ ≈ 2` is steep, so the left-edge-vs-average gap is large on coarse grids and
shifts the entire background resource that every consumer feeds on.

## Change

- `R/setResource.R`: when the flag is set, the scalar `resource_rate` /
  `resource_capacity` are expanded via `power_law_bin_average()` rather than the
  point-sampled `w^p`. The capacity passes `w_max = w_pp_cutoff` so the
  straddling bin gets the partial average and bins above the cutoff are zero.
- `R/helpers.R`: `power_law_bin_average()` (added for #378) gains an optional
  `w_max` cutoff for the knife-edge truncation. With the default `w_max = Inf`
  the result is identical to before, so external mortality (#378) is unaffected.

## Scope and consistency

- Only **auto-calculated** (scalar) rates/capacities are bin-averaged;
  user-supplied full vectors are left untouched.
- `cc_pp` and `rr_pp` are averaged separately; the product/equilibrium
  `r̄_p c̄_p/(r̄_p+μ̄_p)` is second order and `N_R* = c̄_p` is captured exactly.
- The resource then **relaxes to** the bin-averaged capacity, so the initial
  resource abundance follows once a model is run/balanced to steady state; the
  semichemostat predation-mortality `μ_p` bin-average is the separate
  predation-mortality follow-up under #377.

## Tests

`test-setResource.R` gains: rate and capacity match the analytic bin averages
when the flag is on; the straddling bin gets the partial (not full) average and
bins above the cutoff are zero; the default path is byte-identical to the
left-edge power laws. `test-setExtMort.R` still passes (helper default unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)