### PR TITLE
Make resource balancing explicit, not a side effect of the setters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # mizer 3.1.0.9000 (development version)
 
+- Assigning to `resource_params()` no longer balances the resource. It now only
+  rebuilds the size-dependent rate (`rr_pp`) and capacity (`cc_pp`) arrays from
+  the scalars, leaving any manually set (frozen) arrays untouched, exactly as
+  `species_params<-` feeds the species rates. As a result changing the rate-side
+  scalars `r_pp` or `n` now takes effect (previously the value was silently
+  discarded by balancing), and successive scalar edits accumulate instead of
+  overwriting each other. Balancing the resource to preserve the steady state is
+  now solely a feature of `setResource()`. The `resource_rate<-`,
+  `resource_capacity<-`, `resource_level<-` and `resource_dynamics<-` setters
+  gained a `balance` argument (default unchanged) so it can be switched off, e.g.
+  `resource_capacity(params, balance = FALSE) <- my_capacity`. `setResource()`
+  also no longer silently overwrites a manually set rate or capacity array when
+  balancing: the frozen array wins and a warning is issued.
+
 - An installed extension package is now recognised as a dispatching extension
   from the S3 methods it registers for its marker class (e.g.
   `getEncounter.mizerMR`), rather than only from a statically defined S4 marker

--- a/R/newMultispeciesParams.R
+++ b/R/newMultispeciesParams.R
@@ -20,7 +20,9 @@
 #' @inheritParams setResource
 #' @param r_pp `r lifecycle::badge("deprecated")`. Use `resource_rate` argument
 #'   instead.
-#' @param kappa The coefficient of the initial resource abundance power-law.
+#' @param kappa The coefficient \eqn{\kappa} of the resource carrying capacity
+#'   power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial
+#'   resource abundance. See [resource_params()].
 #' @param min_w_pp The smallest size of the resource spectrum. By default this
 #'   is set to the smallest value at which any of the consumers can feed.
 #' @param n The allometric growth exponent. This can be overruled for individual

