### PR TITLE
Make `$` on parameter tables match column names exactly (#487)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -180,6 +180,16 @@ stability of steady states.
 
 ## Bug fixes
 
+- `$` on a `species_params` or `gear_params` table no longer partially matches
+  column names. In a model without length-weight parameters,
+  `species_params(params)$a` returned the `alpha` column and `$b` the `beta`
+  column, with the species names attached, so code converting weights to
+  lengths silently got the assimilation efficiency and the preferred
+  predator/prey mass ratio instead. Writing was never partially matched, so
+  reads and writes disagreed about which column `$b` meant. A name that is not
+  a column now gives `NULL`, with a warning naming the column that used to be
+  returned (#487).
+
 - `w_min` is now included in `given_species_params`, so the `min_w` argument to
   `newMultispeciesParams()` and `emptyParams()` is preserved across any operation
   that rebuilds the species parameters from the given ones. Previously, a

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -16,6 +16,41 @@ different <- function(a, b) {
                       tolerance = 10 * .Machine$double.eps))
 }
 
+#' Extract a column from a parameter table without partial matching
+#'
+#' The `$` operator on a data frame partially matches column names, so
+#' `species_params(params)$a` would return the `alpha` column when there is no
+#' `a` column. That silently gives the wrong parameter, so the `$` methods for
+#' the mizer parameter tables use this helper instead, which matches exactly.
+#'
+#' When the name would have partially matched a single column under the old
+#' behaviour we warn, because that is precisely the case where existing user
+#' code changes its meaning. A name that matches nothing at all returns `NULL`
+#' silently, so that `is.null(species_params(params)$foo)` stays a usable way
+#' of testing whether a parameter is present.
+#'
+#' @param x The parameter table.
+#' @param name The name of the column.
+#' @param what The name of the class, used in the warning message.
+#'
+#' @return The column, or `NULL` if there is no column of that name.
+#' @concept helper
+#' @noRd
+exact_column <- function(x, name, what) {
+    out <- .subset2(x, name, exact = TRUE)
+    if (is.null(out)) {
+        partial <- names(x)[startsWith(names(x), name)]
+        if (length(partial) == 1) {
+            warning("There is no `", name, "` column in this `", what,
+                    "` table, so `$", name, "` returns NULL. Earlier versions ",
+                    "of mizer partially matched the column name and returned ",
+                    "the `", partial, "` column instead. Use `$", partial,
+                    "` if that is what you wanted.")
+        }
+    }
+    out
+}
+
 #' Bin average of a power law over geometric bins
 #'
 #' Computes the exact average of the power law \eqn{w^d} over each bin

