### PR TITLE
Fix species_params<-() diff for list, matrix and object columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# mizer (development version)
+
+## Bug fixes
+
+- `species_params<-()` no longer errors when the species parameter data frame
+  contains a list column (or a column holding S4/other objects), and no longer
+  mis-handles a matrix column. The old-vs-new diff now compares such columns
+  per species with `identical()` instead of `==`.
+
 # mizer 3.2.0
 
 This release overhauls how species and resource parameters are set, makes the

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -234,18 +234,42 @@ species_params.species_params <- function(object, strict = FALSE, ...) {
     # Find what changed compared to old species_params
     old_sp <- object@species_params
     given <- object@given_species_params
-    
+    no_sp <- nrow(old_sp)
+
     common_cols <- intersect(names(value), names(old_sp))
     for (col in common_cols) {
         old_vals <- old_sp[[col]]
         new_vals <- value[[col]]
-        # which ones changed?
-        changed <- !((old_vals == new_vals) | (is.na(old_vals) & is.na(new_vals)))
-        changed[is.na(changed)] <- TRUE
+        # Determine, per species, which values changed. `==` is only reliable
+        # for plain atomic vectors. It is undefined (and errors) for list
+        # columns or columns holding S4/other objects, and for a matrix column
+        # it returns a matrix rather than one logical per species. In those
+        # cases fall back to a per-species `identical()` comparison.
+        simple <- is.atomic(old_vals) && is.atomic(new_vals) &&
+            is.null(dim(old_vals)) && is.null(dim(new_vals)) &&
+            length(old_vals) == no_sp && length(new_vals) == no_sp
+        if (simple) {
+            changed <- !((old_vals == new_vals) |
+                             (is.na(old_vals) & is.na(new_vals)))
+            changed[is.na(changed)] <- TRUE
+        } else {
+            get_row <- function(x, i) {
+                d <- dim(x)
+                if (!is.null(d) && length(d) >= 2) x[i, ] else x[[i]]
+            }
+            changed <- !vapply(
+                seq_len(no_sp),
+                function(i) identical(get_row(old_vals, i), get_row(new_vals, i)),
+                logical(1))
+        }
         
         if (any(changed)) {
             if (!col %in% names(given)) {
-                given[[col]] <- NA
+                given[[col]] <- if (is.list(new_vals)) {
+                    vector("list", length(new_vals))
+                } else {
+                    NA
+                }
             }
             given[[col]][changed] <- new_vals[changed]
         }

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -189,6 +189,36 @@ test_that("species_params setter validates and recalculates", {
     }
 })
 
+test_that("species_params setter handles list and matrix columns", {
+    # The old-vs-new diff in `species_params<-()` must not use `==` on columns
+    # where it is undefined (list, S4) or does not reduce to one logical per
+    # species (matrix). It should fall back to a per-species `identical()`.
+    params <- NS_params_small
+    no_sp <- nrow(species_params(params))
+
+    # List column, round-tripped unchanged: no error, value preserved.
+    sp <- species_params(params)
+    sp$groups <- lapply(seq_len(no_sp), function(i) letters[i])
+    expect_error(species_params(params) <- sp, NA)
+    expect_identical(species_params(params)$groups[[2]], "b")
+
+    # Changing one element of the list column is detected and recorded.
+    sp <- species_params(params)
+    sp$groups[[1]] <- c("a", "z")
+    species_params(params) <- sp
+    expect_identical(species_params(params)$groups[[1]], c("a", "z"))
+    expect_identical(given_species_params(params)$groups[[1]], c("a", "z"))
+
+    # Matrix column, round-tripped unchanged: no error (a bare `==` would return
+    # a matrix rather than one logical per species).
+    params <- NS_params_small
+    sp <- species_params(params)
+    sp$mat <- matrix(seq_len(2 * no_sp), nrow = no_sp)
+    expect_error(species_params(params) <- sp, NA)
+    expect_equal(species_params(params)$mat, matrix(seq_len(2 * no_sp), nrow = no_sp),
+                 ignore_attr = TRUE)
+})
+
 test_that("given_species_params setter can add new explicit columns", {
     params <- NS_params_small
     sp <- given_species_params(params)


### PR DESCRIPTION
## Problem

The old-vs-new diff introduced in `species_params<-()` (mizer 3.2) compares every common column with:

```r
changed <- !((old_vals == new_vals) | (is.na(old_vals) & is.na(new_vals)))
```

`==` is only reliable for plain atomic vectors:

- **List columns** (and columns holding S4/other objects) error with *"comparison of these types is not implemented"*, so `species_params(params) <- sp` fails outright.
- **Matrix columns** return a *matrix* from `==` rather than one logical per species, so the `changed` mask and the downstream `given[[col]][changed] <- ...` indexing are wrong.

This means a model that carries a list column in `species_params` cannot round-trip through the setter at all. It surfaced in the downstream package **mizerEcopath**, whose `ecopath_groups` is a list column: every `species_params(p) <- ...` (including inside its Shiny tuning gadget) errored.

## Fix

Take the fast `==` path only for plain atomic vectors (`is.atomic`, no `dim`, length `no_sp`), and otherwise compare **per species with `identical()`** — using row indexing for matrix columns and `[[i]]` for list columns. A newly-added `given` list column is initialised as a list rather than a scalar `NA`.

Behaviour for ordinary atomic columns is unchanged.

## Tests

Added a regression test (`species_params setter handles list and matrix columns`) covering an unchanged round-trip, a detected change to a list element (recorded in `given_species_params`), and a matrix column round-trip. Full `test-species_params.R` passes (99 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)