### PR TITLE
Give each species parameter default a single home

### DIFF
--- a/.claude/skills/species-param-defaults.md
+++ b/.claude/skills/species-param-defaults.md
@@ -1,0 +1,110 @@
+# Where a species parameter default belongs
+
+Use this skill when adding a new species parameter default, or moving or removing
+an existing one. The instinct to tidy all the defaults into one central place is
+wrong here, and acting on it silently breaks things.
+
+## Rule of thumb
+
+A default lives with the **rate setter that reads the parameter**. Only
+parameters that no single rate setter owns are defaulted centrally, in
+`species_params.data.frame()` in `R/species_params.R`.
+
+## Decide by consumption, not by tidiness
+
+Before assuming central is cleaner, find out who reads the column:
+
+```
+grep -rnE 'species_params\$<name>|species_params\[\["<name>"\]\]' R/
+```
+
+(Single quotes matter: in double quotes the shell eats the backslash and `$`
+becomes an end-of-line anchor, so the search silently finds nothing.)
+
+- **Exactly one `setX()` reads it** → that setter owns the default.
+  (`p`, `k` → `setMetabolicRate()`; `z0`, `z_ext`, `d` → `setExtMort()`;
+  `E_ext` → `setExtEncounter()`; `interaction_resource` → `setInteraction()`;
+  `q`, `gamma` → `setSearchVolume()`; `erepro`, `m`, `w_mat25`, `R_max` →
+  `setReproduction()`.)
+- **No single setter owns it** → central. This happens for five reasons: several
+  setters read it (`n`), only the projection reads it (`alpha`), the size grid is
+  built from it before any setter runs (`w_min`, `w_max`), the table's own
+  length-weight conversion needs it (`a`, `b`), or it is reporting-only
+  (`is_background`).
+
+The current list of central parameters and the five reasons live in the
+**"Where defaults live"** section of `vignettes/default_parameters.qmd`. Keep
+that table current instead of duplicating it here.
+
+A default that needs the whole model (the `w` grid, `resource_params$lambda`, the
+predation kernel) or the setter's own arguments **cannot** be central:
+`species_params.data.frame()` receives only a data frame, and runs inside
+`emptyParams()` before the model exists.
+
+## Traps
+
+### A setter-local default is not redundancy
+
+The rate setters are public API and get called directly, without `setParams()`
+and hence without `validParams()`/`validSpeciesParams()`.
+`check_and_convert_species_params()` does not re-apply defaults either, so
+`params@species_params$z_ext <- NULL` leaves a hole that only `setExtMort()`
+fills. The setter's default is the function guarding its own precondition.
+
+Tests pin this on purpose — `test-setExtMort.R` NULLs `z_ext` and `d`,
+`test-setMetabolicRate.R` NAs `p`, and each requires the setter to restore it.
+
+Deleting such a default tends to fail **silently** rather than loudly:
+`params@species_params$z_ext <- NULL` makes `NULL != 0` give `logical(0)`, so
+`any()` is `FALSE` and the power-law mortality term is dropped with no error.
+
+### Two homes go divergent, not merely untidy
+
+`species_params.data.frame()` set `p = n` while `setMetabolicRate()` set
+`p = 3/4`. The central one ran first and won, so the disagreement stayed latent —
+until the central one was removed, at which point the stale `3/4` would silently
+have become the effective default. **If you remove one of two homes, check what
+the other one says before trusting it.**
+
+### The central defaults are an exported contract
+
+`validSpeciesParams()` is exported and its roxygen lists exactly which defaults
+it fills in. Change `R/validSpeciesParams.R`, the vignette table and `NEWS.md`
+together.
+
+## `given_species_params`
+
+It holds what the user supplied, **plus the defaults of any function argument
+that sets a species parameter**, even when the user did not override the
+argument. `newMultispeciesParams()` applies its `n` and `p` arguments to the data
+frame before `emptyParams()` snapshots it (see `R/newMultispeciesParams.R`),
+which is why `n` and `p` appear in `given_species_params` of a model whose user
+supplied neither. That is intended, not a bug.
+
+Defaults that are **not** function arguments must stay out; they belong in
+`species_params` only.
+
+This matters because `given_species_params<-` discards the whole species
+parameter table and rebuilds it with `validSpeciesParams(value)` followed by
+`setParams()`. Anything neither present in `given_species_params` nor
+re-supplied by a setter is **lost on that round trip**. `w_min` is a known
+violation of the rule — see issue #460.
+
+## Verifying a change to defaults
+
+Moving a default between homes should be numerically inert on the standard
+construction path, because `setParams()` calls every rate setter. Prove it with
+a golden-model diff rather than assuming:
+
+1. Before touching anything, build a model (e.g.
+   `newMultispeciesParams(NS_species_params_gears, inter)`) and save its
+   `species_params` columns and rate arrays (`search_vol`, `intake_max`, `metab`,
+   `mu_b`, `psi`, `maturity`, `ext_encounter`, `ext_diffusion`, `initial_n`,
+   `interaction`).
+2. Make the change, rebuild, and assert no column was lost and no array changed.
+   Only genuinely new columns may differ.
+
+Watch for defaults that reference a column that may not exist: with no maximum
+size given, `species_params(data.frame(species = "a"))` has no `w_mat`, so any
+default derived from `w_mat` must sit inside the `if ("w_inf" %in% names(sp))`
+block.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ mizer is an R package for dynamic multi-species size-spectrum modelling of fish 
 
 **`ArraySpeciesBySize`** / **`ArrayTimeBySpecies`** / **`ArrayTimeBySpeciesBySize`** (S3) — wrap some arrays with metadata. When assigning back to S4 slots, use `slot[] <- value` (not `slot <- value`) to strip the class.
 
-**`species_params`** / **`given_species_params`** / **`gear_params`** (S3) — parameter tables subclassing `data.frame` stored in S4 slots. Users should access/modify these tables via S3 generics (e.g. `species_params(params)` or `gear_params(params)`), but package code and developers can modify slots directly (e.g. `params@species_params`) when appropriate. Inline modifications on the S3 objects (via `[<-`, `$<-`, `[[<-` S3 methods) preserve the subclass and trigger reactive validation checks and conversions (e.g. length-to-weight).
+**`species_params`** / **`given_species_params`** / **`gear_params`** (S3) — parameter tables subclassing `data.frame` stored in S4 slots. Users should access/modify these tables via S3 generics (e.g. `species_params(params)` or `gear_params(params)`), but package code and developers can modify slots directly (e.g. `params@species_params`) when appropriate. Inline modifications on the S3 objects (via `[<-`, `$<-`, `[[<-` S3 methods) preserve the subclass and trigger reactive validation checks and conversions (e.g. length-to-weight). `given_species_params` holds what the user supplied **plus the defaults of any function argument that sets a species parameter** (e.g. `n` and `p` from `newMultispeciesParams()`), even when the user did not override the argument; defaults that are not function arguments stay out of it.
 
 **Customisable rate functions**: users replace rate functions by storing a custom function name in `params@rates_funcs`. Dispatch via `get(params@rates_funcs$FunctionName)(params, ...)`.
 
@@ -22,6 +22,7 @@ mizer is an R package for dynamic multi-species size-spectrum modelling of fish 
 - **Naming**: camelCase or snake_case for functions/variables; PascalCase for classes
 - **Language**: British English (en-GB) — "colour", "behaviour", "modelling"
 - When documenting a mizer S3 generic whose methods share a man page (combined with `@rdname`/`@name`), follow the steps in `.claude/skills/document-s3-generics.md`.