--- a/R/setFishing.R
+++ b/R/setFishing.R
@@ -481,7 +481,7 @@ check_gear_params <- function(x) {
 
 #' @export
 `$.gear_params` <- function(x, name) {
-    out <- NextMethod()
+    out <- exact_column(x, name, "gear_params")
     if (!is.null(out) && !is.data.frame(out)) {
         names(out) <- rownames(x)
     }

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -169,6 +169,25 @@
 #' @param x An object to test with `is.species_params()` or
 #'   `is.given_species_params()`.
 #' @param ... Other arguments passed to methods.
+#' @section Extracting a column with `$`:
+#' `species_params(params)$w_mat` returns the column as a vector named after the
+#' species. Unlike `$` on an ordinary data frame, it does **not** partially
+#' match the column name. Partial matching is dangerous here because so many
+#' species parameter names are prefixes of others: in a model without
+#' length-weight parameters `species_params(params)$a` used to return the
+#' `alpha` column and `$b` the `beta` column, complete with species names, so
+#' code converting weights to lengths silently got the assimilation efficiency
+#' and the preferred predator/prey mass ratio instead. Writing was never
+#' partially matched, so reads and writes disagreed about which column `$b`
+#' meant.
+#'
+#' A name that is not a column now gives `NULL`, so
+#' `is.null(species_params(params)$foo)` is a reliable way of testing whether a
+#' parameter is present. If the name would have partially matched a column
+#' under the old behaviour you also get a warning naming that column, because
+#' that is exactly the case where existing code changes its meaning. The same
+#' holds for [gear_params()].
+#'
 #' @section Setting species parameters without recalculation:
 #' `species_params(params, recalculate = FALSE) <- value` records the values you
 #' changed among the given species parameters, so that they are not calculated
@@ -707,7 +726,7 @@ check_and_convert_species_params <- function(x) {
 
 #' @export
 `$.species_params` <- function(x, name) {
-    out <- NextMethod()
+    out <- exact_column(x, name, "species_params")
     if (!is.null(out) && !is.data.frame(out) && name != "species") {
         names(out) <- rownames(x)
     }

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -42,6 +42,8 @@ plots) are in the changelog and are not repeated here.
 
 | Symptom | Cause | Section |
 |---|---|---|
+| A column read with `$` is now `NULL`, with a warning naming another column | `$` no longer partially matches column names | `$` no longer partially matches (3.3) |
+| Length-weight conversion via `$a`/`$b` gave `alpha`/`beta` values | partial matching, now fixed | `$` no longer partially matches (3.3) |
 | Absolute diet values dropped ~10%, only with `second_order_w` bin-averaging | double-counted prey-bin quadrature, now fixed | Quadrature fixes under `second_order_w` (3.3) |
 | Trophic levels moved slightly, only with `second_order_w` | numerator and denominator now use one quadrature | Quadrature fixes under `second_order_w` (3.3) |
 | Size grid or results changed in a model built with a small `min_w` | `w_min` is no longer reset to 0.001 | `w_min` survives a rebuild (3.3) |
@@ -96,9 +98,32 @@ and are not repeated here.
 
 ## Upgrading from mizer 3.2 to 3.3
 
-All the changes in this release are corrections. Results move only for models
-that had opted in to second-order bin-averaging, or that set `min_w` below the
-default.
+All the changes in this release are corrections. The one that can affect any
+model is that `$` on a parameter table no longer partially matches column names.
+Otherwise results move only for models that had opted in to second-order
+bin-averaging, or that set `min_w` below the default.
+
+### `$` on a parameter table no longer partially matches
+
+`$` on a `species_params` or `gear_params` table now matches column names
+exactly. Partial matching was silently returning the wrong parameter: in a model
+without the length-weight parameters `a` and `b`,
+
+```r
+species_params(NS_params)$a   # used to return the `alpha` column
+species_params(NS_params)$b   # used to return the `beta` column
+```
+
+complete with per-species names, so code converting weights to lengths got the
+assimilation efficiency and the preferred predator/prey mass ratio instead.
+Writing was never partially matched (`sp$b <- 3` always created a new column
+`b`), so reads and writes disagreed about what `$b` meant.
+
+A name that is not a column now gives `NULL`. If the name would have partially
+matched a single column, you also get a warning naming that column. So
+`is.null(species_params(params)$foo)` is now a reliable test for whether a
+parameter is present, and any code that was relying on the abbreviation should
+spell the column out in full (#487).
 
 ### Quadrature fixes under `second_order_w`
 

--- a/man/species_params.Rd
+++ b/man/species_params.Rd
@@ -247,6 +247,27 @@ You are allowed to include additional columns in the species parameter
 data frames. They will simply be ignored by mizer but will be stored in the
 MizerParams object, in case your own code makes use of them.
 }
+\section{Extracting a column with \code{$}}{
+
+\code{species_params(params)$w_mat} returns the column as a vector named after the
+species. Unlike \code{$} on an ordinary data frame, it does \strong{not} partially
+match the column name. Partial matching is dangerous here because so many
+species parameter names are prefixes of others: in a model without
+length-weight parameters \code{species_params(params)$a} used to return the
+\code{alpha} column and \verb{$b} the \code{beta} column, complete with species names, so
+code converting weights to lengths silently got the assimilation efficiency
+and the preferred predator/prey mass ratio instead. Writing was never
+partially matched, so reads and writes disagreed about which column \verb{$b}
+meant.
+
+A name that is not a column now gives \code{NULL}, so
+\code{is.null(species_params(params)$foo)} is a reliable way of testing whether a
+parameter is present. If the name would have partially matched a column
+under the old behaviour you also get a warning naming that column, because
+that is exactly the case where existing code changes its meaning. The same
+holds for \code{\link[=gear_params]{gear_params()}}.
+}
+
 \section{Setting species parameters without recalculation}{
 
 \code{species_params(params, recalculate = FALSE) <- value} records the values you

--- a/tests/testthat/test-setFishing.R
+++ b/tests/testthat/test-setFishing.R
@@ -493,3 +493,20 @@ test_that("calc_selectivity errors for missing or NA selectivity parameters", {
     params_na@gear_params$knife_edge_size[1] <- NA
     expect_error(calc_selectivity(params_na), "Some selectivity parameters are NA")
 })
+
+test_that("$ on gear_params does not partially match column names", {
+    gp <- gear_params(NS_params_small)
+    expect_true("catchability" %in% names(gp))
+    expect_false("catch" %in% names(gp))
+
+    expect_warning(out <- gp$catch,
+                   "There is no `catch` column in this `gear_params`")
+    expect_null(out)
+
+    # A name matching nothing at all stays silent
+    expect_silent(out <- gp$no_such_parameter)
+    expect_null(out)
+
+    # Exact matches are unaffected
+    expect_identical(unname(gp$catchability), gp[["catchability"]])
+})

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -700,6 +700,45 @@ test_that("$ on species_params returns named vectors for non-character columns",
     expect_named(gp$catchability, rownames(gp))
 })
 
+test_that("$ on species_params does not partially match column names", {
+    # Without length-weight parameters, `$a` used to return `alpha` and `$b`
+    # used to return `beta`, with the species names attached
+    sp <- species_params(NS_params_small)
+    sp <- sp[, setdiff(names(sp), c("a", "b"))]
+    expect_s3_class(sp, "species_params")
+    expect_true(all(c("alpha", "beta") %in% names(sp)))
+
+    expect_warning(a <- sp$a, "There is no `a` column")
+    expect_null(a)
+    expect_warning(b <- sp$b, "There is no `b` column")
+    expect_null(b)
+    # The warning points at the column that used to be returned
+    expect_warning(sp$a, "`alpha` column")
+
+    # A name matching nothing at all stays silent, so that testing for the
+    # presence of a parameter remains an option
+    expect_silent(out <- sp$no_such_parameter)
+    expect_null(out)
+
+    # An ambiguous prefix was already NULL before, so it stays silent too
+    expect_silent(out <- sp$w_)
+    expect_null(out)
+
+    # Exact matches are unaffected
+    expect_identical(unname(sp$alpha), sp[["alpha"]])
+
+    # Reads and writes now agree about which column `$b` means
+    sp$b <- 3
+    expect_identical(unname(sp$b), rep(3, nrow(sp)))
+
+    # given_species_params inherits the behaviour
+    given <- given_species_params(NS_params_small)
+    given <- given[, setdiff(names(given), c("a", "b"))]
+    expect_s3_class(given, "given_species_params")
+    expect_true("beta" %in% names(given))
+    expect_warning(expect_null(given$b), "There is no `b` column")
+})
+
 test_that("get_h_default accepts MizerParams, species_params and data.frame", {
     params <- NS_params_small
     sp <- species_params(params)

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -32,9 +32,32 @@ and are not repeated here.
 
 ## Upgrading from mizer 3.2 to 3.3
 
-All the changes in this release are corrections. Results move only for models
-that had opted in to second-order bin-averaging, or that set `min_w` below the
-default.
+All the changes in this release are corrections. The one that can affect any
+model is that `$` on a parameter table no longer partially matches column names.
+Otherwise results move only for models that had opted in to second-order
+bin-averaging, or that set `min_w` below the default.
+
+### `$` on a parameter table no longer partially matches
+
+`$` on a [`species_params`](../reference/species_params.html) or [`gear_params`](../reference/gear_params.html) table now matches column names
+exactly. Partial matching was silently returning the wrong parameter: in a model
+without the length-weight parameters `a` and `b`,
+
+```{r eval=FALSE}
+species_params(NS_params)$a   # used to return the `alpha` column
+species_params(NS_params)$b   # used to return the `beta` column
+```
+
+complete with per-species names, so code converting weights to lengths got the
+assimilation efficiency and the preferred predator/prey mass ratio instead.
+Writing was never partially matched (`sp$b <- 3` always created a new column
+`b`), so reads and writes disagreed about what `$b` meant.
+
+A name that is not a column now gives `NULL`. If the name would have partially
+matched a single column, you also get a warning naming that column. So
+`is.null(species_params(params)$foo)` is now a reliable test for whether a
+parameter is present, and any code that was relying on the abbreviation should
+spell the column out in full (#487).
 
 ### Quadrature fixes under `second_order_w`
 
@@ -105,7 +128,7 @@ The size-dependent carrying capacity (`cc_pp`) and replenishment rate (`rr_pp`)
 were left unchanged until you next called [`setResource()`](../reference/setResource.html).
 
 Now these assignments immediately rebuild the arrays from the scalars, exactly as
-[`species_params()<-`](../reference/species_params.html) rebuilds the species rates:
+`species_params()<-` rebuilds the species rates:
 
 - `kappa`, `lambda` and `w_pp_cutoff` rebuild the carrying capacity;
 - `r_pp` and `n` rebuild the replenishment rate.
@@ -175,7 +198,7 @@ explicitly with `as.data.frame()`.
 
 ### Accessing a column with `$` now returns a named vector
 
-Extracting a single column from a `species_params` or [`gear_params`](../reference/gear_params.html) object with
+Extracting a single column from a `species_params` or `gear_params` object with
 `$` now returns a vector named by species (or by `"species, gear"` for
 `gear_params`):
 


### PR DESCRIPTION
Fixes #487.

## The bug

`$.species_params` and `$.gear_params` both called `NextMethod()`, so they inherited the data frame's partial matching of column names. So many species parameter names are prefixes of others that this silently returned the wrong parameter — and the methods then attach the species names to the result, so the wrong answer came back looking authoritative:

```r
sp <- species_params(params)   # a model without length-weight parameters
sp$a       #> 0.6 0.6 …        — this is `alpha`
sp$b       #> 51076 398849 …   — this is `beta`
sp[["a"]]  #> NULL             — the truth
```

`a` and `b` are the length-weight parameters, so code converting weights to lengths got the assimilation efficiency and the preferred predator/prey mass ratio instead. Writing was never partially matched (`sp$b <- 3` creates a new column `b`), so reads and writes disagreed about which column `$b` meant.

## The fix

Both methods now go through a new `exact_column()` helper in `R/helpers.R`, which uses `.subset2(x, name, exact = TRUE)`. Behaviour on a name that is not a column:

| Case | Result |
|---|---|
| Would have partially matched a single column | `NULL` + warning naming that column |
| Matches nothing at all | `NULL`, silently |
| Ambiguous prefix (`$w_` against `w_inf`/`w_mat`) | `NULL`, silently — unchanged, R already gave `NULL` |

The silent cases matter: warning on every unmatched name would make `is.null(species_params(params)$foo)` unbearably noisy as a presence test, and the ambiguous-prefix case is not a behaviour change at all. The warning is reserved for exactly the situation where existing user code changes meaning.

I went with the immediate fix rather than the one-release deprecation the issue floated as an option. A warning that still returns `alpha` for `$a` leaves the wrong number flowing into the length conversion — the warning is only useful if the wrong value stops arriving with it.

## Tests

New tests in `test-species_params.R` and `test-setFishing.R` (the gear method is defined in `R/setFishing.R`, so its test lives there per the test-organisation convention). They cover the warning and its wording, both silent-`NULL` cases, unaffected exact matches, `given_species_params` inheriting the behaviour, and that reads and writes now agree about `$b`.

Full suite: `[ FAIL 5 | PASS 3674 ]`. All 5 failures are pre-existing on `master` — confirmed by stashing and re-running (4 in `test-newMultispeciesParams.R`, 1 in `test-compareParams.R`, both unrelated to this change).

## Documentation

- New "Extracting a column with `$`" section in `species_params()`, regenerated into `man/species_params.Rd`.
- NEWS.md bug-fix entry.
- New section plus two symptom-index rows in `inst/skills/upgrade-mizer-code/SKILL.md`, regenerated into `vignettes/upgrading.Rmd` with `build_cheatsheets()`. I also corrected that section's preamble, which claimed results move only for models on `second_order_w` or with a small `min_w` — this change can affect any model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MfQJbvRC6yhzLgV7WqeP7