### PR TITLE
Keep the given_species_params class in record_given_species_params()

### DIFF
--- a/R/species_params.R
+++ b/R/species_params.R
@@ -359,9 +359,13 @@ record_given_species_params <- function(given, value, old_sp) {
             given[[col]][changed] <- new_vals[changed]
         }
     }
+    # A column that `old_sp` does not have at all is new and is recorded in
+    # full. Assigned one at a time rather than with `cbind()`, which would
+    # return a plain data frame and so strip the `given_species_params` class,
+    # stopping `$` from naming the entries after the species.
     new_cols <- setdiff(names(value), names(old_sp))
-    if (length(new_cols) > 0) {
-        given <- cbind(given, value[new_cols])
+    for (col in new_cols) {
+        given[[col]] <- value[[col]]
     }
 
     given

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -489,3 +489,22 @@ test_that("record_given_species_params checks the number of species", {
     expect_error(record_given_species_params(given, sp[-1, ], sp),
                  "must all have one row per species")
 })
+
+test_that("record_given_species_params preserves the class of `given`", {
+    params <- NS_params_small
+    sp_before <- species_params(params)
+    given_before <- given_species_params(params)
+
+    # Both with and without a wholly new column, which used to be added with
+    # `cbind()` and thereby strip the class.
+    value <- sp_before
+    value$my_par <- seq_len(nrow(value)) + 0.5
+    for (v in list(sp_before, value)) {
+        given <- record_given_species_params(given_before, v, sp_before)
+        expect_s3_class(given, "given_species_params")
+        expect_s3_class(given, "species_params")
+        expect_identical(rownames(given), rownames(given_before))
+        # `$` names the entries after the species, as for species_params()
+        expect_identical(names(given$w_mat), rownames(given))
+    }
+})


### PR DESCRIPTION
Follow-up to #471.

`record_given_species_params()` added wholly new columns with `cbind()`, which returns a plain data frame and so stripped the `given_species_params`/`species_params` class from the result. Without the class, `$.species_params` no longer applies, and

```r
given_species_params(params)$w_mat
```

comes back without the species names that `species_params(params)$w_mat` carries — an inconsistency between the two accessors that should not exist.

`species_params<-()` never showed this, because the `setParams()` call at the end of the method restores the class. The bug only became reachable when the recording step was exported for standalone use, and it showed up immediately in `mizerEcopath`: after `setFeedingLevels()` recorded its new `h` and `ks`, `given_species_params(params)$h` was unnamed while `species_params(params)$h` was named.

The fix assigns the new columns one at a time, which preserves both the class and the row names.

Regression test covers the class, the row names and the naming done by `$`, with and without a new column. Full suite: **3370 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)