+- When adding, moving or removing a species parameter default, follow `.claude/skills/species-param-defaults.md`. A default belongs to the rate setter that reads the parameter; only parameters that no single rate setter owns are defaulted centrally.
 
 ## Testing
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # mizer 3.1.0.9000 (development version)
 
+- The default for the metabolic exponent `p` is now `n` in `setMetabolicRate()`,
+  which is the only place that sets it. Previously there were two disagreeing
+  defaults: `validSpeciesParams()` set `p = n` and `setMetabolicRate()` set
+  `p = 3/4`. The former always ran first, so `p = n` is the value models have
+  been getting all along and no model changes as a result. The stale `3/4` was
+  only reachable by removing the `p` column from an existing `MizerParams`
+  object and calling `setMetabolicRate()` on it; that now also gives `p = n`.
+
+- Each species parameter default now has a single home: the rate-setting
+  function that uses the parameter. `validSpeciesParams()` now only fills in
+  defaults for parameters that no single rate setter owns, namely `w_max`,
+  `w_repro_max`, `w_mat`, `w_min`, `alpha`, `n`, `a`, `b` and `is_background`.
+  The defaults for `p`, `k`, `z_ext`, `d`, `E_ext`, `D_ext` and
+  `interaction_resource` are supplied by `setMetabolicRate()`, `setExtMort()`,
+  `setExtEncounter()`, `setExtDiffusion()` and `setInteraction()` respectively,
+  where they were already being set. Built models are unaffected, because
+  `setParams()` calls all the rate-setting functions, but
+  `validSpeciesParams()` applied to a bare species parameter data frame now
+  returns fewer columns. See the `default_parameters` vignette.
+
 - `compareParams()` now checks that the number of size bins, species and gears
   agree before comparing the array-valued slots. When they differ it reports the
   mismatch instead of erroring while trying to compare arrays of incompatible

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,15 @@
 # mizer 3.1.0.9000 (development version)
 
-- The default for the metabolic exponent `p` is now `n` in `setMetabolicRate()`,
-  which is the only place that sets it. Previously there were two disagreeing
-  defaults: `validSpeciesParams()` set `p = n` and `setMetabolicRate()` set
-  `p = 3/4`. The former always ran first, so `p = n` is the value models have
-  been getting all along and no model changes as a result. The stale `3/4` was
-  only reachable by removing the `p` column from an existing `MizerParams`
-  object and calling `setMetabolicRate()` on it; that now also gives `p = n`.
+- The default for the metabolic exponent `p` is now `n` rather than `3/4` in
+  `setMetabolicRate()`, which is where the default now lives;
+  `validSpeciesParams()` no longer sets `p`. No model changes as a result.
+  Models built with `newMultispeciesParams()` take `p` from its own `p`
+  argument (default `0.7`), which is injected into the species parameter table
+  before validation and is untouched by this change, so neither of these
+  defaults fires for them. The `validSpeciesParams()` default (`p = n`) only
+  ever applied when it was called directly on a bare species parameter data
+  frame, which now returns no `p` column, and it shadowed the
+  `setMetabolicRate()` default whenever both were in play.
 
 - Each species parameter default now has a single home: the rate-setting
   function that uses the parameter. `validSpeciesParams()` now only fills in

--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,10 @@
   subsetting and subassignment S3 methods, making it safer to use and paving
   the way for future auto-recalculations.
 
