### PR TITLE
Fixed: `getStability()` silently dropped size classes sitting at exactly zero

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,31 @@ stability of steady states.
 
 ## Other improvements
 
+- Fixed: `getStability()` silently dropped any size class sitting at exactly
+  zero from its Jacobian. The finite-difference step was floored at an absolute
+  `.Machine$double.eps`, so for such a class the step was swamped by the rounding
+  error of the abundances it perturbs and the whole column came out as
+  floating-point noise (in practice exactly zero), replacing the class's true
+  decay rate with a spurious zero eigenvalue. The step is now floored at the
+  local scale of the spectrum, interpolated from the nonzero neighbours, as the
+  `steadyNewton()` solve already did. This affects models with an isolated
+  interior zero (a negativity-floor artefact of the second-order schemes) or a
+  tail class that `steadyNewton()` zeroed, and — with `include_resource = TRUE` —
+  the resource classes above `w_pp_cutoff`.
+
+- `getStability()` now evaluates the rate functions only at states satisfying
+  `N >= 0`. Where a centred difference would push a cell negative — which can
+  only happen for a cell at the floor described above — the column is differenced
+  forwards from the unperturbed state instead, which is the appropriate one-sided
+  derivative at the boundary of the physical cone. A custom rate function
+  registered with `setRateFunction()` therefore never has to be defined at
+  negative abundances.
+
+- `getStability()` now stops with an informative error, naming the species and
+  size being perturbed, when the one-step map returns a non-finite value, instead
+  of passing a `NaN` on to the eigenvalue solver and returning a meaningless
+  spectrum.
+
 - New article ["Discontinuous rate functions"](https://sizespectrum.org/mizer/articles/discontinuous_rates.html)
   explains what goes wrong when a custom rate function registered with
   `setRateFunction()` depends discontinuously on the abundances — chattering

--- a/R/steadyNewton.R
+++ b/R/steadyNewton.R
@@ -342,6 +342,31 @@ positive_initial_guess <- function(N, w_min_idx, w_top) {
     N
 }
 
+#' Relative finite-difference step scale
+#'
+#' Returns the scale that [getStability()] multiplies by `h` to get the
+#' finite-difference step for each state variable: the variable's own magnitude
+#' where that is nonzero, and otherwise the local scale of the spectrum as
+#' supplied by `positive_initial_guess()` (log-interpolated from the nonzero
+#' neighbours). Cells whose whole row is zero get no local scale from
+#' `positive_initial_guess()`; they fall back to `.Machine$double.eps`, which is
+#' harmless because the one-step map is exactly linear about a zero baseline.
+#'
+#' A step floored at an *absolute* `.Machine$double.eps` instead would be
+#' swamped by the rounding error of the order-`N` outputs it perturbs, and the
+#' column of the Jacobian would come out as noise (in practice exactly zero).
+#'
+#' @param x The state variables (a vector of densities).
+#' @param local_scale A strictly positive local scale for each entry of `x`, or
+#'   zero where none could be determined.
+#' @return A strictly positive vector of step scales, the same length as `x`.
+#' @noRd
+fd_step_scale <- function(x, local_scale) {
+    local_scale[!is.finite(local_scale) | local_scale <= 0] <-
+        .Machine$double.eps
+    pmax(abs(x), local_scale)
+}
+
 #' Analytic semichemostat resource steady state
 #'
 #' Returns the resource number density that is in equilibrium with the consumer
@@ -529,7 +554,21 @@ steady_state_residual <- function(params, rdd_const, n_other, effort, active,
 #' regular dynamics, evaluating the transport coefficients with the exact
 #' spatial scheme configured in `params` (e.g., first-order upwind or a
 #' second-order limiter). The Jacobian is computed numerically using a
-#' multiplicative (relative) finite-difference step \eqn{h \cdot N^*}.
+#' multiplicative (relative) finite-difference step \eqn{h \cdot N^*}. Where a
+#' cell sits at exactly zero and so has no scale of its own, the step is floored
+#' at the local scale of the spectrum, interpolated from the nonzero neighbours,
+#' so that the cell still gets a resolved derivative rather than a column of
+#' rounding error.
+#'
+#' Every state at which the rate functions are evaluated satisfies
+#' \eqn{N \ge 0}: where a centred step would push a cell negative — which can
+#' only happen for a cell at (or below) the floor described above — the column is
+#' differenced forwards from the unperturbed state instead. At the boundary of
+#' the physical cone the one-sided derivative is the appropriate object anyway,
+#' since the dynamics never visit the states a centred step would sample. A rate
+#' function registered with [setRateFunction()] therefore never has to be defined
+#' at negative abundances. Such columns are first order in `h` rather than
+#' second, so they respond slightly more to a change of `h` than the rest.
 #'
 #' @param params A \linkS4class{MizerParams} object whose `initial_n` holds the
 #'   steady state to analyse. Typically the output of [steadyNewton()].
@@ -617,6 +656,24 @@ getStability <- function(params,
     rates_fns    <- projectRateFunctions(params)
     active_idx   <- which(active$mask)
 
+    # A custom rate function can be non-finite at a state that the differencing
+    # visits. Fail loudly, naming the cell, rather than letting a NaN travel on
+    # into eigen() and come back as a meaningless spectrum.
+    stop_if_not_finite <- function(x, where) {
+        if (!all(is.finite(x))) {
+            stop("getStability(): the one-step map returned non-finite values ",
+                 where, ". Every state it evaluates satisfies N >= 0, so this ",
+                 "points to a rate function that is not finite there.",
+                 call. = FALSE)
+        }
+    }
+    fish_cell <- function(k) {
+        rc <- arrayInd(active_idx[k], dim(params@initial_n))
+        paste0("when perturbing species ",
+               params@species_params$species[rc[1]], " at w = ",
+               signif(params@w[rc[2]], 3))
+    }
+
     # -------------------------------------------------------------------------
     # Shared helper: one step of fish dynamics given N and n_pp.
     # The n_pp here is whatever we choose to pass (quasi-static or actual).
@@ -670,6 +727,25 @@ getStability <- function(params,
     N_vec <- N_ss[active$mask]
     n_fish_active <- length(N_vec)
 
+    # Finite-difference step sizes. The step is relative, `h * N`, so a positive
+    # cell stays positive and its derivative is resolved against its own scale.
+    # A cell sitting at exactly zero has no scale of its own: an absolute floor
+    # would make the step so much smaller than the rounding error of the
+    # (order-`N`) outputs it perturbs that the whole column collapses into
+    # floating-point noise — in practice to exactly zero, which silently drops
+    # the cell from the Jacobian and puts a spurious zero eigenvalue in place of
+    # its true decay rate. Such cells do occur: an isolated negativity-floor
+    # artefact of the second-order schemes, or a tail class that steadyNewton()
+    # zeroed at its structural floor. We therefore floor the step at the local
+    # scale of the spectrum, log-interpolated across the gaps from the nonzero
+    # neighbours exactly as the Newton solve does. A row that is zero throughout
+    # (an extinct species) has no local scale either, but there the one-step map
+    # is exactly linear about a zero baseline, so any step recovers the
+    # derivative and the absolute floor is kept.
+    N_scale <- fd_step_scale(N_vec,
+                             positive_initial_guess(N_ss, params@w_min_idx,
+                                                    active$w_top)[active$mask])
+
     if (!include_resource) {
         # -- Reduced system: resource at quasi-static equilibrium --------------
         if (params@resource_dynamics != "resource_semichemostat") {
@@ -685,12 +761,30 @@ getStability <- function(params,
 
         n_state <- n_fish_active
         L <- matrix(0, nrow = n_state, ncol = n_state)
+        # Baseline for the one-sided columns, shared by all of them. It has to
+        # be evaluated rather than assumed equal to N_ss: the state is a fixed
+        # point only to the tolerance of whatever produced it, and that residual
+        # would otherwise be divided by eps_k into every one-sided column.
+        base <- reduced_step(N_ss)[active$mask]
+        stop_if_not_finite(base, "at the unperturbed steady state")
         for (k in seq_len(n_fish_active)) {
-            eps_k   <- h * pmax(abs(N_vec[k]), .Machine$double.eps)
+            eps_k   <- h * N_scale[k]
             N_plus  <- N_ss; N_plus[active_idx[k]]  <- N_vec[k] + eps_k
-            N_minus <- N_ss; N_minus[active_idx[k]] <- N_vec[k] - eps_k
-            L[, k]  <- (reduced_step(N_plus)[active$mask] -
-                        reduced_step(N_minus)[active$mask]) / (2 * eps_k)
+            if (N_vec[k] - eps_k < 0) {
+                # A centred step would leave the physical cone N >= 0.
+                # Difference forwards instead: at the boundary of the cone the
+                # one-sided derivative is the right object anyway, because the
+                # dynamics never visit the states a centred step would sample.
+                # This keeps every rate function evaluation inside N >= 0, so
+                # extensions need not be defined at negative abundances. The
+                # column is then first order in `h` rather than second.
+                L[, k] <- (reduced_step(N_plus)[active$mask] - base) / eps_k
+            } else {
+                N_minus <- N_ss; N_minus[active_idx[k]] <- N_vec[k] - eps_k
+                L[, k]  <- (reduced_step(N_plus)[active$mask] -
+                            reduced_step(N_minus)[active$mask]) / (2 * eps_k)
+            }
+            stop_if_not_finite(L[, k], fish_cell(k))
         }
 
     } else {
@@ -699,6 +793,14 @@ getStability <- function(params,
         npp_vec <- as.numeric(npp_ss)
         n_npp   <- length(npp_vec)
         n_state <- n_fish_active + n_npp
+
+        # Step scale for the resource, floored the same way as for the fish.
+        # The resource carries structural zeros above `w_pp_cutoff`, where the
+        # capacity vanishes; log-interpolation with flat extrapolation gives
+        # them the scale of the last nonzero class.
+        npp_local <- positive_initial_guess(matrix(npp_vec, nrow = 1),
+                                            w_min_idx = 1L, w_top = n_npp)
+        npp_scale <- fd_step_scale(npp_vec, as.numeric(npp_local))
 
         resource_dyn <- get(params@resource_dynamics)
 
@@ -716,23 +818,40 @@ getStability <- function(params,
         n_state <- n_fish_active + n_npp
         L <- matrix(0, nrow = n_state, ncol = n_state)
 
+        # Baseline for the one-sided columns, fish and resource alike (see the
+        # reduced branch).
+        base <- full_step(N_ss, npp_ss)
+        stop_if_not_finite(base, "at the unperturbed steady state")
+
         # Columns 1..n_fish_active: perturb fish, resource held at n_pp_ss
         for (k in seq_len(n_fish_active)) {
-            eps_k   <- h * pmax(abs(N_vec[k]), .Machine$double.eps)
+            eps_k   <- h * N_scale[k]
             N_plus  <- N_ss; N_plus[active_idx[k]]  <- N_vec[k] + eps_k
-            N_minus <- N_ss; N_minus[active_idx[k]] <- N_vec[k] - eps_k
-            L[, k]  <- (full_step(N_plus,  npp_ss) -
-                        full_step(N_minus, npp_ss)) / (2 * eps_k)
+            if (N_vec[k] - eps_k < 0) {
+                L[, k] <- (full_step(N_plus, npp_ss) - base) / eps_k
+            } else {
+                N_minus <- N_ss; N_minus[active_idx[k]] <- N_vec[k] - eps_k
+                L[, k]  <- (full_step(N_plus,  npp_ss) -
+                            full_step(N_minus, npp_ss)) / (2 * eps_k)
+            }
+            stop_if_not_finite(L[, k], fish_cell(k))
         }
 
         # Columns n_fish_active+1..n_state: perturb resource, fish held at N_ss
         for (j in seq_len(n_npp)) {
             k      <- n_fish_active + j
-            eps_j  <- h * pmax(abs(npp_vec[j]), .Machine$double.eps)
+            eps_j  <- h * npp_scale[j]
             npp_plus  <- npp_ss; npp_plus[j]  <- npp_vec[j] + eps_j
-            npp_minus <- npp_ss; npp_minus[j] <- npp_vec[j] - eps_j
-            L[, k] <- (full_step(N_ss, npp_plus) -
-                       full_step(N_ss, npp_minus)) / (2 * eps_j)
+            if (npp_vec[j] - eps_j < 0) {
+                L[, k] <- (full_step(N_ss, npp_plus) - base) / eps_j
+            } else {
+                npp_minus <- npp_ss; npp_minus[j] <- npp_vec[j] - eps_j
+                L[, k] <- (full_step(N_ss, npp_plus) -
+                           full_step(N_ss, npp_minus)) / (2 * eps_j)
+            }
+            stop_if_not_finite(L[, k],
+                               paste0("when perturbing the resource at w = ",
+                                      signif(params@w_full[j], 3)))
         }
     }
 

--- a/man/getStability.Rd
+++ b/man/getStability.Rd
@@ -119,7 +119,21 @@ Both branches use the same \code{project_n_loop()} C++ Thomas solver as the
 regular dynamics, evaluating the transport coefficients with the exact
 spatial scheme configured in \code{params} (e.g., first-order upwind or a
 second-order limiter). The Jacobian is computed numerically using a
-multiplicative (relative) finite-difference step \eqn{h \cdot N^*}.
+multiplicative (relative) finite-difference step \eqn{h \cdot N^*}. Where a
+cell sits at exactly zero and so has no scale of its own, the step is floored
+at the local scale of the spectrum, interpolated from the nonzero neighbours,
+so that the cell still gets a resolved derivative rather than a column of
+rounding error.
+
+Every state at which the rate functions are evaluated satisfies
+\eqn{N \ge 0}: where a centred step would push a cell negative — which can
+only happen for a cell at (or below) the floor described above — the column is
+differenced forwards from the unperturbed state instead. At the boundary of
+the physical cone the one-sided derivative is the appropriate object anyway,
+since the dynamics never visit the states a centred step would sample. A rate
+function registered with \code{\link[=setRateFunction]{setRateFunction()}} therefore never has to be defined
+at negative abundances. Such columns are first order in \code{h} rather than
+second, so they respond slightly more to a change of \code{h} than the rest.
 }
 }
 \section{Requires a smooth one-step map}{

--- a/tests/testthat/test-steadyNewton.R
+++ b/tests/testthat/test-steadyNewton.R
@@ -343,6 +343,103 @@ test_that("full and reduced stability analyses agree on spectral radius for NS m
                  tolerance = 0.05)
 })
 
+test_that("fd_step_scale floors the step at the local scale of the spectrum", {
+    x <- c(2, 0, -3, 0)
+    local_scale <- c(1, 5, 1, 0)
+    scale <- mizer:::fd_step_scale(x, local_scale)
+
+    # A cell with a magnitude of its own keeps it, whatever its sign.
+    expect_equal(scale[[1]], 2)
+    expect_equal(scale[[3]], 3)
+    # A cell at zero takes the local scale, not an absolute epsilon.
+    expect_equal(scale[[2]], 5)
+    # With no local scale either (a row that is zero throughout) it falls back
+    # to the absolute floor. The step must never be zero.
+    expect_equal(scale[[4]], .Machine$double.eps)
+    expect_true(all(scale > 0))
+})
+
+test_that("getStability resolves cells sitting at exactly zero", {
+    skip_unless_experimental()
+    pn <- steadyNewton(p_steady)
+    stab <- getStability(pn)
+
+    # Punch an isolated hole in the middle of the second species' spectrum, of
+    # the kind the second-order schemes can leave behind. Its Jacobian column
+    # must still be resolved: a step floored at an absolute `.Machine$double.eps`
+    # would be swamped by the rounding error of the outputs, leaving a zero
+    # column that drops the cell from the Jacobian and contributes a spurious
+    # zero eigenvalue.
+    active <- mizer:::steady_active_set(pn)
+    j <- floor(mean(c(pn@w_min_idx[2], active$w_top[2])))
+    holed <- pn
+    holed@initial_n[2, j] <- 0
+    stab_holed <- getStability(holed)
+
+    expect_equal(stab_holed$n_active, stab$n_active)
+    expect_false(any(Mod(stab_holed$eigenvalues) < 1e-12))
+    # The hole is one cell out of many, so the spectrum barely moves.
+    expect_equal(stab_holed$spectral_radius, stab$spectral_radius,
+                 tolerance = 1e-3)
+    # The step is relative, so the answer must not depend on `h`.
+    expect_equal(getStability(holed, h = 1e-5)$spectral_radius,
+                 stab_holed$spectral_radius, tolerance = 1e-6)
+})
+
+test_that("getStability never evaluates rate functions at negative abundances", {
+    skip_unless_experimental()
+    # A cell at zero has to be perturbed by more than its own (zero) magnitude,
+    # so the column is differenced forwards to keep the state in N >= 0.
+    pn <- steadyNewton(p_steady)
+    active <- mizer:::steady_active_set(pn)
+    j <- floor(mean(c(pn@w_min_idx[2], active$w_top[2])))
+    holed <- pn
+    holed@initial_n[2, j] <- 0
+
+    seen <- new.env()
+    seen$min_n <- Inf
+    seen$min_n_pp <- Inf
+    record_min <- function(params, n, n_pp, n_other, t, ...) {
+        seen$min_n    <- min(seen$min_n, n)
+        seen$min_n_pp <- min(seen$min_n_pp, n_pp)
+        mizerEncounter(params, n = n, n_pp = n_pp, n_other = n_other, t = t,
+                       ...)
+    }
+    # setRateFunction() looks the function up by name in the global environment.
+    assign("record_min", record_min, envir = globalenv())
+    on.exit(rm("record_min", envir = globalenv()), add = TRUE)
+    spied <- setRateFunction(holed, "Encounter", "record_min")
+
+    getStability(spied)
+    expect_gte(seen$min_n, 0)
+    expect_gte(seen$min_n_pp, 0)
+
+    # The resource carries structural zeros above w_pp_cutoff, so the coupled
+    # analysis exercises the resource columns too.
+    seen$min_n <- Inf
+    seen$min_n_pp <- Inf
+    getStability(spied, include_resource = TRUE)
+    expect_gte(seen$min_n, 0)
+    expect_gte(seen$min_n_pp, 0)
+})
+
+test_that("getStability errors informatively on a non-finite rate function", {
+    skip_unless_experimental()
+    pn <- steadyNewton(p_steady)
+
+    not_finite <- function(params, n, n_pp, n_other, t, ...) {
+        encounter <- mizerEncounter(params, n = n, n_pp = n_pp,
+                                    n_other = n_other, t = t, ...)
+        encounter[1, 1] <- NaN
+        encounter
+    }
+    assign("not_finite", not_finite, envir = globalenv())
+    on.exit(rm("not_finite", envir = globalenv()), add = TRUE)
+
+    expect_error(getStability(setRateFunction(pn, "Encounter", "not_finite")),
+                 "returned non-finite values")
+})
+
 test_that("leading_eigenvectors have correct shape and are normalised", {
     skip_unless_experimental()
     pn   <- steadyNewton(p_steady)


### PR DESCRIPTION
## Summary

`getStability()` computes its Jacobian with a relative finite-difference step, floored so that a cell at zero still gets perturbed:

```r
eps_k <- h * pmax(abs(N_vec[k]), .Machine$double.eps)
```

The floor was **absolute**, so a size class sitting at exactly zero was perturbed by `1e-4 * 2.2e-16 = 2.2e-20`. That is far smaller than the rounding error of the order-`N` abundances the perturbation propagates into, so the whole column came out as floating-point noise — in practice *exactly zero*. A zero column means `det(L - λI) = -λ · det(minor)`, so the class was silently dropped from the Jacobian and contributed a spurious zero eigenvalue in place of its true decay rate.

Reproduced on `steadyNewton(NS_params)`, which has one such class (species 9, bin 86): its column came out identically zero, where its neighbour's diagonal is 0.249. Punching an isolated hole into `NS_params_small` and comparing against the old step (via `assignInNamespace`):

```
holed  (old)   sr=0.81278616   min|lambda|=0.00e+00   #(|l|<1e-12)=1
holed  (new)   sr=0.81267778   min|lambda|=6.80e-03   #(|l|<1e-12)=0
intact (new)   sr=0.81272339   min|lambda|=6.80e-03   #(|l|<1e-12)=0
```

Affected models: those with an isolated interior zero (a negativity-floor artefact of the second-order schemes), a tail class that `steadyNewton()` zeroed at its structural floor, and — with `include_resource = TRUE` — every resource class above `w_pp_cutoff` (47 of them in `NS_params`).

## Changes

**A local relative floor.** New internal `fd_step_scale()` takes the step scale from the class's own magnitude where it has one, and otherwise from the local scale of the spectrum as log-interpolated by `positive_initial_guess()` — the function the Newton solve already uses for exactly this purpose. The floor has to be *local*, not a global `1e-8 * max(abs(N))`: the resource spans ~12 orders of magnitude across the grid, and a global scale would perturb the smallest genuine resource classes by ~10⁴ times their own value. Rows that are zero throughout (an extinct species) get no local scale and keep the absolute fallback, which is correct there — the map is exactly linear about a zero baseline, so any step recovers the derivative.

For a class with a magnitude of its own the step is unchanged bit-for-bit (`all(scale[-k] == abs(N_vec[-k]))`), so nothing moves in models without zeros.

**Every evaluation stays in `N >= 0`.** A relative floor can exceed the class's own value, so a centred step would push it negative — physically meaningless, and it would force `setRateFunction()` extensions to be defined at negative abundances. Columns whose centred step would leave the cone are differenced forwards from the unperturbed state instead:

```r
if (N_vec[k] - eps_k < 0) {
    L[, k] <- (reduced_step(N_plus)[active$mask] - base) / eps_k
} else {
    ...centred as before...
}
```

At the boundary of the cone the one-sided derivative is the appropriate object anyway, since the dynamics never visit the states a centred step would sample. The test is `N - eps < 0` rather than `N == 0` because a tiny-but-nonzero value below its neighbourhood's scale is in the same position. The baseline is evaluated once and shared by all such columns — it can't be assumed equal to `N_ss`, since the state is a fixed point only to the solver's tolerance and that residual would otherwise be divided by `eps` into every one-sided column. These columns are first order in `h` rather than second.

**Loud failure on a non-finite map.** A `NaN` from a custom rate function previously travelled into `eigen()` and came back as a meaningless spectrum. Now:

```
getStability(): the one-step map returned non-finite values when perturbing
species Cod at w = 12.6. Every state it evaluates satisfies N >= 0, so this
points to a rate function that is not finite there.
```

No change to the `n[n < 0] <- 0` floors in `project_n()`/`project_n_2()`, the resource guard, or `getLimitCycleSim()` — `N >= 0` remains a model invariant, and `getStability()` now upholds it rather than being the one routine that steps outside it.

## Verification

Spying on `Encounter` across every evaluation, the minimum density handed to a rate function is `0` in all configurations, and the spectral radii are `h`-independent:

```
NS_params (1 zero fish cell)
  h=1e-03  sr=0.9523144915  minN=0  minNpp=0
  h=1e-04  sr=0.9523144898  minN=0  minNpp=0
  h=1e-05  sr=0.9523144869  minN=0  minNpp=0

trait model (21 zero resource cells)
  h=1e-03  reduced=0.8245388955  full=0.9953691667  minN=0  minNpp=0
  h=1e-04  reduced=0.8245384558  full=0.9953691667  minN=0  minNpp=0
  h=1e-05  reduced=0.8245384514  full=0.9953691667  minN=0  minNpp=0
```

Tests (`MIZER_TEST_EXPERIMENTAL=true`): `test-steadyNewton.R` passes with four new tests — a unit test of `fd_step_scale()`, the punched-hole test above, a spy asserting `min(n) >= 0` and `min(n_pp) >= 0` across both branches, and an `expect_error` on a non-finite rate function. `test-getLimitCycleSim.R` and `test-plotBifurcation.R` pass unchanged. Docs and `NEWS.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)