### PR TITLE
Second-order predation mortality: prey-bin average in the predation kernel (#381)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,15 @@
   the default; enable the new scheme with `second_order_w(params) <- TRUE`. See
   the "Fast Fourier Transform for Rates" vignette for the derivation.
 
+- When the `bin_average` entry of the `second_order_w` slot is `TRUE`, the
+  predation-rate kernel `ft_pred_kernel_p` is now also averaged over the
+  **prey** bin (a trapezoid fold of the kernel), completing the predator-bin
+  integral above. Predation mortality is a sink integrated against the prey
+  density over the prey bin, so the prey-bin average is the form it needs to be
+  second order; `getPredMort()` and `getResourceMort()` (and `getPredRate()`)
+  pick this up automatically with no change to the rate functions and no extra
+  runtime cost. The default (point-sampled) behaviour is unchanged.
+
 - When the `bin_average` entry of the `second_order_w` slot is `TRUE`,
   `setExtMort()` now replaces the point-sampled power-law external mortality
   \eqn{z_{ext} w^d} by its exact bin average over each bin, making the external

--- a/R/setPredKernel.R
+++ b/R/setPredKernel.R
@@ -67,7 +67,10 @@
 #' Fourier-transformed kernels. This finite-volume consistent quadrature lifts
 #' the encounter and predation rates towards second order at no extra runtime
 #' cost, because the integration is performed once here and the rate functions
-#' themselves are unchanged. The default remains the first-order scheme so that
+#' themselves are unchanged. The predation kernel is additionally averaged over
+#' the prey bin (a trapezoid fold), so that the predation rate returned by
+#' [getPredRate()] is the prey-bin average that the predation-mortality sink
+#' needs to be second order. The default remains the first-order scheme so that
 #' existing models are unaffected. Enable it with `second_order_w(params) <-
 #' TRUE` (see [second_order_w()]), which also turns on the other bin-averaged
 #' rate quadratures so the whole model stays consistent. See the
@@ -225,6 +228,23 @@ setPredKernel.MizerParams <- function(params,
             phi_e[i, ] <- matrix(kernel_e[i, ], nrow = no_w_full) %*% weight_e
             phi_p[i, ] <- matrix(kernel_p[i, ], nrow = no_w_full) %*% weight_p
         }
+        # Prey-bin average of the predation kernel (issue #381). The predation
+        # convolution outputs at the prey node, but the predation-mortality sink
+        # integrates that rate against the prey density over the prey bin, so it
+        # wants the prey-bin average (1/Delta w_p) int pred_rate(w_p) dw_p, not a
+        # point value. Bin-averaging the output over the prey bin is a trapezoid
+        # fold of the kernel over adjacent offsets: with pred_rate at prey node j
+        # using kernel offset m = (predator index) - j, the cell average
+        # 1/2 (pred_rate[j] + pred_rate[j+1]) replaces the offset-m weight by
+        # 1/2 (phi_p(beta^m) + phi_p(beta^{m-1})). This costs nothing at runtime
+        # and completes #374's predator-bin integral with the prey-bin integral,
+        # so the encounter integrates the prey bins and the predation integrates
+        # both predator and prey bins. The lowest offset is one-sided (the
+        # own-size term is dropped from the convolution anyway). Encounter
+        # (phi_e) is left untouched: it feeds the growth flux, a point/face
+        # quantity, and is bin-averaged only at the reproduction integral.
+        phi_p[, -1] <- 0.5 * (phi_p[, -1, drop = FALSE] +
+                                  phi_p[, -no_w_full, drop = FALSE])
     }
 
     for (i in 1:no_sp) {

--- a/man/setPredKernel.Rd
+++ b/man/setPredKernel.Rd
@@ -110,7 +110,10 @@ instead integrated over each logarithmic size bin when building the
 Fourier-transformed kernels. This finite-volume consistent quadrature lifts
 the encounter and predation rates towards second order at no extra runtime
 cost, because the integration is performed once here and the rate functions
-themselves are unchanged. The default remains the first-order scheme so that
+themselves are unchanged. The predation kernel is additionally averaged over
+the prey bin (a trapezoid fold), so that the predation rate returned by
+\code{\link[=getPredRate]{getPredRate()}} is the prey-bin average that the predation-mortality sink
+needs to be second order. The default remains the first-order scheme so that
 existing models are unaffected. Enable it with \code{second_order_w(params) <- TRUE} (see \code{\link[=second_order_w]{second_order_w()}}), which also turns on the other bin-averaged
 rate quadratures so the whole model stays consistent. See the
 \code{vignette("fft")} for the mathematical details.

--- a/tests/testthat/test-setPredKernel.R
+++ b/tests/testthat/test-setPredKernel.R
@@ -212,6 +212,54 @@ test_that("bin-integrated box kernel matches the analytic weights", {
     expect_equal(unname(phi_e[1]), 0, tolerance = 1e-8)
     expect_equal(unname(phi_e[5]), (beta_grid + 1) / 2, tolerance = 1e-4)
     # The predation weight for a fully-covered bin is exactly 1. phi_p is the
-    # reversed kernel, so offset m = 1 sits in the last entry.
+    # reversed kernel, so offset m = 1 sits in the last entry. The prey-bin fold
+    # (issue #381) averages two fully-covered offsets, 1/2 (1 + 1) = 1, so this
+    # value is unchanged.
     expect_equal(unname(phi_p[no_w_full]), 1, tolerance = 1e-4)
+})
+
+test_that("the predation kernel is prey-bin averaged under second_order_w", {
+    # A box kernel whose upper edge ppmr_max lands exactly on a grid point
+    # gives a covered -> uncovered transition between adjacent offsets: the
+    # predator-bin-integrated weight is 1 just below the edge and 0 just above.
+    # The prey-bin trapezoid fold (issue #381) turns the first uncovered offset
+    # into 1/2 (0 + 1) = 1/2 -- a value that appears *only* if the prey-bin
+    # average is applied, and in the correct place.
+    params <- NS_params_small
+    beta_grid <- params@w_full[2] / params@w_full[1]
+    M <- 5L
+    params@species_params$pred_kernel_type <- "box"
+    params@species_params$ppmr_min <- 1
+    params@species_params$ppmr_max <- beta_grid^M  # exactly on a grid point
+    params@second_order_w[["bin_average"]] <- TRUE
+    p_hi <- setPredKernel(params)
+    no_w_full <- length(params@w_full)
+    phi_p <- Re(fft(p_hi@ft_pred_kernel_p[1, ], inverse = TRUE)) / no_w_full
+    # Reversed layout: offset m sits at index no_w_full - m + 1.
+    idx <- function(m) no_w_full - m + 1L
+    # Offsets below the edge are fully covered -> fold of two ones stays 1.
+    expect_equal(unname(phi_p[idx(M - 1L)]), 1, tolerance = 1e-4)
+    # The edge offset M: covered weight 0, previous offset 1 -> fold gives 1/2.
+    expect_equal(unname(phi_p[idx(M)]), 0.5, tolerance = 1e-3)
+    # Beyond the edge both offsets are uncovered -> fold stays 0.
+    expect_equal(unname(phi_p[idx(M + 1L)]), 0, tolerance = 1e-4)
+})
+
+test_that("second_order_w prey-bin average leaves the default path unchanged", {
+    # With the flag off the predation kernel is the previous point-sampled one.
+    expect_equal(setPredKernel(NS_params_small)@ft_pred_kernel_p,
+                 NS_params_small@ft_pred_kernel_p)
+})
+
+test_that("prey-bin-averaged predation mortality stays finite for all consumers", {
+    params <- NS_params_small
+    second_order_w(params) <- c(bin_average = TRUE)
+    # Both the consumer mortality and the resource mortality read the same
+    # (now prey-bin-averaged) predation rate.
+    expect_true(all(is.finite(getPredMort(params))))
+    expect_true(all(is.finite(getResourceMort(params))))
+    # The prey-bin average shifts predation mortality away from the first-order
+    # point-sampled values.
+    expect_false(isTRUE(all.equal(getPredMort(params),
+                                  getPredMort(NS_params_small))))
 })

--- a/vignettes/fft.Rmd
+++ b/vignettes/fft.Rmd
@@ -175,6 +175,29 @@ which replaces $\tilde\phi_i(\beta^{m})$ in the reversed-kernel construction of
 `ft_pred_kernel_p`. Again `mizerPredRate()` is unchanged because the predator
 vector already carries $dw = (\beta-1)\,w_n$.
 
+There is a second integral hidden in the predation rate. Its convolution output
+sits at the **prey** node $w_p$, but predation mortality enters the
+finite-volume update as a sink integrated against the prey density over the
+prey bin, $\tfrac{1}{\Delta w_p}\int_{\text{bin}}\mu_{\mathrm{pred}}(w_p)\,
+N(w_p)\,dw_p$. So, exactly as for external mortality and fishing, the rate that
+enters the mortality wants the **prey-bin average** of $P_j(w_p)$, not its value
+at the prey node. Bin-averaging the convolution output over the prey bin is a
+trapezoid fold of the (reversed) kernel over adjacent offsets,
+$$
+\bar\Phi^{P}_i[m] = \tfrac12\bigl(\Phi^{P}_i[m] + \Phi^{P}_i[m-1]\bigr),
+$$
+because $\tfrac12\bigl(P_j[w_{p}] + P_j[\beta w_{p}]\bigr)
+= \sum_n \tfrac12\bigl(\Phi^P_i[n-j] + \Phi^P_i[n-j-1]\bigr)\,Q_i[n]$. Storing
+$\mathrm{fft}(\bar\Phi^{P})$ as `ft_pred_kernel_p` makes `getPredRate()` come out
+already prey-bin-averaged, so both `mizerPredMort()` and `mizerResourceMort()`
+(the only consumers, both sinks) get the second-order mortality at no runtime
+cost and with no change to the rate functions. With this the two convolutions
+are fully bin-consistent: encounter integrates the prey bins, and predation
+integrates **both** the predator bins and the prey bins. (Encounter is *not*
+prey-bin-averaged on its output, because it feeds the growth flux — a
+point/face quantity — and is bin-averaged only at the reproduction integral; see
+`vignette("numerical_details")`.)
+
 ### Why this is the right weighting
 
 Take the box kernel $\tilde\phi = 1$ over a bin that lies fully inside the


### PR DESCRIPTION
Closes #381. Completes the predation kernel started in #374.

#374 bin-integrated the predation kernel over the **predator** dimension (the
convolution variable), so `getPredRate()` is a second-order **point value at the
prey node**. But predation mortality enters the finite-volume update as a sink
integrated against the prey density over the **prey** bin,
`(1/Δw_p) ∫_bin μ_pred(w_p) N(w_p) dw_p`, so — exactly as for external mortality
(#378) and fishing (#375) — it wants the **prey-bin average** of the rate. This
PR adds that prey-bin average, the missing half of #374.

## Change

Bin-averaging the convolution output over the prey bin is a trapezoid fold of
the kernel over adjacent offsets (zero runtime cost). In `setPredKernel()`'s
`second_order_w` branch:

```r
phi_p[, -1] <- 0.5 * (phi_p[, -1] + phi_p[, -no_w_full])
```

i.e. `phibar_p(offset m) = ½(phi_p(β^m) + phi_p(β^{m-1}))`, applied to the
predator-bin-integrated kernel before the reversed-kernel FFT. Then `pred_rate`
comes out already prey-bin-averaged, so `mizerPredMort` and `mizerResourceMort`
(both sinks, the only consumers) get the second-order mortality with **no change
to the rate functions**. Encounter (`phi_e`) is left untouched: it feeds the
growth flux, a point/face quantity, and is bin-averaged only at the reproduction
integral.

With this, both convolutions are fully bin-consistent: encounter integrates the
prey bins, predation integrates **both** the predator and prey bins.

## Tests

A box kernel with `ppmr_max` landing exactly on a grid point creates a
covered→uncovered transition between adjacent offsets (predator-bin weight 1
then 0). The prey-bin fold turns the first uncovered offset into ½(0+1)=**0.5** —
a value that appears *only* if the prey-bin average is applied, and in the
correct reversed-layout position — which the test pins down. Also: the default
path is byte-identical; `getPredMort`/`getResourceMort` stay finite and shift
off the first-order values.

## Docs

New paragraph in the FFT vignette deriving the prey-bin fold; a note on
`setPredKernel()`; NEWS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)