### PR TITLE
adjustSizeGrid(): warn on per-species diet loss instead of resource biomass

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,8 +85,9 @@
 
 - New `adjustSizeGrid()` function (an S3 generic) adjusts the size grid of
   a `MizerParams` object to a new minimum and/or maximum size. It can both
-  expand and truncate (shrink) the grid, warning if non-negligible abundance
-  (species or resource) is discarded.
+  expand and truncate (shrink) the grid. For each species it warns if truncation
+  discards a non-negligible fraction of the species' biomass, of the diet of its
+  smallest individuals, or of the diet of its largest individuals.
 
 - New experimental `steadyNewton()` finds a steady state by solving the
   steady-state equation directly with a Newton-type root finder (using the

--- a/R/manipulate_species.R
+++ b/R/manipulate_species.R
@@ -566,9 +566,14 @@ renameSpecies.MizerParams <- function(params, replace, ...) {
 #'   should be copied over to the new params object rather than being
 #'   re-calculated from the species parameters. If missing, all species are
 #'   preserved.
-#' @param tol A numeric value specifying the tolerance for lost biomass.
-#'   If the fraction of species biomass or resource biomass lost due to
-#'   truncation exceeds this value, a warning is raised. Defaults to `1e-6`.
+#' @param tol A numeric value specifying the tolerance for truncation losses.
+#'   The following checks are made separately for each species and a warning is
+#'   raised, listing the affected species, if the lost fraction exceeds this
+#'   value for any of them: the fraction of the species' biomass lost, the
+#'   fraction of the diet of the smallest individuals of the species lost to
+#'   resource truncation, and the fraction of the diet of the largest
+#'   individuals of the species lost to resource truncation. Defaults to
+#'   `1e-6`.
 #' @param ... Additional arguments.
 #'
 #' @return A new [MizerParams] object with the updated size grid.
@@ -737,7 +742,7 @@ adjustSizeGrid.MizerParams <- function(params,
         warn_sp <- lost_fracs[lost_fracs > tol]
         if (length(warn_sp) > 0) {
             warning("Non-negligible species biomass was lost due to grid truncation: ",
-                    paste(names(warn_sp), sprintf("(%.2f%%)", warn_sp * 100), collapse = ", "))
+                    paste(names(warn_sp), sprintf("(%g%%)", signif(warn_sp * 100, 3)), collapse = ", "))
         }
     }
 
@@ -764,18 +769,35 @@ adjustSizeGrid.MizerParams <- function(params,
         warn_diet <- lost_diet_fracs[lost_diet_fracs > tol]
         if (length(warn_diet) > 0) {
             warning("Non-negligible diet of smallest fish was lost due to resource truncation: ",
-                    paste(names(warn_diet), sprintf("(%.2f%%)", warn_diet * 100), collapse = ", "))
+                    paste(names(warn_diet), sprintf("(%g%%)", signif(warn_diet * 100, 3)), collapse = ", "))
         }
     }
 
-    # Resource high-end truncation: check resource biomass loss
+    # Resource high-end truncation: check diet loss of largest fish
     if (length(truncated_full_high_idx) > 0) {
-        tot_pp <- sum(params@initial_n_pp * params@w_full * params@dw_full)
-        if (tot_pp > 0) {
-            lost_pp <- sum(params@initial_n_pp[truncated_full_high_idx] * params@w_full[truncated_full_high_idx] * params@dw_full[truncated_full_high_idx]) / tot_pp
-            if (lost_pp > tol) {
-                warning("Non-negligible resource biomass (", sprintf("%.2f%%", lost_pp * 100), ") was lost due to grid truncation.")
-            }
+        pred_kernel <- getPredKernel(params)
+        encounter_old <- getEncounter(params)
+
+        lost_enc_fracs <- sapply(seq_along(params@species_params$species), function(sp_idx) {
+            # Largest size bin the species occupies
+            w_top_idx <- max(which(params@w <= params@species_params$w_max[sp_idx]))
+            tot_enc <- encounter_old[sp_idx, w_top_idx]
+            if (tot_enc <= 0) return(0)
+
+            lost_enc <- params@search_vol[sp_idx, w_top_idx] *
+                params@species_params$interaction_resource[sp_idx] *
+                sum(pred_kernel[sp_idx, w_top_idx, truncated_full_high_idx] *
+                    params@w_full[truncated_full_high_idx] *
+                    params@dw_full[truncated_full_high_idx] *
+                    params@initial_n_pp[truncated_full_high_idx])
+
+            return(lost_enc / tot_enc)
+        })
+        names(lost_enc_fracs) <- params@species_params$species
+        warn_enc <- lost_enc_fracs[lost_enc_fracs > tol]
+        if (length(warn_enc) > 0) {
+            warning("Non-negligible diet of largest fish was lost due to resource truncation: ",
+                    paste(names(warn_enc), sprintf("(%g%%)", signif(warn_enc * 100, 3)), collapse = ", "))
         }
     }
 

--- a/man/adjustSizeGrid.Rd
+++ b/man/adjustSizeGrid.Rd
@@ -36,9 +36,14 @@ should be copied over to the new params object rather than being
 re-calculated from the species parameters. If missing, all species are
 preserved.}
 
