### PR TITLE
Make compareParams() really compare relative differences

### DIFF
--- a/R/compareParams.R
+++ b/R/compareParams.R
@@ -192,13 +192,53 @@ compareSpeciesParams <- function(species_params1,
 
     # Compare only the species and parameters the two tables share, matched by
     # name, so that extra species or parameters do not clutter the comparison.
-    sp_eq <- all.equal(species_params1[species, param_names],
-                       species_params2[species, param_names])
-    if (!isTRUE(sp_eq)) {
+    sp_eq <- compareColumns(species_params1[species, param_names],
+                            species_params2[species, param_names])
+    if (length(sp_eq) > 0) {
         msg <- paste("The following", text, "differ:",
                toString(sp_eq))
         result <- c(result, msg)
     }
 
     result
+}
+
+# Compare the columns of two species parameter tables that hold the same
+# species and the same parameters
+#
+# `all.equal()` chooses for itself whether to compare relative or absolute
+# differences: it falls back to absolute differences whenever the values it is
+# given are themselves smaller than its tolerance. Species parameters are not
+# all of order 1, and a naturally tiny one like `gamma` (~1e-11) then has even
+# a doubling of its value reported as no difference at all. Dividing a column
+# by its own mean magnitude before the comparison puts it on the scale where
+# `all.equal()` compares relative differences, whatever the magnitude of the
+# parameter. Columns that are not numeric, and those with nothing to set the
+# scale by, are passed to `all.equal()` as they are.
+#
+# Returns one message per column that differs, in the same form as
+# `all.equal()` uses for the components of a list, or an empty character
+# vector when the tables agree.
+compareColumns <- function(df1, df2) {
+    msgs <- character()
+    for (col in names(df1)) {
+        v1 <- df1[[col]]
+        v2 <- df2[[col]]
+        if (is.numeric(v1) && is.numeric(v2)) {
+            scale <- mean(abs(v1), na.rm = TRUE)
+            if (!isTRUE(is.finite(scale) && scale > 0)) {
+                # The first table gives no scale, so try the second
+                scale <- mean(abs(v2), na.rm = TRUE)
+            }
+            if (isTRUE(is.finite(scale) && scale > 0)) {
+                v1 <- v1 / scale
+                v2 <- v2 / scale
+            }
+        }
+        eq <- all.equal(v1, v2)
+        if (!isTRUE(eq)) {
+            msgs <- c(msgs, paste0("Component \"", col, "\": ", eq))
+        }
+    }
+    msgs
 }

--- a/tests/testthat/test-compareParams.R
+++ b/tests/testthat/test-compareParams.R
@@ -12,6 +12,18 @@ test_that("compareParams", {
   params3 <- params
   params3@species_params$gamma[[1]] <- params@species_params$gamma[[1]] * 1.1
   expect_true(grepl('gamma', compareParams(params, params3)[[1]]))
+  # A small-magnitude parameter appearing where the first model has none
+  params4 <- params
+  params4@species_params$z0[] <- 0
+  params5 <- params4
+  params5@species_params$z0[[1]] <- 1e-10
+  expect_true(grepl('z0', compareParams(params4, params5)[[1]]))
+  # A non-numeric species param
+  params4 <- params
+  params4@species_params$habitat <- "pelagic"
+  params5 <- params4
+  params5@species_params$habitat[[1]] <- "demersal"
+  expect_true(grepl('habitat', compareParams(params4, params5)[[1]]))
   # Add a species param
   params1 <- params
   params1@species_params$extra <- 1

--- a/tests/testthat/test-newMultispeciesParams.R
+++ b/tests/testthat/test-newMultispeciesParams.R
@@ -65,16 +65,16 @@ test_that("w_min survives a given_species_params<- round-trip", {
     # min_w smaller than default 0.001
     params <- newMultispeciesParams(sp, min_w = 1e-4, info_level = 0)
     expect_true("w_min" %in% names(given_species_params(params)))
-    expect_equal(species_params(params)$w_min[1], 1e-4)
+    expect_equal(species_params(params)$w_min[[1]], 1e-4)
     given_species_params(params)$alpha <- 0.6
-    expect_equal(species_params(params)$w_min[1], 1e-4,
+    expect_equal(species_params(params)$w_min[[1]], 1e-4,
                  label = "w_min after round-trip (min_w < 0.001)")
 
     # min_w larger than default 0.001
     params2 <- newMultispeciesParams(sp, min_w = 0.01, info_level = 0)
-    expect_equal(species_params(params2)$w_min[1], 0.01)
+    expect_equal(species_params(params2)$w_min[[1]], 0.01)
     expect_no_warning(given_species_params(params2)$alpha <- 0.6)
-    expect_equal(species_params(params2)$w_min[1], 0.01,
+    expect_equal(species_params(params2)$w_min[[1]], 0.01,
                  label = "w_min after round-trip (min_w > 0.001)")
 })
 


### PR DESCRIPTION
Two tests were failing on `master`.

## `compareParams()` still missed relative differences in small parameters

`compareParams()` did not report a 10% change in a small species parameter, which is what #482 set out to fix by dropping the `scale = 1` argument. That is not enough: with no scale given, `all.equal()` decides for itself whether to compare relative or absolute differences, and it falls back to absolute differences whenever the values it is given are themselves smaller than its tolerance. Species parameters are not all of order 1, so for a naturally tiny one like `gamma` (~1e-11) even a doubling was reported as no difference at all — which is exactly the case the test added in #482 checks, so `test-compareParams.R:14` has been failing since it was merged.

The species parameter tables are now compared column by column by a new `compareColumns()` helper, which divides each numeric column by its own mean magnitude before the comparison. That puts every column on the scale where `all.equal()` compares relative differences, whatever the magnitude of the parameter. Columns that are not numeric, and those with nothing to set a scale by (all zero, all `NA`), are passed to `all.equal()` as they are; where the first table gives no scale, the second one's is used, so a tiny value appearing where there was a zero is still caught.

The messages keep the `Component "gamma": ...` form that `all.equal()` uses for the components of a list, so the output is unchanged apart from reporting relative rather than absolute differences. The comparisons of the other slots are untouched.

Two cases were added to `test-compareParams.R` for the new branches: a small-magnitude parameter appearing against a column of zeros, and a non-numeric column.

The NEWS entry from #482 already describes this behaviour; it is only now true, so no new entry was added.

## `w_min` test expectations

The four assertions added in #483 were failing on the names, not the values. `$` on a `species_params` object names the entries of the column it returns by species, deliberately so since a8ff52d4, so `species_params(params)$w_min[1]` is `c(a = 1e-4)` and `expect_equal()` was comparing that against a bare number. They now use `[[`, as the rest of the test suite does. The round-trip behaviour the test is about was already correct.

## Testing

The full test suite passes (only the usual experimental tests skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bvq7fWJmgRkSB8JaHXNKg
