### PR TITLE
Advance other components every time step, not every save step

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mizer (development version)
 
+- Fixed a bug in `project()` where the abundances of other components (set via
+  `setComponent()`) were advanced only once per saved time step instead of once
+  per `dt` time step. Their dynamics are now integrated with the same time step
+  as the consumer and resource spectra, so results no longer depend on `t_save`.
+
 - `MizerParams` gains an `ft_pred_kernel_d` slot holding a third Fourier-space
   predation kernel, used by the predation-diffusion integral (when
   `use_predation_diffusion` is `TRUE`). When the `bin_average` entry of

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
   `setComponent()`) were advanced only once per saved time step instead of once
   per `dt` time step. Their dynamics are now integrated with the same time step
   as the consumer and resource spectra, so results no longer depend on `t_save`.
+  Under the second-order time-stepping methods (`"predictor_corrector"` and
+  `"tr_bdf2"`) the other components now also receive a corrector step with the
+  midpoint rates, so they are integrated to the same second-order accuracy as
+  the resource and consumer spectra instead of being left at first order.
 
 - `MizerParams` gains an `ft_pred_kernel_d` slot holding a third Fourier-space
   predation kernel, used by the predation-diffusion integral (when

--- a/R/project.R
+++ b/R/project.R
@@ -651,11 +651,18 @@ project_simple.MizerParams <-
                 }
             }
 
+            # * Carry the updated other components into the next step ----
+            # They were computed into `n_other_new` so that the resource and
+            # consumer updates above still saw the start-of-step value. Now that
+            # those updates are done, advance `n_other` so that the next time
+            # step (and the returned value) uses the new abundances.
+            n_other <- n_other_new
+
             # * Update time ----
             t <- t + dt
         }
 
