### PR TITLE
compareParams(): check dimensions before comparing arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # mizer 3.1.0.9000 (development version)
 
+- `compareParams()` now checks that the number of size bins, species and gears
+  agree before comparing the array-valued slots. When they differ it reports the
+  mismatch instead of erroring while trying to compare arrays of incompatible
+  dimensions. It also compares the species-parameter tables by matching species
+  and parameters by name, so differing species no longer produce a long list of
+  per-column length mismatches, and duplicated messages are no longer repeated.
+
 - The reference index on the website now opens with an "Overview: the mizer
   workflow" section that frames the whole page as a five-stage pipeline (create →
   calibrate → tune dynamics → project → analyse) with links to the key function

--- a/R/compareParams.R
+++ b/R/compareParams.R
@@ -44,7 +44,8 @@ compareParams.MizerParams <- function(params1, params2, ...) {
     }
 
     # size grid ----
-    if (length(params1@w) != length(params2@w)) {
+    same_w <- length(params1@w) == length(params2@w)
+    if (!same_w) {
         msg <- "The number of community size bins is different."
         result <- c(result, msg)
     } else {
@@ -53,7 +54,8 @@ compareParams.MizerParams <- function(params1, params2, ...) {
             result <- c(result, msg)
         }
     }
-    if (length(params1@w_full) != length(params2@w_full)) {
+    same_w_full <- length(params1@w_full) == length(params2@w_full)
+    if (!same_w_full) {
         msg <- "The number of resource size bins is different."
         result <- c(result, msg)
     } else {
@@ -61,6 +63,29 @@ compareParams.MizerParams <- function(params1, params2, ...) {
             msg <- "The resource size bins differ."
             result <- c(result, msg)
         }
+    }
+
+    # number of species and gears ----
+    same_species <- nrow(params1@species_params) == nrow(params2@species_params)
+    if (!same_species) {
+        msg <- "The number of species is different."
+        result <- c(result, msg)
+    }
+    same_gears <- dim(params1@catchability)[[1]] == dim(params2@catchability)[[1]]
+    if (!same_gears) {
+        msg <- "The number of gears is different."
+        result <- c(result, msg)
+    }
+
+    # If the number of size bins, species or gears differs then the
+    # remaining array-valued slots have incompatible dimensions and cannot be
+    # compared element by element, so we stop here.
+    dims_agree <- same_w && same_w_full && same_species && same_gears
+    if (!dims_agree) {
+        result <- unique(result)
+        cat(result, sep = "\n\n")
+        cat("\n")
+        return(invisible(result))
     }
 
     # other slots ----
@@ -100,6 +125,7 @@ compareParams.MizerParams <- function(params1, params2, ...) {
         cat("No differences\n")
         return(invisible("No differences"))
     }
+    result <- unique(result)
     cat(result, sep = "\n\n")
     cat("\n")
     invisible(result)
@@ -130,33 +156,48 @@ compareSpeciesParams <- function(species_params1,
 
     result <- character()
 
-    # species parameters ----
-    sp_names1 <- names(species_params1)
-    sp_names2 <- names(species_params2)
-    sp_diff1 <- setdiff(sp_names1, sp_names2)
-    if (length(sp_diff1) > 0) {
-        msg <- paste0("params1 has the following additional ",
-                      text, ": ", toString(sp_diff1))
+    # Which species are only in one of the two tables? ----
+    species1 <- rownames(species_params1)
+    species2 <- rownames(species_params2)
+    species_diff1 <- setdiff(species1, species2)
+    if (length(species_diff1) > 0) {
+        msg <- paste0("params1 has the following additional species: ",
+                      toString(species_diff1))
         result <- c(result, msg)
     }
-    sp_diff2 <- setdiff(sp_names2, sp_names1)
-    if (length(sp_diff2) > 0) {
-        msg <- paste0("params2 has the following additional ",
-                      text, ": ", toString(sp_diff2))
+    species_diff2 <- setdiff(species2, species1)
+    if (length(species_diff2) > 0) {
+        msg <- paste0("params2 has the following additional species: ",
+                      toString(species_diff2))
         result <- c(result, msg)
     }
-    sp_names <- intersect(sp_names1, sp_names2)
+    species <- intersect(species1, species2)
 
-    sp_eq <- all.equal(species_params1[, sp_names],
-                       species_params2[, sp_names], scale = 1)
+    # Which parameters (columns) are only in one of the two tables? ----
+    param_names1 <- names(species_params1)
+    param_names2 <- names(species_params2)
+    param_diff1 <- setdiff(param_names1, param_names2)
+    if (length(param_diff1) > 0) {
+        msg <- paste0("params1 has the following additional ",
+                      text, ": ", toString(param_diff1))
+        result <- c(result, msg)
+    }
+    param_diff2 <- setdiff(param_names2, param_names1)
+    if (length(param_diff2) > 0) {
+        msg <- paste0("params2 has the following additional ",
+                      text, ": ", toString(param_diff2))
+        result <- c(result, msg)
+    }
+    param_names <- intersect(param_names1, param_names2)
+
+    # Compare only the species and parameters the two tables share, matched by
+    # name, so that extra species or parameters do not clutter the comparison.
+    sp_eq <- all.equal(species_params1[species, param_names],
+                       species_params2[species, param_names], scale = 1)
     if (!isTRUE(sp_eq)) {
         msg <- paste("The following", text, "differ:",
                toString(sp_eq))
         result <- c(result, msg)
-        # ctable <- compareDF::compare_df(params1@species_params[, sp_names],
-        #                       params2@species_params[, sp_names],
-        #                       keep_unchanged_cols = FALSE)
-        # print(ctable$comparison_df)
     }
 
     result

--- a/tests/testthat/test-compareParams.R
+++ b/tests/testthat/test-compareParams.R
@@ -56,3 +56,26 @@ test_that("compareParams", {
   expect_true("The community size bins differ." %in%
                   compareParams(params, params2))
 })
+
+test_that("compareParams reports mismatched species and gear counts", {
+  local_reproducible_output()
+  sink(nullfile())
+  on.exit(sink(), add = TRUE, after = FALSE)
+  params <- NS_params_small
+
+  # Different number of species: report the count difference and the extra
+  # species, but do not try to compare the incompatible arrays.
+  params_fewer <- removeSpecies(params, species_params(params)$species[[1]])
+  result <- compareParams(params, params_fewer)
+  expect_true("The number of species is different." %in% result)
+  expect_true(any(startsWith(result, "params1 has the following additional species:")))
+  expect_false(any(startsWith(result, "The metab slots do not agree")))
+  # Identical messages are not repeated
+  expect_equal(anyDuplicated(result), 0L)
+
+  # Different number of gears
+  params_gears <- params
+  gear_params(params_gears)$gear <- "single"
+  expect_true("The number of gears is different." %in%
+                  compareParams(params, params_gears))
+})


### PR DESCRIPTION
## Summary

Makes `compareParams()` check that the model dimensions agree before it compares the array-valued slots, and tidies up the species-parameter comparison output.

- **Up-front dimension checks.** Before the per-slot array comparison, `compareParams()` now verifies that the number of size bins, species and gears agree. When any of them differ, it reports the mismatch (e.g. `The number of species is different.`) and returns early.
- **Bug fix.** Previously, mismatched dimensions fell through to the per-slot loop where `summariseArrayDiff()` computes `a2 - a1`, which errors on non-conformable arrays. That crash is now avoided.
- **Tidier species-parameter comparison.** `compareSpeciesParams()` now matches species (rows) and parameters (columns) by name and compares only the shared subset, so a differing species count no longer produces a long list of per-column "lengths differ" messages. Species present in only one table are reported cleanly.
- **Deduplication.** Identical messages (e.g. the same "additional species" line arising from both `species_params` and `given_species_params`) are no longer repeated.

Example, comparing `NS_params` against a version with one species removed:

```
params1 has the following additional species: Sprat

The number of species is different.
```

(previously this printed a multi-hundred-word dump of per-column length mismatches).

## Testing

- Added tests covering mismatched species and gear counts: the count message appears, the extra species is listed, incompatible array slots are not compared, and no duplicate messages are produced.
- `testthat::test_file("tests/testthat/test-compareParams.R")` — all 17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T98LXny6oRNBMy9kHubpo4