### PR TITLE
Use size-dependent resource trophic level in getTrophicLevel()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # mizer (development version)
 
+- `getTrophicLevel()` and `getTrophicLevelBySpecies()` now assign the resource a
+  size-dependent trophic level
+  `T_R(w) = max(1, 1 + log(w / w_R) / log(beta_R))` instead of treating it as
+  trophic level 0. The new `w_R` (average primary-producer size) and `beta_R`
+  (average resource predator/prey mass ratio) arguments control this.
+
 - Resource functions now return classed objects that support the same
   convenient `print()`, `summary()`, `plot()`, and `as.data.frame()` methods
   as the consumer rate functions. `getResourceMort()`, `initialNResource()`,

--- a/R/summary_methods.R
+++ b/R/summary_methods.R
@@ -200,7 +200,7 @@ getDiet.MizerParams <- function(params,
 #' assuming the system is in a steady state. The trophic level of an individual
 #' is defined as 1 more than the consumption-rate-weighted average trophic level
 #' of all the prey it has consumed during its lifetime up to the current size.
-#' The trophic level of the primary resource is set to 0.
+#' The resource is given a size-dependent trophic level (see below).
 #'
 #'
 #' @details
@@ -232,10 +232,19 @@ getDiet.MizerParams <- function(params,
 #' r_{ij}(w, w_p) = \theta_{ij}\,\gamma_i(w)\,(1 - f_i(w))\,\phi_i(w/w_p)\,
 #'   N_j(w_p)\,w_p.
 #' }
-#' The sum over \eqn{j} runs over all species. The resource is excluded from
-#' the numerator because its trophic level is 0, but is included in the
-#' denominator (which equals the total biomass consumed over the predator's
-#' lifetime from egg size to current weight \eqn{w}).
+#' The sum over \eqn{j} runs over all species and the resource. The resource is
+#' assigned a size-dependent trophic level
+#' \deqn{
+#'   T_R(w) = \max\left(1,\; 1 + \frac{\log(w / w_R)}{\log(\beta_R)}\right),
+#' }
+#' where \eqn{w_R} is an average size of primary producers (which therefore have
+#' trophic level 1) and \eqn{\beta_R} is an average predator/prey mass ratio for
+#' the resource (for example zooplankton). This adds one trophic level for each
+#' factor of \eqn{\beta_R} increase in resource size, with a floor at 1 so that
+#' the resource trophic level never drops below the primary-producer level.
+#' Both the numerator and the denominator (which equals the total biomass
+#' consumed over the predator's lifetime from egg size to current weight
+#' \eqn{w}) therefore include the resource.
 #'
 #' This equation can be viewed as a linear system
 #' \eqn{(I - D)\,\mathbf{T} = \mathbf{1}} in which the entries of
@@ -247,6 +256,12 @@ getDiet.MizerParams <- function(params,
 #' \eqn{T_i(w)}.
 #'
 #' @inheritParams getDiet
+#' @param w_R An average size (in grams) of primary producers in the resource
+#'   spectrum, used to set the size-dependent resource trophic level. Defaults
+#'   to `1e-10`.
+#' @param beta_R An average predator/prey mass ratio for the resource spectrum,
+#'   used to set the size-dependent resource trophic level. Must be greater than
+#'   `1`. Defaults to `1000`.
 #' @param ... Unused
 #'
 #' @return An `ArraySpeciesBySize` object (species x size) with the trophic
@@ -264,6 +279,8 @@ getTrophicLevel <- function(params,
                             n = initialN(params),
                             n_pp = initialNResource(params),
                             n_other = initialNOther(params),
+                            w_R = 1e-10,
+                            beta_R = 1000,
                             ...) {
     UseMethod("getTrophicLevel")
 }
@@ -273,8 +290,12 @@ getTrophicLevel.MizerParams <- function(params,
                                         n = initialN(params),
                                         n_pp = initialNResource(params),
                                         n_other = initialNOther(params),
+                                        w_R = 1e-10,
+                                        beta_R = 1000,
                                         ...) {
     params <- validParams(params)
+    assert_that(is.number(w_R), w_R > 0,
+                is.number(beta_R), beta_R > 1)
     no_sp <- nrow(params@species_params)
     no_w <- length(params@w)
     no_w_full <- length(params@w_full)
@@ -299,6 +320,26 @@ getTrophicLevel.MizerParams <- function(params,
     # Initialised with T_j = 1 everywhere; updated as trophic levels are computed
     prey_mass_tl <- sweep(n, 2, w_ba * params@dw, "*")  # no_sp x no_w
 
+    # Size-dependent trophic level of the resource:
+    #   T_R(w) = max(1, 1 + log(w / w_R) / log(beta_R))
+    # where w_R is an average primary-producer size and beta_R an average
+    # predator/prey mass ratio for the resource. Unlike the species trophic
+    # levels, this is fixed by the formula, so the resource's whole contribution
+    # to the numerator can be precomputed before the size loop. This mirrors the
+    # `phi_prey_background` term in mizerEncounter().
+    tl_R <- pmax(1, 1 + log(params@w_full / w_R) / log(beta_R))  # no_w_full
+    # Full-grid summary weight, consistent with the species weight w_ba and with
+    # the resource weighting in mizerEncounter() (plain w_full on the default
+    # path; trapezoidal bin-average when second_order_w is on).
+    w_full_ba <- bin_average_summary_weight(params@w_full, params)
+    # TL-weighted resource biomass per bin.
+    resource_mass_tl <- tl_R * n_pp * w_full_ba * params@dw_full  # no_w_full
+    # Resource contribution to the TL-weighted encounter for every predator/size:
+    #   ae_R[i, k] = sum_p kernel[i, k, p] * resource_mass_tl[p]
+    ae_R <- rowSums(sweep(pred_kernel, 3, resource_mass_tl, "*"), dims = 2)
+    E_tl_resource <- params@search_vol *
+        (params@species_params$interaction_resource * ae_R)  # no_sp x no_w
+
     # Cumulative numerator A_i and denominator B_i (integrals weighted by 1/g dw)
     cumA <- numeric(no_sp)
     cumB <- numeric(no_sp)
@@ -314,6 +355,9 @@ getTrophicLevel.MizerParams <- function(params,
         pred_kernel_k <- matrix(pred_kernel[, k, idx_sp], nrow = no_sp)
         ae_k <- pred_kernel_k %*% t(prey_mass_tl)  # no_sp x no_sp
         E_tl <- params@search_vol[, k] * rowSums(params@interaction * ae_k)
+        # Add the TL-weighted resource contribution (resource trophic level is
+        # given by the formula, so this term is precomputed).
+        E_tl <- E_tl + E_tl_resource[, k]
 
         # Update trophic level for each species active at this size
         for (i in seq_len(no_sp)) {
@@ -354,7 +398,8 @@ getTrophicLevel.MizerParams <- function(params,
 #' where \eqn{r_i(w) = (1 - f_i(w))\,E_i(w)} is the consumption rate of an
 #' individual of species \eqn{i} at weight \eqn{w}, \eqn{N_i(w)} is the
 #' abundance density, and \eqn{T_i(w)} is the size-resolved trophic level
-#' from [getTrophicLevel()].
+#' from [getTrophicLevel()]. As in [getTrophicLevel()], the resource is given a
+#' size-dependent trophic level controlled by the `w_R` and `beta_R` arguments.
 #'
 #' @inheritParams getTrophicLevel
 #'
@@ -370,6 +415,8 @@ getTrophicLevelBySpecies <- function(params,
                                      n = initialN(params),
                                      n_pp = initialNResource(params),
                                      n_other = initialNOther(params),
+                                     w_R = 1e-10,
+                                     beta_R = 1000,
                                      ...) {
     UseMethod("getTrophicLevelBySpecies")
 }
@@ -379,9 +426,12 @@ getTrophicLevelBySpecies.MizerParams <- function(params,
                                                   n = initialN(params),
                                                   n_pp = initialNResource(params),
                                                   n_other = initialNOther(params),
+                                                  w_R = 1e-10,
+                                                  beta_R = 1000,
                                                   ...) {
     params <- validParams(params)
-    tl <- getTrophicLevel(params, n = n, n_pp = n_pp, n_other = n_other)
+    tl <- getTrophicLevel(params, n = n, n_pp = n_pp, n_other = n_other,
+                          w_R = w_R, beta_R = beta_R)
     tl[is.na(tl)] <- 0
     encounter <- getEncounter(params, n, n_pp, n_other)
     feeding_level <- getFeedingLevel(params, n, n_pp, n_other)

--- a/man/getTrophicLevel.Rd
+++ b/man/getTrophicLevel.Rd
@@ -9,6 +9,8 @@ getTrophicLevel(
   n = initialN(params),
   n_pp = initialNResource(params),
   n_other = initialNOther(params),
+  w_R = 1e-10,
+  beta_R = 1000,
   ...
 )
 }
@@ -24,6 +26,14 @@ initial resource abundance stored in \code{params}.}
 \item{n_other}{A named list of the abundances of other dynamical
 components. Defaults to the initial values stored in \code{params}.}
 
+\item{w_R}{An average size (in grams) of primary producers in the resource
+spectrum, used to set the size-dependent resource trophic level. Defaults
+to \code{1e-10}.}
+
+\item{beta_R}{An average predator/prey mass ratio for the resource spectrum,
+used to set the size-dependent resource trophic level. Must be greater than
+\code{1}. Defaults to \code{1000}.}
+
 \item{...}{Unused}
 }
 \value{
@@ -37,7 +47,7 @@ Calculates the trophic level of individuals of each species at each size,
 assuming the system is in a steady state. The trophic level of an individual
 is defined as 1 more than the consumption-rate-weighted average trophic level
 of all the prey it has consumed during its lifetime up to the current size.
-The trophic level of the primary resource is set to 0.
+The resource is given a size-dependent trophic level (see below).
 }
 \details{
 In the traditional non-size-resolved approach, all individuals of a species
@@ -68,10 +78,19 @@ prey species \eqn{j} at weight \eqn{w_p}:
 r_{ij}(w, w_p) = \theta_{ij}\,\gamma_i(w)\,(1 - f_i(w))\,\phi_i(w/w_p)\,
   N_j(w_p)\,w_p.
 }
-The sum over \eqn{j} runs over all species. The resource is excluded from
-the numerator because its trophic level is 0, but is included in the
-denominator (which equals the total biomass consumed over the predator's
-lifetime from egg size to current weight \eqn{w}).
+The sum over \eqn{j} runs over all species and the resource. The resource is
+assigned a size-dependent trophic level
+\deqn{
+  T_R(w) = \max\left(1,\; 1 + \frac{\log(w / w_R)}{\log(\beta_R)}\right),
+}
+where \eqn{w_R} is an average size of primary producers (which therefore have
+trophic level 1) and \eqn{\beta_R} is an average predator/prey mass ratio for
+the resource (for example zooplankton). This adds one trophic level for each
+factor of \eqn{\beta_R} increase in resource size, with a floor at 1 so that
+the resource trophic level never drops below the primary-producer level.
+Both the numerator and the denominator (which equals the total biomass
+consumed over the predator's lifetime from egg size to current weight
+\eqn{w}) therefore include the resource.
 
 This equation can be viewed as a linear system
 \eqn{(I - D)\,\mathbf{T} = \mathbf{1}} in which the entries of

--- a/man/getTrophicLevelBySpecies.Rd
+++ b/man/getTrophicLevelBySpecies.Rd
@@ -9,6 +9,8 @@ getTrophicLevelBySpecies(
   n = initialN(params),
   n_pp = initialNResource(params),
   n_other = initialNOther(params),
+  w_R = 1e-10,
+  beta_R = 1000,
   ...
 )
 }
@@ -23,6 +25,14 @@ initial resource abundance stored in \code{params}.}
 
 \item{n_other}{A named list of the abundances of other dynamical
 components. Defaults to the initial values stored in \code{params}.}
+
+\item{w_R}{An average size (in grams) of primary producers in the resource
+spectrum, used to set the size-dependent resource trophic level. Defaults
+to \code{1e-10}.}
+
+\item{beta_R}{An average predator/prey mass ratio for the resource spectrum,
+used to set the size-dependent resource trophic level. Must be greater than
+\code{1}. Defaults to \code{1000}.}
 
 \item{...}{Unused}
 }
@@ -40,7 +50,8 @@ defined as
 where \eqn{r_i(w) = (1 - f_i(w))\,E_i(w)} is the consumption rate of an
 individual of species \eqn{i} at weight \eqn{w}, \eqn{N_i(w)} is the
 abundance density, and \eqn{T_i(w)} is the size-resolved trophic level
-from \code{\link[=getTrophicLevel]{getTrophicLevel()}}.
+from \code{\link[=getTrophicLevel]{getTrophicLevel()}}. As in \code{\link[=getTrophicLevel]{getTrophicLevel()}}, the resource is given a
+size-dependent trophic level controlled by the \code{w_R} and \code{beta_R} arguments.
 }
 \examples{
 getTrophicLevelBySpecies(NS_params)

--- a/tests/testthat/test-summary_methods.R
+++ b/tests/testthat/test-summary_methods.R
@@ -235,6 +235,30 @@ test_that("getTrophicLevel increases along body size for apex predators", {
     expect_true(cod_tl[length(cod_tl)] >= cod_tl[1])
 })
 
+test_that("non-zero resource trophic level lifts trophic levels above 1", {
+    # With the resource carrying a trophic level >= 1, fish that feed should
+    # have trophic levels strictly above 1.
+    tl <- getTrophicLevel(NS_params_small)
+    expect_true(all(tl > 1, na.rm = TRUE))
+    expect_true(all(is.finite(tl[!is.na(tl)])))
+})
+
+test_that("getTrophicLevel responds monotonically to beta_R", {
+    # A smaller beta_R packs more trophic steps into the resource spectrum and
+    # so should give resource (and hence fish) higher trophic levels.
+    tl_low <- getTrophicLevel(NS_params_small, beta_R = 100)
+    tl_high <- getTrophicLevel(NS_params_small, beta_R = 1e6)
+    finite <- !is.na(tl_low) & !is.na(tl_high)
+    expect_true(all(tl_low[finite] >= tl_high[finite] - 1e-10))
+    expect_false(isTRUE(all.equal(tl_low[finite], tl_high[finite])))
+})
+
+test_that("getTrophicLevelBySpecies forwards w_R and beta_R", {
+    tl_default <- getTrophicLevelBySpecies(NS_params_small)
+    tl_low <- getTrophicLevelBySpecies(NS_params_small, beta_R = 100)
+    expect_false(isTRUE(all.equal(tl_default, tl_low)))
+})
+
 # getTrophicLevelBySpecies ----
 test_that("getTrophicLevelBySpecies returns named vector", {
     tl_sp <- getTrophicLevelBySpecies(params, n, n_pp)


### PR DESCRIPTION
Closes #404.

## Problem

`getTrophicLevel()` assigned trophic level 0 to the entire resource spectrum, excluding it from the numerator of the lifetime-integrated trophic-level calculation (it appeared only in the denominator as total consumption). In a typical mizer model the resource extends to fairly large individuals (zooplankton etc.) that are not primary producers, and even genuine primary producers are conventionally assigned trophic level 1, not 0. The result understated fish trophic levels.

## Change

The resource is now given a size-dependent trophic level

$$T_R(w) = \max\left(1,\; 1 + \frac{\log(w / w_R)}{\log(\beta_R)}\right)$$

where `w_R` is an average size of primary producers (which therefore sit at trophic level 1) and `beta_R` is an average predator/prey mass ratio for the resource. This adds one trophic level per factor of `beta_R` in resource size, with a floor at 1.

Implementation notes:
- The resource trophic level is fixed by the formula, so its whole contribution to the numerator is precomputed once before the size loop, mirroring the `phi_prey_background` term in `mizerEncounter()`. It uses the full `pred_kernel` and `interaction_resource`, and the same `bin_average_summary_weight` convention as the species term so numerator and denominator stay consistent.
- New `w_R` (default `1e-10`) and `beta_R` (default `1000`) arguments on `getTrophicLevel()`, forwarded by `getTrophicLevelBySpecies()`. No `MizerParams`/`resource_params` or class changes.

## Tests / docs

- Added tests: resource lifts all fish trophic levels above 1, monotonic response to `beta_R`, and argument forwarding through `getTrophicLevelBySpecies()`. Existing structure/monotonicity tests still pass (`test-summary_methods.R`: 0 failures).
- Updated roxygen for both functions (including the new `T_R(w)` formula and a note on resource handling in `getTrophicLevelBySpecies()`), regenerated man pages, and added a `NEWS.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)