### PR TITLE
Document species parameter storage and constructor-argument handling

### DIFF
--- a/R/species_params.R
+++ b/R/species_params.R
@@ -91,6 +91,9 @@
 #'   `ks` of the metabolic rate, see [get_ks_default()].
 #' * `age_mat` is the age at maturity and is used to get a default value for
 #'   the coefficient `h` of the maximum intake rate, see [get_h_default()].
+#' * If `age_mat` is not supplied, mizer used the von Bertalanffy parameters
+#'   `k_vb`, `w_inf` and `t0` as well as the weight-length exponent `b` to
+#'   determine it. This is unreliable and is therefore not recommended.
 #'
 #' Changing these parameters with `species_params<-()` updates the stored
 #' species parameter table and triggers a recalculation via [setParams()].
@@ -98,10 +101,6 @@
 #' parameters are recalculated rather than kept at explicitly supplied values.
 #' In typical workflows these quantities should therefore be changed via
 #' `given_species_params<-()`.
-#'
-#' In the past, mizer also used the von Bertalanffy parameters `k_vb`, `w_inf`
-#' and `t0` to determine a default for `h`. This is unreliable and is therefore
-#' now deprecated.
 #'
 #' There are other species parameters that are used in tuning the model to
 #' observations:

--- a/vignettes/default_parameters.qmd
+++ b/vignettes/default_parameters.qmd
@@ -65,13 +65,27 @@ Here is a minimal model set up from nothing but a name and a maximum size:
 params <- newMultispeciesParams(
     data.frame(species = "Cod", w_max = 5000)
 )