+- Default values for the `a` (0.01) and `b` (3) species parameters (for the 
+  weight-length relationship) are now saved in `species_params` instead of being 
+  calculated internally by `l2w()` and `w2l()` only when needed.
+
 - `resource_params<-` now rebuilds the resource size-spectrum arrays (`cc_pp`,
   `rr_pp`) via `setResource()`, making resource parameter assignment
   consistent with `species_params<-` and `gear_params<-` (#439).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # mizer 3.1.0.9000 (development version)
 
+- The `p` argument of `setMetabolicRate()` is deprecated (#459). It never had
+  any effect on a `MizerParams` object: such an object always has a `p` column
+  already, and the argument was only ever used to fill in a missing one, so it
+  was silently ignored. Set the species parameter instead, with
+  `species_params(params)$p <- value`. The `p` argument of
+  `newMultispeciesParams()` is a different argument and is not affected.
+
 - The default for the metabolic exponent `p` is now `n` rather than `3/4` in
   `setMetabolicRate()`, which is where the default now lives;
   `validSpeciesParams()` no longer sets `p`. No model changes as a result.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -145,9 +145,6 @@ bin_midpoints <- function(params, w_full = FALSE) {
 #' This is useful for converting a length-based species parameter to a
 #' weight-based species parameter.
 #'
-#' If any `a` or `b` parameters are missing the default values `a = 0.01` and
-#' `b = 3` are used for the missing values.
-#'
 #' @param l Lengths in cm. Either a single number used for all species or a
 #'   vector with one number for each species.
 #' @param w Weights in grams. Either a single number used for all species or a
@@ -170,11 +167,9 @@ l2w <- function(l, species_params) {
     if (length(l) != 1 && length(l) != nrow(sp)) {
         stop("The length of 'l' should be one or equal to the number of species.")
     }
-    sp <- sp %>%
-        set_species_param_default("a", 0.01,
-                                  "Using default values for 'a' parameter.") %>%
-        set_species_param_default("b", 3,
-                                  "Using default values for 'b' parameter.")
+    if (!all(c("a", "b") %in% names(sp))) {
+        stop("The species parameter data frame must contain columns 'a' and 'b'.")
+    }
 
     sp[["a"]] * l^sp[["b"]]
 }
@@ -194,11 +189,9 @@ w2l <- function(w, species_params) {
     if (length(w) != 1 && length(w) != nrow(sp)) {
         stop("The length of 'w' should be one or equal to the number of species.")
     }
-    sp <- sp %>%
-        set_species_param_default("a", 0.01,
-                                  "Using default values for 'a' parameter.") %>%
-        set_species_param_default("b", 3,
-                                  "Using default values for 'b' parameter.")
+    if (!all(c("a", "b") %in% names(sp))) {
+        stop("The species parameter data frame must contain columns 'a' and 'b'.")
+    }
 
     (w / sp[["a"]])^(1 / sp[["b"]])
 }

--- a/R/newMultispeciesParams.R
+++ b/R/newMultispeciesParams.R
@@ -27,6 +27,8 @@
 #'   is set to the smallest value at which any of the consumers can feed.
 #' @param n The allometric growth exponent. This can be overruled for individual
 #'   species by including a `n` column in the `species_params`.
+#' @param p The allometric metabolic exponent. This can be overruled for
+#'   individual species by including a `p` column in the `species_params`.
 #' @param second_order_w `r lifecycle::badge("experimental")` Selects the
 #'   second-order numerical scheme for the new model. Accepts the same values as
 #'   the [second_order_w()] setter: a single logical (`TRUE` switches on both
@@ -290,7 +292,7 @@ newMultispeciesParams <- function(
 #' @inheritDotParams setPredKernel -reset
 #' @inheritDotParams setSearchVolume -reset
 #' @inheritDotParams setMaxIntakeRate -reset
-#' @inheritDotParams setMetabolicRate -reset
+#' @inheritDotParams setMetabolicRate -reset -p
 #' @inheritDotParams setExtMort -reset
 #' @inheritDotParams setExtEncounter -reset
 #' @inheritDotParams setReproduction -reset

--- a/R/plots.R
+++ b/R/plots.R
@@ -2930,8 +2930,6 @@ plot_growth_curves <- function(params, species,
             stop("The size at age data frame needs to have either a 'length' or a 'weight' column.")
         }
         if (!"weight" %in% names(size_at_age)) {
-            sp <- set_species_param_default(sp, "a", 0.004, message = "Using a = 0.004 for missing weight-length conversion parameters.")
-            sp <- set_species_param_default(sp, "b", 3, message = "Using b = 3 for missing weight-length conversion parameters.")
             size_at_age <- left_join(size_at_age, select(sp, species, a, b),
                                      by = "species")
             size_at_age$weight <- size_at_age$a * size_at_age$length ^ size_at_age$b

--- a/R/setInteraction.R
+++ b/R/setInteraction.R
@@ -112,11 +112,11 @@ setInteraction.MizerParams <- function(params,
     }
     params@interaction[] <- interaction
 
-    # Check the interaction_resource column in species_params
-    message <- "Note: No interaction_resource column in species data frame so assuming all species feed on resource."
+    # Set the default for the interaction_resource column in species_params.
+    # A missing column means all species feed on the resource, which is the
+    # normal case and so is not worth a message.
     species_params <- set_species_param_default(params@species_params,
-                                                "interaction_resource", 1,
-                                                message = message)
+                                                "interaction_resource", 1)
     # Check that all values of interaction vector are positive
     if (!all(species_params$interaction_resource >= 0)) {
         stop("Values in the resource interaction vector must be non-negative.")

--- a/R/setMetabolicRate.R
+++ b/R/setMetabolicRate.R
@@ -21,7 +21,7 @@
 #' is the rate at which energy is expended on activity and movement. The values
 #' of \eqn{k_s}, \eqn{p} and \eqn{k} are taken from the `ks`, `p` and
 #' `k` columns in the species parameter dataframe. If any of these
-#' parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = 3/4} and
+#' parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = n} and
 #' \deqn{k_s = f_c h \alpha w_{mat}^{n-p},}{k_s = f_c * h * alpha * w_mat^(n - p),}
 #' where \eqn{f_c} is the critical feeding level taken from the `fc` column
 #' in the species parameter data frame. If the critical feeding level is not
@@ -70,7 +70,8 @@ setMetabolicRate.MizerParams <- function(object, metab = NULL, p = NULL,
         if (!is.numeric(p)) stop("p must be numeric")
         params <- set_species_param_default(params, "p", p)
     } else {
-        params <- set_species_param_default(params, "p", 3/4)
+        params <- set_species_param_default(params, "p",
+                                            params@species_params[["n"]])
     }
     species_params <- params@species_params
 

--- a/R/setMetabolicRate.R
+++ b/R/setMetabolicRate.R
@@ -36,9 +36,11 @@
 #' @param metab Optional. An array (species x size) holding the metabolic rate
 #'   for each species at size. If not supplied, a default is set as described in
 #'   the section "Setting metabolic rate".
-#' @param p The allometric metabolic exponent. This is only used if `metab`
-#'   is not given explicitly and if the exponent is not specified in a `p`
-#'   column in the `species_params`.
+#' @param p `r lifecycle::badge("deprecated")` The allometric metabolic
+#'   exponent. Set the `p` column in the species parameters instead, with
+#'   `species_params(params)$p <- value`. This argument never took effect on a
+#'   `MizerParams` object because such an object always has a `p` column
+#'   already, and the argument was only used to fill in a missing one.
 #' @param reset
 #'   If set to TRUE, then the metabolic rate will be reset to the
 #'   value calculated from the species parameters, even if it was previously
@@ -57,22 +59,28 @@
 #' # Reset metabolic rate from species parameters
 #' params <- setMetabolicRate(NS_params, reset = TRUE)
 #' getMetabolicRate(params)["Cod", 1:5]
-setMetabolicRate <- function(object, metab = NULL, p = NULL,
+setMetabolicRate <- function(object, metab = NULL, p = deprecated(),
                              reset = FALSE, ...) {
     UseMethod("setMetabolicRate")
 }
 #' @export
-setMetabolicRate.MizerParams <- function(object, metab = NULL, p = NULL,
+setMetabolicRate.MizerParams <- function(object, metab = NULL, p = deprecated(),
                                          reset = FALSE, ...) {
     assert_that(is.flag(reset))
     params <- object
-    if (!is.null(p)) {
+    if (lifecycle::is_present(p)) {
+        lifecycle::deprecate_warn(
+            when = "3.2.0",
+            what = "setMetabolicRate(p)",
+            details = "Set the `p` column in the species parameters instead, with `species_params(params)$p <- value`."
+        )
         if (!is.numeric(p)) stop("p must be numeric")
+        # Only fills in a missing or NA `p`, which is why this never had an
+        # effect on a MizerParams object. Kept as-is until the argument goes.
         params <- set_species_param_default(params, "p", p)
-    } else {
-        params <- set_species_param_default(params, "p",
-                                            params@species_params[["n"]])
     }
+    params <- set_species_param_default(params, "p",
+                                        params@species_params[["n"]])
     species_params <- params@species_params
 
     if (reset) {

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -195,15 +195,13 @@ species_params.data.frame <- function(object, strict = FALSE, ...) {
         sp <- set_species_param_default(sp, "w_repro_max", sp$w_inf)
         sp <- set_species_param_default(sp, "w_mat", sp$w_inf / 4)
     }
+    # Only parameters that no single rate setter owns are defaulted here. A
+    # parameter that exactly one `setX()` function reads is defaulted by that
+    # function instead, so that each default has a single home. See the
+    # "Where defaults live" section of the `default_parameters` vignette.
     sp <- set_species_param_default(sp, "w_min", 0.001)
     sp <- set_species_param_default(sp, "alpha", 0.6)
-    sp <- set_species_param_default(sp, "interaction_resource", 1)
     sp <- set_species_param_default(sp, "n", 3/4)
-    sp <- set_species_param_default(sp, "p", sp$n)
-    sp <- set_species_param_default(sp, "z_ext", 0)
-    sp <- set_species_param_default(sp, "d", sp$n - 1)
-    sp <- set_species_param_default(sp, "E_ext", 0)
-    sp <- set_species_param_default(sp, "D_ext", 0)
     sp <- set_species_param_default(sp, "is_background", FALSE)
     sp <- set_species_param_default(sp, "a", 0.01)
     sp <- set_species_param_default(sp, "b", 3)

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -205,6 +205,8 @@ species_params.data.frame <- function(object, strict = FALSE, ...) {
     sp <- set_species_param_default(sp, "E_ext", 0)
     sp <- set_species_param_default(sp, "D_ext", 0)
     sp <- set_species_param_default(sp, "is_background", FALSE)
+    sp <- set_species_param_default(sp, "a", 0.01)
+    sp <- set_species_param_default(sp, "b", 3)
     class(sp) <- c("species_params", setdiff(class(sp), c("given_species_params", "species_params")))
     check_and_convert_species_params(sp)
 }

--- a/R/validSpeciesParams.R
+++ b/R/validSpeciesParams.R
@@ -53,6 +53,8 @@
 #' * `alpha` is set to `0.6`
 #' * `interaction_resource` is set to `1`
 #' * `n` is set to `3/4`
+#' * `a` is set to `0.01`
+#' * `b` is set to `3`
 #' * `p` is set to `n`
 #' * `z_ext` is set to `0`
 #' * `d` is set to `n - 1`

--- a/R/validSpeciesParams.R
+++ b/R/validSpeciesParams.R
@@ -44,22 +44,34 @@
 #' 
 #' `validSpeciesParams()` first calls `validGivenSpeciesParams()` but then
 #' goes further by adding default values for species parameters that were not
-#' provided. The function sets default values if any of the following species
-#' parameters are missing or NA:
+#' provided. It only sets defaults for those species parameters that are not
+#' owned by a single rate-setting function, namely those that are read by
+#' several of them (`n`), that are used only when projecting (`alpha`), that
+#' determine the size grid (`w_min`, `w_max`), that are needed for the
+#' length-weight conversion (`a`, `b`) or that are used only for reporting
+#' (`is_background`). The function sets default values if any of the following
+#' species parameters are missing or NA:
 #' * `w_max` is set to `1.5 * w_inf` (it is only a computational boundary)
 #' * `w_repro_max` is set to `w_inf`
 #' * `w_mat` is set to `w_inf/4`
 #' * `w_min` is set to `0.001`
 #' * `alpha` is set to `0.6`
-#' * `interaction_resource` is set to `1`
 #' * `n` is set to `3/4`
 #' * `a` is set to `0.01`
 #' * `b` is set to `3`
-#' * `p` is set to `n`
-#' * `z_ext` is set to `0`
-#' * `d` is set to `n - 1`
-#' * `E_ext` is set to `0`
-#' * `D_ext` is set to `0`
+#' * `is_background` is set to `FALSE`
+#'
+#' All other species parameters are given their default values by the
+#' rate-setting function that uses them, so that each default has a single
+#' home. For example `p` and `k` are set by [setMetabolicRate()], `z_ext`, `d`
+#' and `z0` by [setExtMort()], `E_ext` by [setExtEncounter()], `D_ext` by
+#' [setExtDiffusion()], `interaction_resource` by [setInteraction()], `beta`
+#' and `sigma` by [setPredKernel()], `q` and `gamma` by [setSearchVolume()],
+#' and `erepro`, `m`, `w_mat25` and `R_max` by [setReproduction()]. These
+#' columns are therefore absent from the data frame returned by
+#' `validSpeciesParams()` but present in the species parameters of a
+#' `MizerParams` object, because [setParams()] calls all the rate-setting
+#' functions.
 #'
 #' Note that the species parameters returned by these functions are not
 #' guaranteed to produce a viable model. More checks of the parameters are

--- a/man/completeSpeciesParams.Rd
+++ b/man/completeSpeciesParams.Rd
@@ -73,6 +73,8 @@ parameters are missing or NA:
 \item \code{alpha} is set to \code{0.6}
 \item \code{interaction_resource} is set to \code{1}
 \item \code{n} is set to \code{3/4}
+\item \code{a} is set to \code{0.01}
+\item \code{b} is set to \code{3}
 \item \code{p} is set to \code{n}
 \item \code{z_ext} is set to \code{0}
 \item \code{d} is set to \code{n - 1}

--- a/man/completeSpeciesParams.Rd
+++ b/man/completeSpeciesParams.Rd
@@ -63,24 +63,36 @@ detects such a name.
 
 \code{validSpeciesParams()} first calls \code{validGivenSpeciesParams()} but then
 goes further by adding default values for species parameters that were not
-provided. The function sets default values if any of the following species
-parameters are missing or NA:
+provided. It only sets defaults for those species parameters that are not
+owned by a single rate-setting function, namely those that are read by
+several of them (\code{n}), that are used only when projecting (\code{alpha}), that
+determine the size grid (\code{w_min}, \code{w_max}), that are needed for the
+length-weight conversion (\code{a}, \code{b}) or that are used only for reporting
+(\code{is_background}). The function sets default values if any of the following
+species parameters are missing or NA:
 \itemize{
 \item \code{w_max} is set to \code{1.5 * w_inf} (it is only a computational boundary)
 \item \code{w_repro_max} is set to \code{w_inf}
 \item \code{w_mat} is set to \code{w_inf/4}
 \item \code{w_min} is set to \code{0.001}
 \item \code{alpha} is set to \code{0.6}
-\item \code{interaction_resource} is set to \code{1}
 \item \code{n} is set to \code{3/4}
 \item \code{a} is set to \code{0.01}
 \item \code{b} is set to \code{3}
-\item \code{p} is set to \code{n}
-\item \code{z_ext} is set to \code{0}
-\item \code{d} is set to \code{n - 1}
-\item \code{E_ext} is set to \code{0}
-\item \code{D_ext} is set to \code{0}
+\item \code{is_background} is set to \code{FALSE}
 }
+
+All other species parameters are given their default values by the
+rate-setting function that uses them, so that each default has a single
+home. For example \code{p} and \code{k} are set by \code{\link[=setMetabolicRate]{setMetabolicRate()}}, \code{z_ext}, \code{d}
+and \code{z0} by \code{\link[=setExtMort]{setExtMort()}}, \code{E_ext} by \code{\link[=setExtEncounter]{setExtEncounter()}}, \code{D_ext} by
+\code{\link[=setExtDiffusion]{setExtDiffusion()}}, \code{interaction_resource} by \code{\link[=setInteraction]{setInteraction()}}, \code{beta}
+and \code{sigma} by \code{\link[=setPredKernel]{setPredKernel()}}, \code{q} and \code{gamma} by \code{\link[=setSearchVolume]{setSearchVolume()}},
+and \code{erepro}, \code{m}, \code{w_mat25} and \code{R_max} by \code{\link[=setReproduction]{setReproduction()}}. These
+columns are therefore absent from the data frame returned by
+\code{validSpeciesParams()} but present in the species parameters of a
+\code{MizerParams} object, because \code{\link[=setParams]{setParams()}} calls all the rate-setting
+functions.
 
 Note that the species parameters returned by these functions are not
 guaranteed to produce a viable model. More checks of the parameters are

--- a/man/l2w.Rd
+++ b/man/l2w.Rd
@@ -32,8 +32,5 @@ where \code{a} and \code{b} are taken from the species parameter data frame and
 \details{
 This is useful for converting a length-based species parameter to a
 weight-based species parameter.
-
-If any \code{a} or \code{b} parameters are missing the default values \code{a = 0.01} and
-\code{b = 3} are used for the missing values.
 }
 \concept{helper}

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -76,9 +76,8 @@ described in the section "Setting maximum intake rate".}
 for each species at size. If not supplied, a default is set as described in
 the section "Setting metabolic rate".}
 
-\item{p}{The allometric metabolic exponent. This is only used if \code{metab}
-is not given explicitly and if the exponent is not specified in a \code{p}
-column in the \code{species_params}.}
+\item{p}{The allometric metabolic exponent. This can be overruled for
+individual species by including a \code{p} column in the \code{species_params}.}
 
 \item{ext_mort}{Optional. An array (species x size) holding the external
 mortality rate.  If not supplied, a default is set as described in the

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -441,7 +441,7 @@ where \eqn{k_s w^p} represents the rate of standard metabolism and \eqn{k w}
 is the rate at which energy is expended on activity and movement. The values
 of \eqn{k_s}, \eqn{p} and \eqn{k} are taken from the \code{ks}, \code{p} and
 \code{k} columns in the species parameter dataframe. If any of these
-parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = 3/4} and
+parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = n} and
 \deqn{k_s = f_c h \alpha w_{mat}^{n-p},}{k_s = f_c * h * alpha * w_mat^(n - p),}
 where \eqn{f_c} is the critical feeding level taken from the \code{fc} column
 in the species parameter data frame. If the critical feeding level is not

--- a/man/setMetabolicRate.Rd
+++ b/man/setMetabolicRate.Rd
@@ -7,7 +7,7 @@
 \alias{metab<-}
 \title{Set metabolic rate}
 \usage{
-setMetabolicRate(object, metab = NULL, p = NULL, reset = FALSE, ...)
+setMetabolicRate(object, metab = NULL, p = deprecated(), reset = FALSE, ...)
 
 getMetabolicRate(params)
 
@@ -22,9 +22,11 @@ metab(params) <- value
 for each species at size. If not supplied, a default is set as described in
 the section "Setting metabolic rate".}
 
-\item{p}{The allometric metabolic exponent. This is only used if \code{metab}
-is not given explicitly and if the exponent is not specified in a \code{p}
-column in the \code{species_params}.}
+\item{p}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The allometric metabolic
+exponent. Set the \code{p} column in the species parameters instead, with
+\code{species_params(params)$p <- value}. This argument never took effect on a
+\code{MizerParams} object because such an object always has a \code{p} column
+already, and the argument was only used to fill in a missing one.}
 
 \item{reset}{If set to TRUE, then the metabolic rate will be reset to the
 value calculated from the species parameters, even if it was previously

--- a/man/setMetabolicRate.Rd
+++ b/man/setMetabolicRate.Rd
@@ -67,7 +67,7 @@ where \eqn{k_s w^p} represents the rate of standard metabolism and \eqn{k w}
 is the rate at which energy is expended on activity and movement. The values
 of \eqn{k_s}, \eqn{p} and \eqn{k} are taken from the \code{ks}, \code{p} and
 \code{k} columns in the species parameter dataframe. If any of these
-parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = 3/4} and
+parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = n} and
 \deqn{k_s = f_c h \alpha w_{mat}^{n-p},}{k_s = f_c * h * alpha * w_mat^(n - p),}
 where \eqn{f_c} is the critical feeding level taken from the \code{fc} column
 in the species parameter data frame. If the critical feeding level is not

--- a/man/setParams.Rd
+++ b/man/setParams.Rd
@@ -313,7 +313,7 @@ where \eqn{k_s w^p} represents the rate of standard metabolism and \eqn{k w}
 is the rate at which energy is expended on activity and movement. The values
 of \eqn{k_s}, \eqn{p} and \eqn{k} are taken from the \code{ks}, \code{p} and
 \code{k} columns in the species parameter dataframe. If any of these
-parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = 3/4} and
+parameters are not supplied, the defaults are \eqn{k = 0}, \eqn{p = n} and
 \deqn{k_s = f_c h \alpha w_{mat}^{n-p},}{k_s = f_c * h * alpha * w_mat^(n - p),}
 where \eqn{f_c} is the critical feeding level taken from the \code{fc} column
 in the species parameter data frame. If the critical feeding level is not

--- a/man/setParams.Rd
+++ b/man/setParams.Rd
@@ -34,9 +34,6 @@ described in the section "Setting maximum intake rate".}
     \item{\code{metab}}{Optional. An array (species x size) holding the metabolic rate
 for each species at size. If not supplied, a default is set as described in
 the section "Setting metabolic rate".}
-    \item{\code{p}}{The allometric metabolic exponent. This is only used if \code{metab}
-is not given explicitly and if the exponent is not specified in a \code{p}
-column in the \code{species_params}.}
     \item{\code{ext_mort}}{Optional. An array (species x size) holding the external
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}

--- a/man/validSpeciesParams.Rd
+++ b/man/validSpeciesParams.Rd
@@ -79,6 +79,8 @@ parameters are missing or NA:
 \item \code{alpha} is set to \code{0.6}
 \item \code{interaction_resource} is set to \code{1}
 \item \code{n} is set to \code{3/4}
+\item \code{a} is set to \code{0.01}
+\item \code{b} is set to \code{3}
 \item \code{p} is set to \code{n}
 \item \code{z_ext} is set to \code{0}
 \item \code{d} is set to \code{n - 1}

--- a/man/validSpeciesParams.Rd
+++ b/man/validSpeciesParams.Rd
@@ -69,24 +69,36 @@ detects such a name.
 
 \code{validSpeciesParams()} first calls \code{validGivenSpeciesParams()} but then
 goes further by adding default values for species parameters that were not
-provided. The function sets default values if any of the following species
-parameters are missing or NA:
+provided. It only sets defaults for those species parameters that are not
+owned by a single rate-setting function, namely those that are read by
+several of them (\code{n}), that are used only when projecting (\code{alpha}), that
+determine the size grid (\code{w_min}, \code{w_max}), that are needed for the
+length-weight conversion (\code{a}, \code{b}) or that are used only for reporting
+(\code{is_background}). The function sets default values if any of the following
+species parameters are missing or NA:
 \itemize{
 \item \code{w_max} is set to \code{1.5 * w_inf} (it is only a computational boundary)
 \item \code{w_repro_max} is set to \code{w_inf}
 \item \code{w_mat} is set to \code{w_inf/4}
 \item \code{w_min} is set to \code{0.001}
 \item \code{alpha} is set to \code{0.6}
-\item \code{interaction_resource} is set to \code{1}
 \item \code{n} is set to \code{3/4}
 \item \code{a} is set to \code{0.01}
 \item \code{b} is set to \code{3}
-\item \code{p} is set to \code{n}
-\item \code{z_ext} is set to \code{0}
-\item \code{d} is set to \code{n - 1}
-\item \code{E_ext} is set to \code{0}
-\item \code{D_ext} is set to \code{0}
+\item \code{is_background} is set to \code{FALSE}
 }
+
+All other species parameters are given their default values by the
+rate-setting function that uses them, so that each default has a single
+home. For example \code{p} and \code{k} are set by \code{\link[=setMetabolicRate]{setMetabolicRate()}}, \code{z_ext}, \code{d}
+and \code{z0} by \code{\link[=setExtMort]{setExtMort()}}, \code{E_ext} by \code{\link[=setExtEncounter]{setExtEncounter()}}, \code{D_ext} by
+\code{\link[=setExtDiffusion]{setExtDiffusion()}}, \code{interaction_resource} by \code{\link[=setInteraction]{setInteraction()}}, \code{beta}
+and \code{sigma} by \code{\link[=setPredKernel]{setPredKernel()}}, \code{q} and \code{gamma} by \code{\link[=setSearchVolume]{setSearchVolume()}},
+and \code{erepro}, \code{m}, \code{w_mat25} and \code{R_max} by \code{\link[=setReproduction]{setReproduction()}}. These
+columns are therefore absent from the data frame returned by
+\code{validSpeciesParams()} but present in the species parameters of a
+\code{MizerParams} object, because \code{\link[=setParams]{setParams()}} calls all the rate-setting
+functions.
 
 Note that the species parameters returned by these functions are not
 guaranteed to produce a viable model. More checks of the parameters are

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -1,49 +1,38 @@
 test_that("l2w works", {
-    no_sp <- nrow(NS_species_params_small)
+    sp <- validSpeciesParams(NS_species_params_small)
+    no_sp <- nrow(sp)
     # call with species_params
-    expect_identical(l2w(2, NS_species_params_small), rep(0.08, no_sp))
+    expect_identical(l2w(2, sp), rep(0.08, no_sp))
     # call with params - result is named by species
+    # NS_params_small should have `a` and `b` because of the mizer upgrade,
+    # but let's make sure by testing against it directly if it has them.
+    # (Actually we will just test it directly)
     expect_equal(l2w(2, NS_params_small), rep(0.08, no_sp), ignore_attr = TRUE)
     # call with wrong 2nd argument
     expect_error(l2w(2, 4),
                  "The second argument must be either ")
     # call with wrong 1st argument
-    expect_error(l2w("a", NS_species_params_small),
+    expect_error(l2w("a", sp),
                  "l is not a numeric or integer vector")
-    expect_error(l2w(1:2, NS_species_params_small),
+    expect_error(l2w(1:2, sp),
                  "The length of 'l'")
-    sp <- NS_species_params_small[1:2, "species", drop = FALSE]
-    expect_condition(
-        expect_condition(expect_equal(l2w(c(2, 3), sp), c(0.08, 0.27)),
-                         "Using default values for 'a' parameter.",
-                         class = "info_about_default"),
-        "Using default values for 'b' parameter.",
-        class = "info_about_default"
-    )
 })
 
 test_that("w2l works", {
-    no_sp <- nrow(NS_species_params_small)
+    sp <- validSpeciesParams(NS_species_params_small)
+    no_sp <- nrow(sp)
     # call with species_params
-    expect_identical(w2l(0.08, NS_species_params_small), rep(2, no_sp))
+    expect_identical(w2l(0.08, sp), rep(2, no_sp))
     # call with params - result is named by species
     expect_equal(w2l(0.08, NS_params_small), rep(2, no_sp), ignore_attr = TRUE)
     # call with wrong 1st argument
-    expect_error(w2l("a", NS_species_params_small),
+    expect_error(w2l("a", sp),
                  "w is not a numeric or integer vector")
-    expect_error(w2l(1:2, NS_species_params_small),
+    expect_error(w2l(1:2, sp),
                  "The length of 'w'")
     # w2l should do the inverse of l2w
-    expect_equal(w2l(l2w(2, NS_species_params_small), NS_species_params_small),
+    expect_equal(w2l(l2w(2, sp), sp),
                  rep(2, no_sp))
-    sp <- NS_species_params_small[1:2, "species", drop = FALSE]
-    expect_condition(
-        expect_condition(expect_equal(w2l(c(0.08, 0.27), sp), c(2, 3)),
-                         "Using default values for 'a' parameter.",
-                         class = "info_about_default"),
-        "Using default values for 'b' parameter.",
-        class = "info_about_default"
-    )
 })
 
 test_that("resource_power_law point-samples by default", {

--- a/tests/testthat/test-setExtDiffusion.R
+++ b/tests/testthat/test-setExtDiffusion.R
@@ -41,6 +41,19 @@ test_that("setExtDiffusion works", {
     expect_false(identical(params@time_modified, p2@time_modified))
 })
 
+test_that("setExtDiffusion defaults D_ext to 0", {
+    # setExtDiffusion owns the D_ext default, so it must supply it even when
+    # called standalone, without going through setParams()/validParams().
+    params <- NS_params_small
+    params@species_params$D_ext <- NULL
+
+    p2 <- setExtDiffusion(params, reset = TRUE)
+
+    expect_equal(p2@species_params$D_ext, rep(0, nrow(p2@species_params)),
+                 ignore_attr = TRUE)
+    expect_equal(p2@ext_diffusion, p2@ext_diffusion * 0, ignore_attr = TRUE)
+})
+
 test_that("setExtDiffusion uses D_ext species param", {
     params <- NS_params_small
     species_params(params)$D_ext <- 0.1

--- a/tests/testthat/test-setExtEncounter.R
+++ b/tests/testthat/test-setExtEncounter.R
@@ -19,6 +19,19 @@ test_that("setExtEncounter works", {
     expect_false(identical(params@time_modified, p2@time_modified))
 })
 
+test_that("setExtEncounter defaults E_ext to 0", {
+    # setExtEncounter owns the E_ext default, so it must supply it even when
+    # called standalone, without going through setParams()/validParams().
+    params <- NS_params_small
+    params@species_params$E_ext <- NULL
+
+    p2 <- setExtEncounter(params, reset = TRUE)
+
+    expect_equal(p2@species_params$E_ext, rep(0, nrow(p2@species_params)),
+                 ignore_attr = TRUE)
+    expect_equal(p2@ext_encounter, p2@ext_encounter * 0, ignore_attr = TRUE)
+})
+
 test_that("setExtEncounter uses E_ext species param", {
     params <- NS_params_small
     species_params(params)$E_ext <- 0.1

--- a/tests/testthat/test-setMetabolicRate.R
+++ b/tests/testthat/test-setMetabolicRate.R
@@ -9,7 +9,10 @@ test_that("setMetabolicRate works", {
     p2@metab <- params@metab
     expect_unchanged(p2, params)
 })
-test_that("setMetabolicRate can set exponent p", {
+test_that("the deprecated p argument still only fills in a missing p", {
+    # Deprecating the argument does not change what it does: it only ever
+    # filled in a missing or NA `p`, never overwrote one. See issue #459.
+    withr::local_options(lifecycle_verbosity = "quiet")
     # no change where p is already set in species_params
     params <- setMetabolicRate(params, p = 1)
     expect_identical(params@species_params$p, rep(0.7, 3), ignore_attr = TRUE)
@@ -65,6 +68,25 @@ test_that("Can get and set metab slot", {
     expect_identical(comment(params@metab), "test")
 })
 
+test_that("the p argument of setMetabolicRate is deprecated", {
+    params <- NS_params_small
+    expect_warning(setMetabolicRate(params, p = 0.8), "deprecated")
+
+    # Setting the species parameter is the replacement and does work.
+    p2 <- params
+    species_params(p2)$p <- 0.8
+    expect_equal(species_params(p2)$p, rep(0.8, nrow(species_params(p2))),
+                 ignore_attr = TRUE)
+    expect_false(isTRUE(all.equal(c(metab(p2)), c(metab(params)))))
+
+    # The `p` argument of newMultispeciesParams() is a different argument and
+    # is not deprecated.
+    sp <- data.frame(species = c("a", "b"), w_inf = c(100, 200))
+    expect_no_warning(
+        p3 <- suppressMessages(newMultispeciesParams(sp, p = 0.8)))
+    expect_equal(species_params(p3)$p, c(0.8, 0.8), ignore_attr = TRUE)
+})
+
 test_that("setMetabolicRate uses the documented defaults and validates inputs", {
     # `p` defaults to `n`. NS_params_small has n = 2/3, so this also pins that
     # the default tracks `n` rather than a hardcoded 3/4.
@@ -74,7 +96,8 @@ test_that("setMetabolicRate uses the documented defaults and validates inputs", 
     expect_equal(species_params(params)$p, species_params(params)$n,
                  ignore_attr = TRUE)
 
-    expect_error(setMetabolicRate(NS_params_small, p = "x"), "p must be numeric")
+    expect_error(suppressWarnings(setMetabolicRate(NS_params_small, p = "x")),
+                 "p must be numeric")
 
     # The default must not depend on how the model was reached: filling `p`
     # via a standalone setter call must agree with the construction path.

--- a/tests/testthat/test-setMetabolicRate.R
+++ b/tests/testthat/test-setMetabolicRate.R
@@ -66,13 +66,25 @@ test_that("Can get and set metab slot", {
 })
 
 test_that("setMetabolicRate uses the documented defaults and validates inputs", {
+    # `p` defaults to `n`. NS_params_small has n = 2/3, so this also pins that
+    # the default tracks `n` rather than a hardcoded 3/4.
     params <- NS_params_small
     params@species_params$p[] <- NA
     params <- setMetabolicRate(params)
-    expect_identical(species_params(params)$p, rep(3 / 4, nrow(species_params(params))),
-                     ignore_attr = TRUE)
+    expect_equal(species_params(params)$p, species_params(params)$n,
+                 ignore_attr = TRUE)
 
     expect_error(setMetabolicRate(NS_params_small, p = "x"), "p must be numeric")
+
+    # The default must not depend on how the model was reached: filling `p`
+    # via a standalone setter call must agree with the construction path.
+    sp <- data.frame(species = c("a", "b"), w_inf = c(100, 200), n = 0.7)
+    params <- suppressMessages(newMultispeciesParams(sp))
+    expect_equal(species_params(params)$p, c(0.7, 0.7), ignore_attr = TRUE)
+
+    params@species_params$p[] <- NA
+    params <- suppressMessages(setMetabolicRate(params))
+    expect_equal(species_params(params)$p, c(0.7, 0.7), ignore_attr = TRUE)
 
     new <- metab(NS_params_small)
     bad_names <- new

--- a/tests/testthat/test-validSpeciesParams.R
+++ b/tests/testthat/test-validSpeciesParams.R
@@ -52,7 +52,7 @@ test_that("validSpeciesParams() works", {
     expect_s3_class(sp <- validSpeciesParams(sp), "data.frame")
     expect_equal(sp$w_mat, sp$w_max / 4)
     expect_equal(sp$alpha, c(0.6, 0.6), ignore_attr = TRUE)
-    expect_equal(sp$interaction_resource, c(1, 1), ignore_attr = TRUE)
+    expect_equal(sp$n, c(3/4, 3/4), ignore_attr = TRUE)
     expect_identical(rownames(sp), c("2", "1"))
 })
 
@@ -101,9 +101,9 @@ test_that("validSpeciesParams sets the documented defaults", {
                      w_mat = c(NA, 20),
                      w_min = c(NA, 1),
                      alpha = c(NA, 0.5),
-                     interaction_resource = c(NA, 2),
                      n = c(NA, 0.8),
-                     p = c(NA, 0.7))
+                     a = c(NA, 0.02),
+                     b = c(NA, 3.1))
 
     sp2 <- validSpeciesParams(sp)
 
@@ -111,9 +111,34 @@ test_that("validSpeciesParams sets the documented defaults", {
     expect_equal(sp2$w_mat, c(10 / 4, 20), ignore_attr = TRUE)
     expect_equal(sp2$w_min, c(0.001, 1), ignore_attr = TRUE)
     expect_equal(sp2$alpha, c(0.6, 0.5), ignore_attr = TRUE)
-    expect_equal(sp2$interaction_resource, c(1, 2), ignore_attr = TRUE)
     expect_equal(sp2$n, c(3/4, 0.8), ignore_attr = TRUE)
-    expect_equal(sp2$p, c(3/4, 0.7), ignore_attr = TRUE)
+    expect_equal(sp2$a, c(0.01, 0.02), ignore_attr = TRUE)
+    expect_equal(sp2$b, c(3, 3.1), ignore_attr = TRUE)
+    expect_false(sp2$is_background[[1]])
+})
+
+test_that("validSpeciesParams does not set defaults owned by a rate setter", {
+    # Parameters that exactly one setX() function reads are defaulted by that
+    # function, not here, so that each default has a single home.
+    sp <- validSpeciesParams(data.frame(species = "a", w_inf = 100))
+    for (par in c("p", "z_ext", "d", "E_ext", "D_ext", "interaction_resource",
+                  "k", "erepro", "m", "w_mat25", "q", "gamma", "h", "ks")) {
+        expect_false(par %in% names(sp),
+                     info = paste(par, "should be set by its rate setter, not centrally"))
+    }
+    # But the owning setters do supply them, so a built model has them all.
+    params <- suppressMessages(newMultispeciesParams(
+        data.frame(species = "a", w_inf = 100)))
+    for (par in c("p", "z_ext", "d", "E_ext", "D_ext", "interaction_resource",
+                  "k", "erepro", "m", "w_mat25", "q", "gamma", "h", "ks")) {
+        expect_true(par %in% names(params@species_params), info = par)
+    }
+})
+
+test_that("a missing maximum-size column does not break the defaults", {
+    # Without w_inf there is no w_mat column, so any default derived from
+    # w_mat must not be evaluated. See species_params.data.frame().
+    expect_no_error(species_params(data.frame(species = c("a", "b"))))
 })
 
 test_that("w_inf is the first-class maximum-size parameter", {

--- a/vignettes/default_parameters.qmd
+++ b/vignettes/default_parameters.qmd
@@ -241,6 +241,20 @@ These parameters have been handled differently over the history of `mizer`:
 
 When creating a `MizerParams` object, `validSpeciesParams()` (and subsequent setup functions like `setSearchVolume()`, `setMaxIntakeRate()`, `setMetabolicRate()`, `setExtMort()`, and `setReproduction()`) check the species parameter data frame and fill in missing parameters.
 
+### Where defaults live
+
+Each default has a single home: the rate-setting function that uses the parameter. `setMetabolicRate()` defaults `p` and `k` because it is the only function that reads them; `setExtMort()` defaults `z0`, `z_ext` and `d`; and so on. This matters because the rate setters are also called directly, without going through `setParams()`, so a setter has to be able to supply the defaults it needs on its own.
+
+Only parameters that no single rate setter owns are defaulted centrally in `validSpeciesParams()`. That happens for five reasons:
+
+- **several setters read it** --- `n` is used by `setExtDiffusion()`, `setExtEncounter()`, `setExtMort()`, `setMaxIntakeRate()`, `setReproduction()` and `setSearchVolume()`;
+- **only the projection reads it** --- no setter touches `alpha`; it is used when calculating growth and reproduction;
+- **the size grid is built from it** --- `w_min` and `w_max` are needed before any rate setter runs;
+- **the length-weight conversion needs it** --- `a` and `b` are used by `validSpeciesParams()` itself to convert lengths such as `l_mat` into weights;
+- **it is only used for reporting** --- `is_background`.
+
+A consequence is that `validSpeciesParams()` applied to a bare data frame returns only the central defaults. The setter-owned columns appear once the model is built, because `setParams()` calls every rate-setting function.
+
 Below is a reference of the default values and the functions responsible for calculating them:
 
 | Parameter | Description | Default Value / Formula | Function |
@@ -250,22 +264,27 @@ Below is a reference of the default values and the functions responsible for cal
 | `w_mat` | Size at maturity | `w_inf / 4` | `validSpeciesParams()` |
 | `w_min` | Egg size / birth size | `0.001` g | `validSpeciesParams()` |
 | `alpha` | Assimilation efficiency | `0.6` | `validSpeciesParams()` |
-| `interaction_resource` | Species interaction strength with resource | `1` | `validSpeciesParams()` |
 | `n` | Allometric scaling exponent of intake | `3/4` | `validSpeciesParams()` |
-| `p` | Allometric scaling exponent of metabolism | `n` (which is `3/4`) | `validSpeciesParams()` |
-| `z_ext` | Size-dependent external mortality | `0` | `validSpeciesParams()` |
-| `d` | Exponent of size-dependent external mortality | `n - 1` | `validSpeciesParams()` |
-| `E_ext` | External encounter rate | `0` | `validSpeciesParams()` |
-| `D_ext` | External diffusion rate | `0` | `validSpeciesParams()` |
+| `a` | Length-weight conversion coefficient | `0.01` | `validSpeciesParams()` |
+| `b` | Length-weight conversion exponent | `3` | `validSpeciesParams()` |
 | `is_background` | Flag indicating background species | `FALSE` | `validSpeciesParams()` |
 | `h` | Maximum intake rate coefficient | Derived from growth/age at maturity (or `30`) | `get_h_default()` |
 | `gamma` | Search volume coefficient | Derived from target feeding level $f_0$ | `get_gamma_default()` |
+| `q` | Exponent of the search volume | `lambda - 2 + n` | `setSearchVolume()` |
 | `f0` | Target feeding level | `0.6` (or derived from `gamma` if given) | `get_f0_default()` |
-| `fc` | Critical feeding level | `0.2` | `set_species_param_default()` |
+| `fc` | Critical feeding level | `0.2` | `get_ks_default()` |
 | `ks` | Standard metabolic rate coefficient | Derived from critical feeding level $f_c$ | `get_ks_default()` |
+| `p` | Allometric scaling exponent of metabolism | `n` | `setMetabolicRate()` |
 | `k` | Activity/movement cost coefficient | `0` | `setMetabolicRate()` |
 | `z0` | Constant external mortality rate | `z0pre * w_inf^z0exp` | `setExtMort()` |
+| `z_ext` | Size-dependent external mortality | `0` | `setExtMort()` |
+| `d` | Exponent of size-dependent external mortality | `n - 1` | `setExtMort()` |
+| `E_ext` | External encounter rate | `0` | `setExtEncounter()` |
+| `D_ext` | External diffusion rate | `0` | `setExtDiffusion()` |
+| `interaction_resource` | Species interaction strength with resource | `1` | `setInteraction()` |
 | `erepro` | Reproduction efficiency | `1` | `setReproduction()` |
+| `m` | Exponent of the investment into reproduction | `1` | `setReproduction()` |
+| `w_mat25` | Size at which 25% of individuals are mature | `w_mat / 3^(1/10)` | `setReproduction()` |
 | `beta` | Preferred predator/prey mass ratio | `30` | `default_pred_kernel_params()` |
 | `sigma` | Width of predation kernel | `2` | `default_pred_kernel_params()` |
 


### PR DESCRIPTION
## Summary

Every species parameter default now has exactly one home, and which home is decided by what consumes the parameter. Two commits, same principle pulling in opposite directions:

- **`a` and `b`** (0b5b661b) are consumed by the length-weight conversion itself — `l2w()`/`w2l()` are called from `check_and_convert_species_params()` *inside* `species_params.data.frame()`. Their defaults move **into** `species_params` rather than being applied ad-hoc inside `l2w()`/`w2l()`.
- **`p`, `z_ext`, `d`, `E_ext`, `D_ext`, `interaction_resource`** (c6102224) are each read by exactly one rate setter. Their defaults move **out** of the central table to that setter — where they already were, duplicated.

## Which parameters stay central

A parameter is defaulted by `validSpeciesParams()` only when no single rate setter owns it, which happens for five reasons:

| Reason | Parameters |
| :--- | :--- |
| Several setters read it | `n` (six of them: `setExtDiffusion`, `setExtEncounter`, `setExtMort`, `setMaxIntakeRate`, `setReproduction`, `setSearchVolume`); `w_mat`, `w_inf` |
| Only the projection reads it; no setter touches it | `alpha` |
| The size grid is built from it, before any setter runs | `w_min`, `w_max` |
| The table's own length-weight conversion needs it | `a`, `b` |
| Reporting only | `is_background` |

Everything else belongs to its setter: `p`/`k` to `setMetabolicRate()`, `z0`/`z_ext`/`d` to `setExtMort()`, `E_ext` to `setExtEncounter()`, `D_ext` to `setExtDiffusion()`, `interaction_resource` to `setInteraction()`, `q`/`gamma` to `setSearchVolume()`, `erepro`/`m`/`w_mat25`/`R_max` to `setReproduction()`, `beta`/`sigma` to `setPredKernel()`.

The setter-local defaults are not redundancy: the rate setters are public API that can be called directly, without `setParams()` and hence without `validSpeciesParams()`, so each setter has to supply what it needs on its own. Tests already relied on this (e.g. `test-setExtMort.R` NULLs `z_ext`/`d` and requires `setExtMort()` to restore them).

## The `p` default

Three places set `p`, with three different values:

1. `newMultispeciesParams()`'s own `p` argument, default `0.7`, injected into the species parameter table at [newMultispeciesParams.R#L179-L180](https://github.com/sizespectrum/mizer/blob/master/R/newMultispeciesParams.R#L179-L180) **before** validation;
2. `species_params.data.frame()`'s `p = n`;
3. `setMetabolicRate()`'s `p = 3/4`.

(1) preempts both others, so it is `p = 0.7` — not `p = n` — that models built in the usual way have been getting. (2) applied only when `validSpeciesParams()` was called directly on a bare data frame, and it shadowed (3).

This PR removes (2). That promotes (3) from shadowed to live, so it is corrected from `3/4` to `n` for consistency with the exponent it tracks. (1) is untouched and still wins for `newMultispeciesParams()`, which is why no model changes.

### The `p` argument of `setMetabolicRate()` (deprecated here)

There is a fourth would-be home: `setMetabolicRate()`'s own `p` argument. It never had any effect on a `MizerParams` object, because it is applied with `set_species_param_default()` — which only fills a missing or `NA` column and never overwrites — and (1) guarantees the column is always already there. The condition it was documented for, "if the exponent is not specified in a `p` column", is unreachable. It was silently ignored.

It is now **deprecated** in favour of `species_params(params)$p <- value`, which triggers `setParams()` and does what was meant. This also makes the family consistent: `setSearchVolume()` has no `q` argument and `setMaxIntakeRate()` has no `n` argument. What the argument does is unchanged while deprecated; it just warns now.

`newMultispeciesParams()`'s `p` is a *different* argument, is not forwarded to `setMetabolicRate()`, and still works. It is now documented explicitly there so it does not inherit the deprecation badge, and is excluded from the arguments `setParams()` advertises in its dots.

Closes #459.

## Behaviour

Built models are unchanged — `setParams()` calls every rate setter, so each deleted default is immediately re-supplied by its owner. Verified with a golden-model diff of `NS_params` across the change: no `species_params` column lost, and no numeric change to `search_vol`, `intake_max`, `metab`, `mu_b`, `psi`, `maturity`, `ext_encounter`, `ext_diffusion`, `initial_n` or `interaction`.

**User-visible change:** `validSpeciesParams()` applied to a bare species parameter data frame now returns fewer columns; the setter-owned ones appear once the model is built. Its roxygen previously documented returning `n`, `p`, `z_ext`, `d`, `E_ext`, `D_ext` and `interaction_resource`, and has been rewritten.

## Also

- Dropped the `interaction_resource` note in `setInteraction()`. It was dead while the column was set centrally and would otherwise have fired on *every* model build; "all species feed on the resource" is the unremarkable default.
- Removed the unreachable `a = 0.004` / `b = 3` defaults in `plot_growth_curves()`, which conflicted with the central `a = 0.01`.

## Tests

- `test-validSpeciesParams.R`: asserts the setter-owned columns are absent from a bare `validSpeciesParams()` result but present on a built model; guards the no-maximum-size case.
- `test-setMetabolicRate.R`: pins `p == n` rather than a hardcoded `3/4`, and that the construction and standalone-setter paths agree.
- `test-setExtEncounter.R` / `test-setExtDiffusion.R`: new standalone-setter tests for `E_ext` / `D_ext` restoration.
- `test-setMetabolicRate.R`: the `p` argument warns; setting the species parameter works; `newMultispeciesParams(sp, p =)` still works and does not warn. The existing test that pinned the argument's fill-only semantics is kept (they are unchanged) and renamed.

Full suite green apart from `test-plots.R:501`, which fails identically on `master` and is annotated in-source as machine-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZop1EdWQNm9SXGCqwWg8k