-\item{tol}{A numeric value specifying the tolerance for lost biomass.
-If the fraction of species biomass or resource biomass lost due to
-truncation exceeds this value, a warning is raised. Defaults to \code{1e-6}.}
+\item{tol}{A numeric value specifying the tolerance for truncation losses.
+The following checks are made separately for each species and a warning is
+raised, listing the affected species, if the lost fraction exceeds this
+value for any of them: the fraction of the species' biomass lost, the
+fraction of the diet of the smallest individuals of the species lost to
+resource truncation, and the fraction of the diet of the largest
+individuals of the species lost to resource truncation. Defaults to
+\code{1e-6}.}
 }
 \value{
 A new \link{MizerParams} object with the updated size grid.

--- a/tests/testthat/test-manipulate_species.R
+++ b/tests/testthat/test-manipulate_species.R
@@ -520,7 +520,7 @@ test_that("adjustSizeGrid works for expansion and truncation", {
     expect_warning(adjustSizeGrid(params, new_max_w = params@w[18]),
                    "Non-negligible species biomass was lost")
 
-    # Truncating further down with low tol and non-zero resource at large sizes triggers resource biomass warning:
+    # Truncating the top with low tol and non-zero resource at large sizes triggers largest-fish diet warning:
     params_pp <- params
     params_pp@resource_params$w_pp_cutoff <- 50000
     params_pp@initial_n_pp[] <- 1
@@ -529,7 +529,7 @@ test_that("adjustSizeGrid works for expansion and truncation", {
             adjustSizeGrid(params_pp, new_max_w = params@w[18], tol = 1e-15),
             "Non-negligible species biomass was lost"
         ),
-        "Non-negligible resource biomass"
+        "Non-negligible diet of largest fish was lost"
     )
 
     # 5. Invalid parameters


### PR DESCRIPTION
## Summary

Reworks the resource-truncation warnings in `adjustSizeGrid()` so they report what actually matters for the model dynamics — how much of each species' food (encounter) is discarded — rather than resource biomass.

### Changes

- **High-end resource truncation** now warns on **diet loss**, not resource biomass. The previous check warned when a non-negligible fraction of resource *biomass* was discarded above the new maximum size. Biomass loss is not the relevant quantity: encounter feeds growth and reproduction only through the fish's *total* food intake. The new check mirrors the existing low-end (smallest-fish) check but is evaluated at the **largest size each species occupies**, where the largest resource particles matter most. It reports the lost resource encounter as a fraction of that fish's total encounter.

- **Consistent wording.** The low-end and high-end messages now read symmetrically — "Non-negligible diet of smallest/largest fish was lost due to resource truncation: ...". Both are the same kind of ratio (lost resource encounter ÷ total encounter), sampled at the most-exposed fish size for the part of the resource being removed.

- **Per-species clarity in the docs.** The `tol` parameter documentation now states explicitly that all three checks — species biomass, smallest-fish diet, largest-fish diet — are applied **separately to each species**, and the warning lists the affected species.

- **More useful precision.** Lost fractions are reported with 3 significant figures (`%g` of `signif(x, 3)`) instead of two decimal places. With the default `tol = 1e-6`, a loss just above threshold now shows as `0.0001%` rather than the uninformative `0.00%`.

### Testing

`testthat::test_file("tests/testthat/test-manipulate_species.R")` — all 137 tests pass. The existing high-end-truncation test was updated to expect the new largest-fish diet message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)