-        return(list(n = n, n_pp = n_pp, n_other = n_other_new, rates = r))
+        return(list(n = n, n_pp = n_pp, n_other = n_other, rates = r))
     }
 
 validEffortArray <- function(effort, params) {

--- a/R/project.R
+++ b/R/project.R
@@ -560,6 +560,26 @@ project_simple.MizerParams <-
         c <- matrix(0, nrow = no_sp, ncol = no_w)
         S <- matrix(0, nrow = no_sp, ncol = no_w)
 
+        # Advance the other components by one Euler step from the start-of-step
+        # state (`n`, `n_pp`, `n_other`) using the supplied rates. Used for the
+        # predictor (with the start-of-step rates `r`) and, for the
+        # second-order methods, the corrector (with the midpoint rates
+        # `r_mid`), so that the other components are integrated to the same
+        # order of accuracy as the resource and consumer spectra.
+        step_other_components <- function(rates) {
+            out <- list()
+            for (component in names(params@other_dynamics)) {
+                out[[component]] <-
+                    other_dynamics_fns[[component]](
+                        params,
+                        n = n, n_pp = n_pp, n_other = n_other,
+                        rates = rates, t = t, dt = dt,
+                        component = component, ...
+                    )
+            }
+            out
+        }
+
         # Loop over time steps ----
         for (i_time in 1:steps) {
             r <- rates_fns$Rates(
@@ -568,23 +588,14 @@ project_simple.MizerParams <-
                 t = t, effort = effort, rates_fns = rates_fns, ...
             )
 
-            # * Update other components ----
-            n_other_new <- list() # So that the resource dynamics can still
-            # use the current value
-            for (component in names(params@other_dynamics)) {
-                n_other_new[[component]] <-
-                    other_dynamics_fns[[component]](
-                        params,
-                        n = n,
-                        n_pp = n_pp,
-                        n_other = n_other,
-                        rates = r,
-                        t = t,
-                        dt = dt,
-                        component = component,
-                        ...
-                    )
-            }
+            # * Update other components (predictor) ----
+            # First-order Euler update using the start-of-step rates `r`. For
+            # the Euler method this is the final value for the step. The
+            # second-order methods use `n_other_hat` in the end-of-step rates
+            # (like the resource's `n_pp_hat`) and then overwrite `n_other_new`
+            # with a corrector below.
+            n_other_hat <- step_other_components(r)
+            n_other_new <- n_other_hat
 
             # * Update resource and species ----
             if (method == "predictor_corrector" || method == "tr_bdf2") {
@@ -605,10 +616,16 @@ project_simple.MizerParams <-
                 # End-of-step rates from the prediction, then midpoint rates
                 r_hat <- rates_fns$Rates(
                     params,
-                    n = n_hat, n_pp = n_pp_hat, n_other = n_other_new,
+                    n = n_hat, n_pp = n_pp_hat, n_other = n_other_hat,
                     t = t + dt, effort = effort, rates_fns = rates_fns, ...
                 )
                 r_mid <- average_rates(r, r_hat)
+
+                # Corrector: other components with the midpoint rates, so they
+                # reach the same second-order accuracy as the resource and
+                # consumer. Computed from the start-of-step state before the
+                # resource corrector below overwrites `n_pp`.
+                n_other_new <- step_other_components(r_mid)
 
                 # Corrector: resource with midpoint resource mortality
                 n_pp <- resource_dynamics_fn(params,

--- a/tests/testthat/test-extension.R
+++ b/tests/testthat/test-extension.R
@@ -305,3 +305,22 @@ test_that("getFMort.MizerSim preserves n_other component names with time_range",
     sim <- project(p, t_max = 3, dt = 1, t_save = 1)
     expect_no_error(getFMort(sim, time_range = 2:3))
 })
+
+test_that("Other components are advanced once per time step, not per save step", {
+    # A component whose dynamics add `dt` at every time step. After projecting
+    # for one year it must equal 1 regardless of how often results are saved.
+    e$ticker_dyn <- function(params, n_other, component, dt, ...) {
+        n_other[[component]] + dt
+    }
+    p <- setComponent(NS_params_small, "ticker", initial_value = 0,
+                      dynamics_fun = "ticker_dyn")
+
+    sim <- project(p, t_max = 2, t_save = 1, dt = 0.1, progress_bar = FALSE)
+    expect_equal(sim@n_other[[2, "ticker"]], 1)
+    expect_equal(sim@n_other[[3, "ticker"]], 2)
+
+    # The result at a given time must not depend on the save frequency.
+    sim_fine <- project(p, t_max = 1, t_save = 0.1, dt = 0.1,
+                        progress_bar = FALSE)
+    expect_equal(sim_fine@n_other[[11, "ticker"]], 1)
+})

--- a/tests/testthat/test-extension.R
+++ b/tests/testthat/test-extension.R
@@ -324,3 +324,32 @@ test_that("Other components are advanced once per time step, not per save step",
                         progress_bar = FALSE)
     expect_equal(sim_fine@n_other[[11, "ticker"]], 1)
 })
+
+test_that("Other components get a corrector step under second-order methods", {
+    # A component that integrates a time-varying, rate-derived signal. Because
+    # its dynamics read `rates`, the corrector (midpoint rates) differs from
+    # the predictor (start-of-step rates), so the second-order methods must be
+    # more accurate than Euler. This guards against the other components being
+    # left at first-order accuracy while the resource and consumers are
+    # advanced to second order.
+    e$accum_dyn <- function(params, n_other, component, rates, dt, ...) {
+        n_other[[component]] + dt * sum(rates$mort)
+    }
+    make_p <- function() {
+        p <- NS_params_small
+        p@initial_n[] <- p@initial_n * 1.5   # perturb to create a transient
+        setComponent(p, "accum", initial_value = 0, dynamics_fun = "accum_dyn")
+    }
+    accum <- function(method, dt) {
+        project(make_p(), t_max = 2, t_save = 2, dt = dt, method = method,
+                progress_bar = FALSE)@n_other[[2, "accum"]]
+    }
+    ref <- accum("euler", 0.0005)            # fine-step reference
+
+    euler_err <- abs(accum("euler", 0.1) - ref)
+    for (method in c("predictor_corrector", "tr_bdf2")) {
+        # Generous margin: in practice the second-order error is several times
+        # smaller, but we only need to confirm the corrector is taking effect.
+        expect_lt(abs(accum(method, 0.1) - ref), euler_err / 2)
+    }
+})


### PR DESCRIPTION
## Problem

In `project_simple()` the abundances of *other components* (registered with
`setComponent()`, e.g. detritus, carrion, or multiple-resource spectra) are
computed into `n_other_new` at every `dt` time step, but `n_other` was never
reassigned to `n_other_new` inside the step loop. Consequently each
`project_simple()` call advanced the other components only **once** (using the
start-of-step value throughout), i.e. once per *saved* time step, while the
consumer (`n`) and resource (`n_pp`) spectra advanced every `dt`.

Effects:
- Other-component trajectories depended on `t_save` and were under-integrated
  whenever `t_save > dt`.
- Extensions that store dynamic state as an other component (e.g. mizerMR's
  resources) only matched the equivalent built-in dynamics when `t_save == dt`.

A second, related shortcoming: under the second-order time-stepping methods
(`"predictor_corrector"` and `"tr_bdf2"`) the resource and consumer spectra get
a **predictor and a corrector** (a predicted state feeds the end-of-step rates,
and the final update uses the midpoint rates `r_mid = (r + r_hat)/2`), but the
other components were stepped only **once with the start-of-step rates `r`** —
plain Euler. So even when the model was integrated to second order, any
other component whose dynamics depend on time-varying rates stayed
**first-order accurate**.

### Reproducer

```r
inc <- function(params, n_other, component, dt, ...) n_other[[component]] + dt
assign("inc_dyn", inc, envir = .GlobalEnv)
p <- setComponent(NS_params, "ticker", initial_value = 0, dynamics_fun = "inc_dyn")
sim <- project(p, t_max = 1, t_save = 1, dt = 0.1, progress_bar = FALSE)
sim@n_other[[2, "ticker"]]   # 0.1 before the fix, 1.0 after
```

## Fix

1. **Step every `dt`.** Carry `n_other <- n_other_new` forward at the end of
   each step — after the resource and consumer updates, which intentionally
   still use the start-of-step value — and return the final `n_other`. This is
   consistent with how `n` and `n_pp` are stepped, and the other components'
   own dynamics functions already receive `dt` and integrate one step at a time.

2. **Second-order accuracy.** Give the other components the same
   predictor/corrector treatment as the resource. The per-component update is
   extracted into a small closure `step_other_components(rates)` that does one
   Euler step from the start-of-step state with the supplied rates. It is used:
   - as the **predictor** with the start-of-step rates `r` (the result
     `n_other_hat` now feeds the end-of-step rates `r_hat`, mirroring how
     `n_pp_hat` does); and
   - for the second-order methods, as a **corrector** with the midpoint rates
     `r_mid`, computed from the start-of-step state before the resource
     corrector overwrites `n_pp`.

   The Euler method is unchanged in behaviour (`n_other_new <- n_other_hat`).

## Tests

- Regression test in `test-extension.R`: a component whose dynamics add `dt`
  each step must equal 1 after one year, independent of `t_save`.
- New regression test in `test-extension.R`: a component that integrates a
  time-varying, rate-derived signal must be more accurate under
  `predictor_corrector`/`tr_bdf2` than under Euler, confirming the corrector
  is taking effect. Empirically the second-order methods converge at ~2nd order
  (error ratio ~4–6 on halving `dt`) where Euler is ~1st order (~2); previously
  all three were stuck at first order.
- Full test suite passes with no regressions. No mizer model in the suite
  relied on the previous behaviour; standard models have no other components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