--- a/R/resource_dynamics.R
+++ b/R/resource_dynamics.R
@@ -49,13 +49,15 @@ resource_constant <- function(params, n_pp, ...) {
 #' its cutoff value: \deqn{c_R(w) = c_R w^{-\lambda}} for all \eqn{w} less than
 #' `w_pp_cutoff` and zero for larger sizes.
 #'
-#' The resource parameter `kappa` (\eqn{\kappa}) is slightly different in that
-#' it is not a parameter for the resource dynamics. Instead it is a parameter
-#' that determined the initial resource abundance when the model was created:
-#' \deqn{N_R(w) = \kappa\, w^{-\lambda}}{c_R(w) = \kappa w^{-\lambda}}
-#' for all \eqn{w} less than `w_pp_cutoff` and zero for larger sizes. Note that
-#' the initial resource abundance is not changed by [setResource()] even if you
-#' change the value of `kappa` in the `resource_params`.
+#' The resource parameter `kappa` (\eqn{\kappa}) is the coefficient \eqn{c_R} of
+#' the carrying capacity in the power law above, so
+#' \deqn{c_R(w) = \kappa\, w^{-\lambda}}{c_R(w) = \kappa w^{-\lambda}}
+#' for all \eqn{w} less than `w_pp_cutoff` and zero for larger sizes. Changing
+#' `kappa` therefore rescales the carrying capacity. It has a second role in that
+#' the same expression also set the initial resource abundance when the model was
+#' created: \deqn{N_R(w) = \kappa\, w^{-\lambda}.}{N_R(w) = \kappa w^{-\lambda}.}
+#' Unlike the carrying capacity, however, the initial resource abundance is
+#' **not** updated when you subsequently change `kappa` (or call [setResource()]).
 #'
 #' Assigning to `resource_params` only rebuilds the size-dependent resource rate
 #' and capacity arrays from these scalars (leaving any arrays you have set

--- a/R/resource_dynamics.R
+++ b/R/resource_dynamics.R
@@ -56,7 +56,16 @@ resource_constant <- function(params, n_pp, ...) {
 #' for all \eqn{w} less than `w_pp_cutoff` and zero for larger sizes. Note that
 #' the initial resource abundance is not changed by [setResource()] even if you
 #' change the value of `kappa` in the `resource_params`.
-#' 
+#'
+#' Assigning to `resource_params` only rebuilds the size-dependent resource rate
+#' and capacity arrays from these scalars (leaving any arrays you have set
+#' manually untouched). It does **not** balance the resource, i.e. it does not
+#' adjust one of the rate or capacity to keep the resource at the steady state
+#' where it replenishes at the rate at which it is consumed. This mirrors the
+#' way the species parameters feed the species rates. If you want to preserve
+#' the steady state after changing a resource scalar, call [setResource()] with
+#' the appropriate argument (which balances by default).
+#'
 #' @param params A MizerParams object
 #' @return A named list of resource parameters.
 #' @seealso [setResource()]
@@ -92,7 +101,12 @@ resource_params <- function(params) {
     
     params@resource_params <- value
     params@time_modified <- lubridate::now()
-    setResource(params, resource_params_changed = rp_changed)
+    # Setting the scalar resource parameters only rebuilds the size-dependent
+    # rate and capacity arrays from those scalars (respecting any manual
+    # overrides). It does not balance the resource: that is a deliberate action
+    # reserved for `setResource()`. This mirrors how `species_params<-` feeds
+    # the species-parameter rates.
+    setResource(params, resource_params_changed = rp_changed, balance = FALSE)
 }
 
 

--- a/R/setResource.R
+++ b/R/setResource.R
@@ -22,7 +22,12 @@
 #' in that case you should not specify `resource_capacity` as well.
 #'
 #' If you provide none of the arguments `resource_level`, `resource_rate` or
-#' `resource_capacity` then the resource rate is kept at its previous value.
+#' `resource_capacity`, and you do not change any of the resource parameters,
+#' then the resource rate is kept at its previous value and, when balancing, the
+#' capacity is recalculated from it. If instead you change one of the resource
+#' parameters (`kappa`, `lambda`, `n` or `w_pp_cutoff`) or set `reset = TRUE`,
+#' the rate and capacity are recalculated from the resource parameters (and then
+#' balanced, unless `balance = FALSE`).
 #'
 #' @section Setting resource dynamics:
 #'
@@ -58,7 +63,9 @@
 #'
 #' The values for `lambda`, `n` and `w_pp_cutoff` are stored in a list
 #' in the `resource_params` slot of the MizerParams object so that they can be
-#' re-used automatically in the future. That list can be accessed with
+#' re-used automatically in the future. If you specify `resource_rate` or
+#' `resource_capacity` as a single number, that coefficient is likewise stored,
+#' as `r_pp` and `kappa` respectively. That list can be accessed with
 #' [resource_params()].
 #'
 #' @param params A MizerParams object
@@ -330,7 +337,10 @@ setResource.MizerParams <- function(params,
     }
 
     # Recompute rate from stored scalar r_pp if not provided and not commented ----
-    if (is.null(resource_rate) && is.null(resource_capacity) && resource_params_changed) {
+    # This is deliberately independent of whether the capacity was recomputed:
+    # each array is rebuilt from its own scalars so that rate-side parameters
+    # (`r_pp`, `n`) take effect even when capacity-side parameters also changed.
+    if (is.null(resource_rate) && resource_params_changed) {
         if (is.null(comment(params@rr_pp))) {
             r_pp <- params@resource_params[["r_pp"]]
             if (!is.null(r_pp) && is.numeric(r_pp) && length(r_pp) == 1) {
@@ -375,6 +385,16 @@ setResource.MizerParams <- function(params,
             }
         }
 
+        # Whichever side is NULL going into the balancing function is the one
+        # that gets derived from the other. A frozen (commented) array is only
+        # protected from *incidental* balancing, i.e. when the user did not
+        # explicitly supply the complementary rate/capacity/level
+        # (`num_args_user == 0`). An explicit request to balance against a
+        # supplied value overrides the freeze; pass `balance = FALSE` to keep a
+        # manually set array in that case.
+        derive_rate <- is.null(resource_rate)
+        derive_capacity <- is.null(resource_capacity)
+
         balance_fn <- get0(paste0("balance_", params@resource_dynamics))
         if (!is.function(balance_fn)) {
             stop("There is no balancing function available for ",
@@ -384,8 +404,31 @@ setResource.MizerParams <- function(params,
         balance <- balance_fn(params,
                               resource_rate = resource_rate,
                               resource_capacity = resource_capacity)
-        resource_rate <- balance$resource_rate
-        resource_capacity <- balance$resource_capacity
+
+        freeze_rate <- num_args_user == 0 && derive_rate &&
+            !is.null(comment(params@rr_pp))
+        freeze_capacity <- num_args_user == 0 && derive_capacity &&
+            !is.null(comment(params@cc_pp))
+        if (freeze_rate) {
+            warning("The resource rate has been set manually and so it was ",
+                    "not rebalanced. The resource may no longer replenish at ",
+                    "the rate at which it is consumed. Use `reset = TRUE` to ",
+                    "recalculate it from the resource parameters.",
+                    call. = FALSE)
+            resource_rate <- NULL
+        } else {
+            resource_rate <- balance$resource_rate
+        }
+        if (freeze_capacity) {
+            warning("The resource capacity has been set manually and so it ",
+                    "was not rebalanced. The resource may no longer replenish ",
+                    "at the rate at which it is consumed. Use `reset = TRUE` ",
+                    "to recalculate it from the resource parameters.",
+                    call. = FALSE)
+            resource_capacity <- NULL
+        } else {
+            resource_capacity <- balance$resource_capacity
+        }
     }
 
     # Set rates
@@ -413,8 +456,8 @@ resource_rate <- function(params) {
 #' @rdname setResource
 #' @param value The desired new value for the respective parameter.
 #' @export
-`resource_rate<-` <- function(params, value) {
-    setResource(params, resource_rate = value)
+`resource_rate<-` <- function(params, balance = NULL, value) {
+    setResource(params, resource_rate = value, balance = balance)
 }
 
 #' @rdname setResource
@@ -427,8 +470,8 @@ resource_capacity <- function(params) {
 
 #' @rdname setResource
 #' @export
-`resource_capacity<-` <- function(params, value) {
-    setResource(params, resource_capacity = value)
+`resource_capacity<-` <- function(params, balance = NULL, value) {
+    setResource(params, resource_capacity = value, balance = balance)
 }
 
 
@@ -444,8 +487,8 @@ resource_level <- function(params) {
 
 #' @rdname setResource
 #' @export
-`resource_level<-` <- function(params, value) {
-    setResource(params, resource_level = value)
+`resource_level<-` <- function(params, balance = NULL, value) {
+    setResource(params, resource_level = value, balance = balance)
 }
 
 
@@ -463,6 +506,6 @@ resource_dynamics <- function(params) {
 #' params <- NS_params
 #' resource_dynamics(params)
 #' resource_dynamics(params) <- "resource_constant"
-`resource_dynamics<-` <- function(params, value) {
-    setResource(params, resource_dynamics = value)
+`resource_dynamics<-` <- function(params, balance = NULL, value) {
+    setResource(params, resource_dynamics = value, balance = balance)
 }

--- a/man/MizerParams.Rd
+++ b/man/MizerParams.Rd
@@ -48,7 +48,9 @@ species by including a \code{n} column in the \code{species_params}.}
 coefficient in the search rate. Ignored if \code{gamma} is given
 explicitly.}
 
-\item{kappa}{The coefficient of the initial resource abundance power-law.}
+\item{kappa}{The coefficient \eqn{\kappa} of the resource carrying capacity
+power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial
+resource abundance. See \code{\link[=resource_params]{resource_params()}}.}
 
 \item{lambda}{Used to set power-law exponent for resource capacity if the
 \code{resource_capacity} argument is given as a single number.}

--- a/man/newCommunityParams.Rd
+++ b/man/newCommunityParams.Rd
@@ -59,7 +59,9 @@ if it is left as \code{NA}.}
 the maximum intake rate of the community as well as the intrinsic growth
 rate of the resource.}
 
-\item{kappa}{The coefficient of the initial resource abundance power-law.}
+\item{kappa}{The coefficient \eqn{\kappa} of the resource carrying capacity
+power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial
+resource abundance. See \code{\link[=resource_params]{resource_params()}}.}
 
 \item{lambda}{Used to set power-law exponent for resource capacity if the
 \code{resource_capacity} argument is given as a single number.}

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -758,7 +758,9 @@ The power-law exponent \eqn{\lambda} is taken from the \code{lambda} argument.
 
 The values for \code{lambda}, \code{n} and \code{w_pp_cutoff} are stored in a list
 in the \code{resource_params} slot of the MizerParams object so that they can be
-re-used automatically in the future. That list can be accessed with
+re-used automatically in the future. If you specify \code{resource_rate} or
+\code{resource_capacity} as a single number, that coefficient is likewise stored,
+as \code{r_pp} and \code{kappa} respectively. That list can be accessed with
 \code{\link[=resource_params]{resource_params()}}.
 }
 

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -111,7 +111,9 @@ reproduction".}
 reproduction rate from the density-independent rate. Defaults to
 "\code{\link[=BevertonHoltRDD]{BevertonHoltRDD()}}".}
 
-\item{kappa}{The coefficient of the initial resource abundance power-law.}
+\item{kappa}{The coefficient \eqn{\kappa} of the resource carrying capacity
+power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial
+resource abundance. See \code{\link[=resource_params]{resource_params()}}.}
 
 \item{n}{The allometric growth exponent. This can be overruled for individual
 species by including a \code{n} column in the \code{species_params}.}

--- a/man/resource_params.Rd
+++ b/man/resource_params.Rd
@@ -38,13 +38,15 @@ power-law form for the carrying capacity \eqn{c_R(w)} and \code{w_pp_cutoff} is
 its cutoff value: \deqn{c_R(w) = c_R w^{-\lambda}} for all \eqn{w} less than
 \code{w_pp_cutoff} and zero for larger sizes.
 
-The resource parameter \code{kappa} (\eqn{\kappa}) is slightly different in that
-it is not a parameter for the resource dynamics. Instead it is a parameter
-that determined the initial resource abundance when the model was created:
-\deqn{N_R(w) = \kappa\, w^{-\lambda}}{c_R(w) = \kappa w^{-\lambda}}
-for all \eqn{w} less than \code{w_pp_cutoff} and zero for larger sizes. Note that
-the initial resource abundance is not changed by \code{\link[=setResource]{setResource()}} even if you
-change the value of \code{kappa} in the \code{resource_params}.
+The resource parameter \code{kappa} (\eqn{\kappa}) is the coefficient \eqn{c_R} of
+the carrying capacity in the power law above, so
+\deqn{c_R(w) = \kappa\, w^{-\lambda}}{c_R(w) = \kappa w^{-\lambda}}
+for all \eqn{w} less than \code{w_pp_cutoff} and zero for larger sizes. Changing
+\code{kappa} therefore rescales the carrying capacity. It has a second role in that
+the same expression also set the initial resource abundance when the model was
+created: \deqn{N_R(w) = \kappa\, w^{-\lambda}.}{N_R(w) = \kappa w^{-\lambda}.}
+Unlike the carrying capacity, however, the initial resource abundance is
+\strong{not} updated when you subsequently change \code{kappa} (or call \code{\link[=setResource]{setResource()}}).
 
 Assigning to \code{resource_params} only rebuilds the size-dependent resource rate
 and capacity arrays from these scalars (leaving any arrays you have set

--- a/man/resource_params.Rd
+++ b/man/resource_params.Rd
@@ -45,6 +45,15 @@ that determined the initial resource abundance when the model was created:
 for all \eqn{w} less than \code{w_pp_cutoff} and zero for larger sizes. Note that
 the initial resource abundance is not changed by \code{\link[=setResource]{setResource()}} even if you
 change the value of \code{kappa} in the \code{resource_params}.
+
+Assigning to \code{resource_params} only rebuilds the size-dependent resource rate
+and capacity arrays from these scalars (leaving any arrays you have set
+manually untouched). It does \strong{not} balance the resource, i.e. it does not
+adjust one of the rate or capacity to keep the resource at the steady state
+where it replenishes at the rate at which it is consumed. This mirrors the
+way the species parameters feed the species rates. If you want to preserve
+the steady state after changing a resource scalar, call \code{\link[=setResource]{setResource()}} with
+the appropriate argument (which balances by default).
 }
 \seealso{
 \code{\link[=setResource]{setResource()}}

--- a/man/setResource.Rd
+++ b/man/setResource.Rd
@@ -28,19 +28,19 @@ setResource(
 
 resource_rate(params)
 
-resource_rate(params) <- value
+resource_rate(params, balance = NULL) <- value
 
 resource_capacity(params)
 
-resource_capacity(params) <- value
+resource_capacity(params, balance = NULL) <- value
 
 resource_level(params)
 
-resource_level(params) <- value
+resource_level(params, balance = NULL) <- value
 
 resource_dynamics(params)
 
-resource_dynamics(params) <- value
+resource_dynamics(params, balance = NULL) <- value
 }
 \arguments{
 \item{params}{A MizerParams object}
@@ -133,7 +133,12 @@ to the current resource number density divided by the resource level. So
 in that case you should not specify \code{resource_capacity} as well.
 
 If you provide none of the arguments \code{resource_level}, \code{resource_rate} or
-\code{resource_capacity} then the resource rate is kept at its previous value.
+\code{resource_capacity}, and you do not change any of the resource parameters,
+then the resource rate is kept at its previous value and, when balancing, the
+capacity is recalculated from it. If instead you change one of the resource
+parameters (\code{kappa}, \code{lambda}, \code{n} or \code{w_pp_cutoff}) or set \code{reset = TRUE},
+the rate and capacity are recalculated from the resource parameters (and then
+balanced, unless \code{balance = FALSE}).
 }
 \section{Setting resource dynamics}{
 
@@ -170,7 +175,9 @@ The power-law exponent \eqn{\lambda} is taken from the \code{lambda} argument.
 
 The values for \code{lambda}, \code{n} and \code{w_pp_cutoff} are stored in a list
 in the \code{resource_params} slot of the MizerParams object so that they can be
-re-used automatically in the future. That list can be accessed with
+re-used automatically in the future. If you specify \code{resource_rate} or
+\code{resource_capacity} as a single number, that coefficient is likewise stored,
+as \code{r_pp} and \code{kappa} respectively. That list can be accessed with
 \code{\link[=resource_params]{resource_params()}}.
 }
 

--- a/man/set_multispecies_model.Rd
+++ b/man/set_multispecies_model.Rd
@@ -48,7 +48,9 @@ species by including a \code{n} column in the \code{species_params}.}
 coefficient in the search rate. Ignored if \code{gamma} is given
 explicitly.}
 
-\item{kappa}{The coefficient of the initial resource abundance power-law.}
+\item{kappa}{The coefficient \eqn{\kappa} of the resource carrying capacity
+power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial
+resource abundance. See \code{\link[=resource_params]{resource_params()}}.}
 
 \item{lambda}{Used to set power-law exponent for resource capacity if the
 \code{resource_capacity} argument is given as a single number.}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -72,6 +72,10 @@ articles:
   - cheatsheet-changing-parameters
   - cheatsheet-fishing
   - cheatsheet-analysis-and-plotting
+- title: Upgrading
+  navbar: Upgrading
+  contents:
+  - upgrading
 - title: Extending mizer
   navbar: Extending mizer
   contents:

--- a/tests/testthat/test-setResource.R
+++ b/tests/testthat/test-setResource.R
@@ -261,8 +261,8 @@ test_that("resource_params<- rebuilds capacity and rate arrays (issue #439)", {
     p1 <- p
     resource_params(p1)$kappa <- 10 * resource_params(p1)$kappa
     expect_equal(as.numeric(resource_capacity(p1)), 10 * as.numeric(cc0))
-    # rr_pp is rebalanced under semichemostat
-    expect_false(isTRUE(all.equal(as.numeric(resource_rate(p1)), as.numeric(rr0))))
+    # resource_params<- does not balance, so rr_pp is left unchanged
+    expect_equal(as.numeric(resource_rate(p1)), as.numeric(rr0))
 
     # 2. resource_params(p)$lambda <- x changes the slope of cc_pp
     p2 <- p
@@ -279,9 +279,11 @@ test_that("resource_params<- rebuilds capacity and rate arrays (issue #439)", {
     resource_capacity(p3) <- custom_cc
     expect_identical(comment(p3@cc_pp), "set manually")
     
-    # Modifying kappa now does not overwrite custom cc_pp array
+    # Modifying kappa now does not overwrite custom cc_pp array and, because
+    # resource_params<- no longer balances, the freeze comment survives too.
     resource_params(p3)$kappa <- 10 * resource_params(p3)$kappa
     expect_equal(resource_capacity(p3), custom_cc, ignore_attr = TRUE)
+    expect_identical(comment(p3@cc_pp), "set manually")
     
     # setResource(..., reset = TRUE) resets to scalar-driven capacity
     p4 <- setResource(p3, reset = TRUE)
@@ -297,4 +299,79 @@ test_that("resource_params<- rebuilds capacity and rate arrays (issue #439)", {
     w_full <- p5@w_full
     expect_true(all(p5@cc_pp[w_full >= new_cutoff] == 0))
     expect_true(all(p5@initial_n_pp[w_full >= new_cutoff] == 0))
+})
+
+test_that("resource_params<- does not balance and rate-side scalars take effect", {
+    p <- NS_params_small
+    # Give the model a scalar r_pp so the rate is driven by resource_params
+    p <- setResource(p, resource_rate = 1, balance = FALSE)
+    rr1 <- as.numeric(resource_rate(p))
+
+    # Changing the rate-side scalar r_pp now updates rr_pp (was inert before
+    # because balancing re-derived the rate from the capacity)
+    resource_params(p)$r_pp <- 2
+    expect_equal(as.numeric(resource_rate(p)), 2 * rr1)
+
+    # Sequential scalar edits accumulate: a later capacity-side change does not
+    # discard the earlier rate-side change (mirrors species_params<-)
+    cc_before <- as.numeric(resource_capacity(p))
+    rr_before <- as.numeric(resource_rate(p))
+    resource_params(p)$kappa <- 5 * resource_params(p)$kappa
+    expect_equal(as.numeric(resource_rate(p)), rr_before)
+    expect_equal(as.numeric(resource_capacity(p)), 5 * cc_before)
+})
+
+test_that("resource setters take a balance argument", {
+    p <- NS_params_small
+    rr0 <- as.numeric(resource_rate(p))
+
+    # balance = FALSE leaves the opposite side untouched
+    p_f <- p
+    resource_capacity(p_f, balance = FALSE) <- 2 * resource_capacity(p_f)
+    expect_equal(as.numeric(resource_rate(p_f)), rr0)
+
+    # the default (balance = TRUE) rebalances the rate to the new capacity
+    p_t <- p
+    resource_capacity(p_t) <- 2 * resource_capacity(p_t)
+    expect_false(isTRUE(all.equal(as.numeric(resource_rate(p_t)), rr0)))
+})
+
+test_that("incidental balancing does not overwrite a frozen array (freeze wins)", {
+    p <- NS_params_small
+    # Freeze the capacity manually
+    resource_capacity(p) <- 2 * resource_capacity(p)
+    expect_false(is.null(comment(p@cc_pp)))
+    cc_frozen <- as.numeric(resource_capacity(p))
+
+    # An incidental balance (no rate/capacity supplied) would re-derive the
+    # capacity, but the frozen capacity must be preserved and a warning issued.
+    expect_warning(
+        p2 <- setResource(p, balance = TRUE),
+        "set manually"
+    )
+    expect_equal(as.numeric(resource_capacity(p2)), cc_frozen)
+    expect_false(is.null(comment(p2@cc_pp)))
+})
+
+test_that("explicit balancing overrides a frozen complementary array", {
+    p <- NS_params_small
+    # Freeze the rate manually
+    resource_rate(p) <- resource_rate(p)
+    expect_false(is.null(comment(p@rr_pp)))
+
+    # Explicitly supplying a new capacity with balance = TRUE (the default)
+    # re-derives the rate, overriding the freeze, so the resource stays at
+    # steady state.
+    p2 <- setResource(p, resource_capacity = 2 * resource_capacity(p))
+    N <- initialNResource(p2)
+    mu <- getResourceMort(p2)
+    r <- p2@rr_pp
+    c <- p2@cc_pp
+    sel <- (mu + r) > 0
+    expect_equal((r * c / (mu + r))[sel], N[sel], ignore_attr = TRUE)
+
+    # ... but balance = FALSE keeps the frozen rate untouched.
+    p3 <- setResource(p, resource_capacity = 2 * resource_capacity(p),
+                      balance = FALSE)
+    expect_equal(resource_rate(p3), resource_rate(p), ignore_attr = TRUE)
 })

--- a/vignettes/cheatsheet-changing-parameters.Rmd
+++ b/vignettes/cheatsheet-changing-parameters.Rmd
@@ -193,6 +193,13 @@ params <- setResource(params, reset = TRUE)       # unfreeze: recompute from the
 This mirrors the species-parameter behaviour exactly: scalars are the "given"
 inputs, the arrays are calculated from them unless you override an array by hand.
 
+Keeping the resource at its steady state (where it replenishes at the rate at
+which it is consumed) is a separate, deliberate step called *balancing*. It is
+**not** triggered by `resource_params(params) <-`; it happens only in
+[`setResource()`](../reference/setResource.html), and in the array/level/dynamics
+setters, which balance by default. Pass `balance = FALSE` to switch it off, e.g.
+`resource_capacity(params, balance = FALSE) <- my_capacity`.
+
 ---
 
 ### The interaction matrix

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -1,0 +1,101 @@
+---
+title: "Upgrading mizer"
+output:
+  html_document:
+    toc: yes
+    toc_float: yes
+    fig_width: 5
+    fig_height: 4
+vignette: >
+  %\VignetteIndexEntry{Upgrading mizer}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+    collapse = TRUE,
+    comment = "#>",
+    eval = FALSE
+)
+library(mizer)
+```
+
+This article collects the changes that may require you to update your own code
+or models when you upgrade to a new release of mizer. Existing model objects
+created with an earlier version continue to load and run — they are upgraded
+automatically — so the notes below are about changes in *behaviour* and in the
+functions you call, not about stored objects. The changes are grouped by the
+release in which they took effect, most recent first.
+
+# Setting resource parameters
+
+Two related changes affect how you modify the resource size spectrum. Together
+they make the resource scalars behave like the species parameters: a scalar is
+an input, and the size-dependent arrays are computed from it.
+
+## Assigning to `resource_params()` now updates the resource arrays
+
+Previously, assigning to `resource_params()` — or to one of its components, such
+as `resource_params(params)$kappa <- ...` — only stored the new scalar values.
+The size-dependent carrying capacity (`cc_pp`) and replenishment rate (`rr_pp`)
+were left unchanged until you next called `setResource()`.
+
+Now these assignments immediately rebuild the arrays from the scalars, exactly as
+`species_params()<-` rebuilds the species rates:
+
+- `kappa`, `lambda` and `w_pp_cutoff` rebuild the carrying capacity;
+- `r_pp` and `n` rebuild the replenishment rate.
+
+Arrays that you have set by hand are left untouched (see *Frozen arrays* below).
+
+If your code changed a resource scalar and then called `setResource()` to apply
+it, nothing breaks — you can drop the now-redundant `setResource()` call. If you
+changed a resource scalar and relied on the arrays *not* changing until later,
+review that code.
+
+## Assigning to `resource_params()` does not balance the resource
+
+*Balancing* means adjusting the rate and capacity together so that the resource
+replenishes at exactly the rate at which it is consumed, keeping it at its steady
+state. Assigning to `resource_params()` rebuilds the arrays from the scalars but
+does **not** balance, so the resource steady state generally shifts.
+
+Balancing is now solely a feature of `setResource()`. To change a resource
+coefficient *and* keep the resource balanced, call `setResource()` rather than
+assigning to `resource_params()`:
+
+```{r}
+# Rebuild the capacity from a new coefficient and rebalance the rate,
+# so the steady state is preserved:
+params <- setResource(params, resource_capacity = new_kappa)
+
+# Likewise, set a new rate coefficient and rebalance the capacity:
+params <- setResource(params, resource_rate = new_r_pp)
+```
+
+## The resource setters gained a `balance` argument
+
+`resource_rate<-`, `resource_capacity<-`, `resource_level<-` and
+`resource_dynamics<-` still balance by default (unchanged behaviour), but they
+now accept a `balance` argument so you can switch balancing off:
+
+```{r}
+# Set the capacity but leave the rate untouched (do not rebalance):
+resource_capacity(params, balance = FALSE) <- my_capacity
+```
+
+## Frozen arrays are protected from incidental balancing
+
+When you set `rr_pp` or `cc_pp` by hand (by assigning a full array rather than a
+scalar), mizer marks it "set manually" — it is *frozen* and will not be
+recomputed from the resource parameters. Previously, an operation that
+re-balanced the resource *without* being given a replacement rate or capacity —
+for example changing only `resource_dynamics`, or calling `setResource()` with
+neither a rate nor a capacity — would silently overwrite such a frozen array. It
+is now kept, and a warning is issued instead.
+
+To deliberately recompute a frozen array from the resource parameters, pass
+`reset = TRUE`. An *explicit* balance — where you hand `setResource()` a new rate
+or capacity — still overrides the freeze; pass `balance = FALSE` if you want the
+frozen array kept in that case.


### PR DESCRIPTION
Closes #447.

## Problem

`setResource()`'s balancing (deriving one of `rr_pp`/`cc_pp` from the other to keep the resource at its consumed-equals-replenished steady state) was firing *implicitly* whenever a user edited a resource parameter, because every convenience setter forwarded to `setResource()` with balancing on. This caused three problems:

1. **Rate-side scalars were inert.** `resource_params(p)$n <-` / `$r_pp <-` had no effect — the rate recompute was gated on the capacity being absent, but capacity was always recomputed from `kappa` first, so the rate was re-derived by balancing and the user's value discarded.
2. **Sequential scalar edits didn't accumulate.** Unlike `species_params<-`, setting `r_pp` then `kappa` in two calls lost the first.
3. **Balancing silently cleared a freeze.** A manually set (commented) array's freeze comment was stamped to `NULL` by the post-balance assignment.

## Changes

- **`resource_params<-` no longer balances.** It rebuilds `rr_pp`/`cc_pp` from the scalars, respecting freezes — structurally identical to `species_params<-`. Rate-side scalars now take effect and sequential edits accumulate.
- **Decoupled the rate/capacity recompute** in `setResource()` so each array is rebuilt from its own scalars independently.
- **The `resource_rate<-`, `resource_capacity<-`, `resource_level<-`, `resource_dynamics<-` setters gained a `balance` argument** (default `NULL` = auto, i.e. unchanged behaviour), e.g. `resource_capacity(params, balance = FALSE) <- cc`.
- **Freeze wins over *incidental* balancing.** If `setResource()` balances without being handed a complementary rate/capacity and the side it would derive is frozen, the frozen array is preserved and a warning is issued. An explicit balance against a supplied value still overrides the freeze (pass `balance = FALSE` to keep it) — this preserves the standard `setResource(rate)` → `setResource(capacity)` calibration workflow.
- **Doc clarifications:** what happens when no array argument is supplied (rate kept vs recomputed from the resource parameters), and that scalar `resource_rate`/`resource_capacity` coefficients are stored in `resource_params` as `r_pp` and `kappa`.

## Behaviour change to note

`resource_capacity(p) <- Y` (default) still rebalances the rate even if the rate was set manually; use `resource_capacity(p, balance = FALSE) <- Y` to preserve a hand-set rate. `resource_params<-` no longer preserves the steady state — call `setResource()` for that.

## Testing

Full suite passes (3173 tests, 0 failures). Updated the issue #439 test (a `kappa` change via `resource_params<-` no longer rebalances the rate) and added tests for: rate-side scalars taking effect, sequential edits accumulating, freeze surviving a scalar change, the `balance` argument on the setters, incidental-balance freeze protection, and explicit balancing overriding a frozen complementary array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