-# Only these columns were supplied (n and p come from arguments of
-# newMultispeciesParams() and so count as "given"):
+# The columns that count as "given":
 names(given_species_params(params))
 # Everything else was calculated, for example:
 intersect(c("w_mat", "w_min", "h", "gamma", "ks"),
           names(calculated_species_params(params)))
 ```
+
+Notice that `n` and `p` appear among the *given* parameters even though we did
+not put them in the data frame. This is deliberate: some species parameters can
+also be set through arguments to the constructor functions (here the `n` and `p`
+arguments of `newMultispeciesParams()`), and any species parameter set from such
+an argument is recorded as given — **even when the argument was left at its
+default value in the function signature**. In other words, "given" means "fixed
+by the way you called the constructor", not only "typed into the species
+parameter data frame". The practical consequence is that these values count as
+explicit input and so are not silently changed by later recalculations.
+
+(Constructor arguments that do *not* directly correspond to a species parameter
+behave differently. For example `z0pre` and `z0exp` are used to *compute* the
+external mortality parameter `z0`, which therefore appears among the calculated
+parameters rather than the given ones.)
 
 ### Changing parameters: `given_species_params<-()` vs. `species_params<-()`
 

--- a/vignettes/default_parameters.qmd
+++ b/vignettes/default_parameters.qmd
@@ -25,6 +25,157 @@ This vignette details the philosophy, the relationships, and the mathematical de
 
 ---
 
+## How species parameters are stored and used
+
+Because most species parameters can be filled in with defaults, `mizer` needs to
+keep track of which values *you* supplied and which it calculated for you. It
+also needs a rule for what should happen when you later change a value. This
+section explains the machinery — the two species-parameter data frames, the
+accessor and setter functions, the role of `setParams()`, and the "comment"
+mechanism on the size-dependent rate arrays — so that the rest of this vignette
+makes sense.
+
+### Two data frames: given vs. full
+
+Every `MizerParams` object stores **two** species-parameter data frames:
+
+* **`given_species_params`** holds only the values that were supplied
+  explicitly (by you, or by a wrapper function such as
+  `newMultispeciesParams()`). Parameters you never mentioned simply do not
+  appear here, or appear as `NA`.
+* **`species_params`** is the *full* table that the model actually uses. It
+  contains your given values **plus** all the defaults and derived values that
+  `mizer` filled in.
+
+You access them with three functions:
+
+```{r eval=FALSE}
+given_species_params(params)       # only what was supplied explicitly
+calculated_species_params(params)  # only the values mizer filled in
+species_params(params)             # the complete table (given + calculated)
+```
+
+`calculated_species_params()` is just `species_params()` with the given entries
+blanked out, so the given and calculated frames together reconstruct the full
+table.
+
+Here is a minimal model set up from nothing but a name and a maximum size:
+
+```{r message=FALSE, warning=FALSE}
+params <- newMultispeciesParams(
+    data.frame(species = "Cod", w_max = 5000)
+)
+# Only these columns were supplied (n and p come from arguments of
+# newMultispeciesParams() and so count as "given"):
+names(given_species_params(params))
+# Everything else was calculated, for example:
+intersect(c("w_mat", "w_min", "h", "gamma", "ks"),
+          names(calculated_species_params(params)))
+```
+
+### Changing parameters: `given_species_params<-()` vs. `species_params<-()`
+
+There are correspondingly two ways to change species parameters, and the
+difference matters:
+
+* **`given_species_params<-()`** (recommended) records your change as a *given*
+  value and then triggers a recalculation, via `setParams()`, of every
+  calculated parameter and size-dependent rate that depends on it. This is what
+  you almost always want.
+* **`species_params<-()`** overwrites the *full* table directly. It does **not**
+  protect your change: the value you write is not marked as "given", so the very
+  next recalculation (for instance the next time you use
+  `given_species_params<-()`) may overwrite it with a freshly calculated
+  default.
+
+For example, in a model where the age at maturity is known, `mizer` derives the
+maximum intake coefficient `h` from it (see the
+["Dependency Chain"](#the-dependency-chain) below). Changing the size at maturity
+through the given parameters then propagates to `h` (and onward to `gamma` and
+`ks`) automatically:
+
+```{r message=FALSE, warning=FALSE}
+growing <- newMultispeciesParams(
+    data.frame(species = "Cod", w_max = 5000, age_mat = 5)
+)
+species_params(growing)$h
+given_species_params(growing)$w_mat <- 1000
+species_params(growing)$h           # recalculated
+```
+
+After this, `w_mat` has moved from the calculated frame into the given frame of
+`growing`, because you have now supplied it explicitly.
+
+A useful consequence of the given/calculated split is that supplying a value
+*switches off* the corresponding default calculation. The
+["Dependency Chain"](#the-dependency-chain) below shows, for instance, that
+`age_mat` is only used to calculate a default for `h`. If you give `h` directly,
+`age_mat` is ignored; if you give `gamma`, the `f0` value is ignored; and so on.
+`given_species_params<-()` will warn you when you set a parameter whose effect is
+overridden by another value you have already given.
+
+### `setParams()` and the size-dependent rate arrays
+
+The species parameters are not used directly during a simulation. Instead they
+are used to compute the **size-dependent rate arrays** (search volume, maximum
+intake rate, metabolic rate, external mortality, reproduction, …) that are
+stored in their own slots of the `MizerParams` object. The function that does
+this translation is `setParams()`, which simply calls each of the individual
+setter functions (`setSearchVolume()`, `setMaxIntakeRate()`,
+`setMetabolicRate()`, and so on) in the correct order. Both
+`given_species_params<-()` and `species_params<-()` call `setParams()` for you,
+which is why changing a species parameter automatically updates the rates.
+
+### Overriding a rate directly: the "comment" mechanism
+
+Sometimes you do not want a rate to follow the allometric default at all — you
+have your own array of values. Every setter function accepts the rate array
+directly, e.g.
+
+```{r message=FALSE, warning=FALSE}
+sv <- getSearchVolume(params)
+sv[] <- 2 * sv                      # your own custom values
+params <- setSearchVolume(params, search_vol = sv)
+```
+
+When you supply an array this way, `mizer` attaches a `comment()` to the stored
+slot (the text `"set manually"` unless you set your own comment):
+
+```{r}
+comment(params@search_vol)
+```
+
+This comment is a **flag that protects your values**. While a rate array carries
+a comment, `setParams()` will *not* recalculate it from the species parameters,
+and the species parameters that would normally feed into it are effectively
+ignored for that rate. So after the override above, changing `gamma` no longer
+affects the search volume:
+
+```{r message=FALSE, warning=FALSE}
+given_species_params(params)$gamma <- 1e-10
+species_params(params)$gamma        # the species parameter did change ...
+identical(comment(params@search_vol), "set manually")  # ... but the rate is frozen
+```
+
+To go back to the automatically calculated values, call the setter with
+`reset = TRUE`, which removes the comment and recomputes the rate from the
+species parameters:
+
+```{r message=FALSE, warning=FALSE}
+params <- setSearchVolume(params, reset = TRUE)
+comment(params@search_vol)          # NULL again
+```
+
+In summary:
+
+* Provide a *species parameter* (via `given_species_params<-()`) when you want
+  `mizer` to keep deriving the rate for you, using your value as input.
+* Provide a *rate array* (via the relevant setter) when you want to override the
+  rate completely; this sets a comment that freezes the rate until you
+  `reset` it.
+
+---
+
 ## Species Parameter Defaults Reference Table
 
 When creating a `MizerParams` object, `validSpeciesParams()` (and subsequent setup functions like `setSearchVolume()`, `setMaxIntakeRate()`, `setMetabolicRate()`, `setExtMort()`, and `setReproduction()`) check the species parameter data frame and fill in missing parameters.


### PR DESCRIPTION
## Summary

Adds an explanatory section to `vignettes/default_parameters.qmd` covering how species parameters are stored and used, so that the interaction between `species_params`, `given_species_params`, `setParams()`, and the rate-array `comment()` mechanism is documented for users.

The new material explains:

- **Two data frames** — `given_species_params` (what was supplied explicitly) vs. the full `species_params` table (given + calculated), and `calculated_species_params()` as the complement.
- **`given_species_params<-()` vs. `species_params<-()`** — why the former is recommended (records a value as given and triggers a protected recalculation) and how supplying a value switches off the corresponding default calculation.
- **`setParams()`** — how species parameters are translated into the size-dependent rate arrays.
- **The `comment()` mechanism** — supplying a rate array directly attaches a comment that freezes the rate so `setParams()` won't recalculate it, and `reset = TRUE` restores the derived values.
- **Constructor-argument handling** — any species parameter set from a constructor argument (e.g. `n`, `p`) is recorded as *given* even when left at its signature default, and this is contrasted with arguments like `z0pre`/`z0exp` that only feed into a *calculated* parameter (`z0`). This behaviour was verified to be consistent across `newMultispeciesParams()`, `newSingleSpeciesParams()`, `newCommunityParams()`, and `newTraitParams()`.

All R code chunks in the new section were executed against the loaded package and produce the documented output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)