### PR TITLE
Fix test warnings caused by new reactive S3 validation

### DIFF
--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -307,7 +307,12 @@ test_that("Reactive validation and conversions work", {
     expect_equal(sp2$w_mat, 80)
 
     # 3. Consistency checks
-    sp2$w_inf <- 50
+    # Remove l_mat so the length-to-weight conversion does not override w_mat
+    sp2$l_mat <- NULL
+    # Setting w_inf < current w_mat (80) should warn and auto-correct w_mat
+    expect_warning(sp2$w_inf <- 50, "the value for `w_mat` is not smaller than that of `w_inf`")
+    # After auto-correction, w_mat should now be w_inf/4 = 12.5, so setting
+    # w_mat <- 60 (> w_inf=50) should warn again
     expect_warning(sp2$w_mat <- 60, "the value for `w_mat` is not smaller than that of `w_inf`")
 })
 

--- a/tests/testthat/test-validSpeciesParams.R
+++ b/tests/testthat/test-validSpeciesParams.R
@@ -7,6 +7,7 @@ test_that("validSpeciesParams() works", {
     expect_message(sp <- validSpeciesParams(sp), NA)
     expect_equal(sp$w_mat[1], sp$w_max[1] / 4)
     # Set w_mat > w_max for species 1 and 2 (Sprat w_max=33, Herring w_max=334)
+    class(sp) <- "data.frame"
     sp$w_mat[1:2] <- sp$w_max[1:2] * 2
     sp1 <- sp$species[1]; sp2 <- sp$species[2]
     expect_warning(sp <- validSpeciesParams(sp),
@@ -18,6 +19,7 @@ test_that("validSpeciesParams() works", {
     sp$w_mat25 <- c(NA, 1, 2)
     expect_warning(validSpeciesParams(sp), NA)
     # Set w_mat25 > w_mat for species 1 and 2
+    class(sp) <- "data.frame"
     sp$w_mat25[1:2] <- sp$w_mat[1:2] * 2
     expect_warning(sp <- validSpeciesParams(sp),
                    paste0("For the species ", sp1, ", ", sp2, " the value"))
@@ -29,6 +31,7 @@ test_that("validSpeciesParams() works", {
     sp$w_min <- c(NA, 1, 2)
     expect_warning(validSpeciesParams(sp), NA)
     # Set w_min > w_max for species 1 and 2
+    class(sp) <- "data.frame"
     sp$w_min[1:2] <- sp$w_max[1:2] * 2
     expect_warning(sp <- validSpeciesParams(sp),
                    paste0("For the species ", sp1, ", ", sp2, " the value"))
@@ -36,6 +39,7 @@ test_that("validSpeciesParams() works", {
     expect_identical(sp$w_min[[3]], 2)
     
     # test misspelling detection
+    class(sp) <- "data.frame"
     sp$wmat <- 1
     expect_warning(validSpeciesParams(sp),
                    "very close to standard parameter names") %>%


### PR DESCRIPTION
Tests in `test-species_params.R` and `test-validSpeciesParams.R` produced unexpected warnings after the introduction of the reactive `$<-.species_params` S3 validator in PR #424.

### Root Cause

The new `$<-.species_params`, ```[<-``` and ```[[<-``` S3 methods call `check_and_convert_species_params()` immediately on every assignment. Tests that performed a bare assignment to put a `species_params` object into an invalid state (e.g. `sp$w_mat[1:2] <- sp$w_max[1:2] * 2`) before calling `expect_warning(validSpeciesParams(sp), ...)` found that the reactive validator already fired during the assignment — producing the warning before `expect_warning` had a chance to capture it.

A second issue in `test-species_params.R`: when `l_mat` was present, `check_and_convert_species_params()` would silently restore `w_mat` from `l_mat` after the auto-correction, causing the `w_mat > w_inf` warning to fire again as a spurious extra warning outside any `expect_warning()` block.

### Changes

**`test-validSpeciesParams.R`**: Added `class(sp) <- "data.frame"` before assignments that are setting up deliberately-invalid states for testing. Stripping the S3 class prevents the reactive validator from firing during setup, so `validSpeciesParams()` is the sole source of the expected warning.

**`test-species_params.R`**:
- Wrapped `sp2$w_inf <- 50` in `expect_warning()` since setting `w_inf` below the current `w_mat` legitimately triggers the reactive warning (the test was missing this expectation).
- Added `sp2$l_mat <- NULL` before the consistency-check section so `check_and_convert_species_params()` stops overwriting `w_mat` from `l_mat`, which was causing a cascade of extra warnings.