### PR TITLE
Stop a frozen search volume corrupting the gamma and f0 defaults (#488)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -230,6 +230,19 @@ stability of steady states.
 
 ## Bug fixes
 
+- The default values for the `gamma` and `f0` species parameters are no longer
+  corrupted by a search volume that you have set by hand. `get_gamma_default()`
+  measures the energy available to a predator by giving it a search volume
+  coefficient of 1, but it obtained that search volume by calling
+  `setSearchVolume()`, which refuses to recalculate a `search_vol` array you
+  have set yourself. So mizer's own internal calculation was blocked along with
+  yours and the available energy was read off your array instead, making the
+  resulting `gamma` wrong by however much your array differed from the
+  unit-gamma one — many orders of magnitude in realistic models. Both
+  `get_gamma_default()` and `get_f0_default()` now compute the search volume
+  they need directly from the species parameters, so they are unaffected by a
+  frozen `search_vol` and remain exact inverses of each other (#488).
+
 - Changing a species parameter that feeds a rate array you have set by hand now
   warns you that the change has no effect on the model. Previously
   `species_params<-()` and `given_species_params<-()` recorded the new value in

--- a/R/setSearchVolume.R
+++ b/R/setSearchVolume.R
@@ -104,15 +104,10 @@ setSearchVolume.MizerParams <- function(params, search_vol = NULL, reset = FALSE
     }
 
     # Calculate default for any missing gammas
-    q <- params@resource_params$lambda - 2 + params@species_params[["n"]]
-    params@species_params <-
-        set_species_param_default(params@species_params, "q", q)
+    params <- set_q_default(params)
     params@species_params$gamma <- get_gamma_default(params)
 
-    search_vol <-
-        sweep(outer(params@species_params[["q"]], params@w,
-                    function(x, y) y ^ x),
-              1, params@species_params$gamma, "*")
+    search_vol <- compute_search_vol(params)
 
     # Prevent overwriting slot if it has been commented
     if (!is.null(comment(params@search_vol))) {
@@ -127,6 +122,44 @@ setSearchVolume.MizerParams <- function(params, search_vol = NULL, reset = FALSE
 
     params@time_modified <- lubridate::now()
     return(params)
+}
+
+#' Fill in the default for the `q` species parameter
+#'
+#' The allometric exponent of the search volume defaults to `lambda - 2 + n`.
+#' Factored out of [setSearchVolume()] so that the functions calculating
+#' defaults can rely on `q` being present without having to go through the
+#' setter.
+#'
+#' @param params A MizerParams object
+#' @return The MizerParams object with any missing `q` filled in
+#' @noRd
+set_q_default <- function(params) {
+    q <- params@resource_params$lambda - 2 + params@species_params[["n"]]
+    params@species_params <-
+        set_species_param_default(params@species_params, "q", q)
+    params
+}
+
+#' Calculate the search volume from the species parameters
+#'
+#' Evaluates \eqn{\gamma_i(w) = \gamma_i w^{q_i}} from the `gamma` and `q`
+#' columns of the species parameter data frame, which both have to be present.
+#'
+#' This is the calculation that [setSearchVolume()] performs, factored out so
+#' that internal callers can obtain the search volume implied by the species
+#' parameters without going through the setter. The setter refuses to
+#' recalculate a `search_vol` slot that the user has set by hand, and that
+#' refusal must not extend to mizer's own use of the search volume when deriving
+#' default parameters (issue #488).
+#'
+#' @param params A MizerParams object
+#' @return An array (species x size) with the search volume
+#' @noRd
+compute_search_vol <- function(params) {
+    sweep(outer(params@species_params[["q"]], params@w,
+                function(x, y) y ^ x),
+          1, params@species_params$gamma, "*")
 }
 
 #' @rdname setSearchVolume

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -1275,9 +1275,14 @@ get_gamma_default <- function(params) {
             species_params[["h"]] <- get_h_default(params)
         }
         # Calculate available energy by setting search_volume
-        # coefficient to 1
+        # coefficient to 1. We write the search volume into the slot directly
+        # instead of going through `setSearchVolume()`, because that setter
+        # refuses to recalculate a search volume that the user has set by hand
+        # and would leave us measuring the available energy with the user's
+        # array instead of the unit-gamma one (issue #488).
         params@species_params$gamma <- 1
-        params <- setSearchVolume(params)
+        params <- set_q_default(params)
+        params@search_vol[] <- compute_search_vol(params)
         # and setting a power-law prey spectrum
         params@initial_n[] <- 0
         if (defaults_edition() < 2) {
@@ -1340,6 +1345,14 @@ get_f0_default <- function(params) {
             any(is.na(species_params[["h"]]))) {
             species_params[["h"]] <- get_h_default(params)
         }
+        # This is the inverse of `get_gamma_default()` and so has to measure
+        # the available energy with the search volume implied by the given
+        # `gamma`, not with whatever is in the slot, which the user may have
+        # set by hand (issue #488). Only the species with a given `gamma` get
+        # their search volume replaced, the others keep theirs so that no NAs
+        # enter the calculation.
+        params <- set_q_default(params)
+        params@search_vol[given, ] <- compute_search_vol(params)[given, ]
         # Calculate available energy by setting a power-law prey spectrum
         params@initial_n[] <- 0
         params@species_params$interaction_resource <- 1

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -57,6 +57,7 @@ plots) are in the changelog and are not repeated here.
 | Repeated "`l_mat` is not consistent with `w_mat`" warning has stopped | the given species parameters are brought into line | Length and weight follow the one you gave last (3.3) |
 | Size grid or results changed in a model built with a small `min_w` | `w_min` is no longer reset to 0.001 | `w_min` survives a rebuild (3.3) |
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
+| A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
 | `unused argument (sim = ...)` from `plotBiomass()`, `plotYield()`, `plotYieldGear()` | first argument renamed to `object` | Renamed arguments and changed defaults (3.0) |
 | `unused argument (time_range = ...)` from `plotDiet()` | removed in 3.0, back for `MizerSim` in 3.1 | Renamed arguments and changed defaults (3.0) |
 | `setInitialValues()` warns that it is deprecated | replaced by `finalParams()` | `setInitialValues()` is deprecated (3.0) |
@@ -308,6 +309,39 @@ the size grid it asked for, and results change accordingly.
 small-magnitude parameters such as `gamma` (~1e-8) are no longer treated as equal
 when they differ by up to ~10%. Comparisons that previously reported two models
 as identical may now report differences — those differences were always there.
+
+### Defaults for `gamma` and `f0` ignore a hand-set search volume
+
+`get_gamma_default()` works out how much energy is available to a predator by
+giving it a search volume coefficient of 1. It used to obtain that search volume
+by calling `setSearchVolume()`, which refuses to recalculate a `search_vol`
+array you have set by hand — so mizer's own internal call was blocked along with
+yours, and the available energy was measured with *your* array. The resulting
+`gamma` was wrong by whatever factor separated your array from the unit-gamma
+one, which in a realistic model is many orders of magnitude. `get_f0_default()`,
+the inverse, had the same problem. Both now build the search volume they need
+directly from the species parameters (#488).
+
+```r
+sv <- search_vol(params)
+search_vol(params) <- sv * 10          # freeze the search volume
+
+sp <- species_params(params)
+sp$gamma <- NA
+species_params(params) <- sp           # ask mizer to recalculate gamma
+
+species_params(params)$gamma
+#> Used to come back ~1e9 times too large; now the same value you would
+#> get without the frozen search volume.
+```
+
+If you have a model in which you set `search_vol` by hand and then let mizer
+fill in a missing `gamma` or `f0`, that model's species parameters were wrong
+and change with this release. Note that the recalculated `gamma` still has no
+effect on the model while the search volume stays frozen — mizer now warns you
+about that separately, see "A change that cannot take effect now warns" above.
+Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
+the control of the species parameters.
 
 ## Upgrading from mizer 3.1 to 3.2
 

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -57,6 +57,31 @@ test_that("default for gamma is correct", {
 })
 
 
+test_that("gamma and f0 defaults ignore a frozen search volume (#488)", {
+    params <- NS_params_small
+    frozen <- params
+    sv <- search_vol(frozen)
+    sv[] <- sv * 10
+    search_vol(frozen) <- sv
+    expect_false(is.null(comment(frozen@search_vol)))
+
+    # `get_gamma_default()` measures the available energy with a search volume
+    # coefficient of 1, so the user's array must not enter the calculation.
+    params@species_params$gamma[] <- NA
+    frozen@species_params$gamma[] <- NA
+    expect_equal(get_gamma_default(frozen), get_gamma_default(params))
+
+    # `get_f0_default()` is the inverse and must use the search volume implied
+    # by `gamma`, not the frozen one.
+    expect_equal(get_f0_default(NS_params_small),
+                 suppressMessages(get_f0_default(
+                     setSearchVolume(NS_params_small, search_vol = sv))))
+
+    # The frozen array itself is left untouched by the default calculations.
+    expect_equal(search_vol(frozen), sv, ignore_attr = TRUE)
+})
+
+
 test_that("Setting species params works", {
     params <- newMultispeciesParams(NS_species_params_small, info_level = 0)
     # changing h changes intake_max

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -234,6 +234,39 @@ small-magnitude parameters such as `gamma` (~1e-8) are no longer treated as equa
 when they differ by up to ~10%. Comparisons that previously reported two models
 as identical may now report differences — those differences were always there.
 
+### Defaults for `gamma` and `f0` ignore a hand-set search volume
+
+[`get_gamma_default()`](../reference/get_gamma_default.html) works out how much energy is available to a predator by
+giving it a search volume coefficient of 1. It used to obtain that search volume
+by calling [`setSearchVolume()`](../reference/setSearchVolume.html), which refuses to recalculate a [`search_vol`](../reference/setSearchVolume.html)
+array you have set by hand — so mizer's own internal call was blocked along with
+yours, and the available energy was measured with *your* array. The resulting
+`gamma` was wrong by whatever factor separated your array from the unit-gamma
+one, which in a realistic model is many orders of magnitude. [`get_f0_default()`](../reference/get_f0_default.html),
+the inverse, had the same problem. Both now build the search volume they need
+directly from the species parameters (#488).
+
+```{r eval=FALSE}
+sv <- search_vol(params)
+search_vol(params) <- sv * 10          # freeze the search volume
+
+sp <- species_params(params)
+sp$gamma <- NA
+species_params(params) <- sp           # ask mizer to recalculate gamma
+
+species_params(params)$gamma
+#> Used to come back ~1e9 times too large; now the same value you would
+#> get without the frozen search volume.
+```
+
+If you have a model in which you set `search_vol` by hand and then let mizer
+fill in a missing `gamma` or `f0`, that model's species parameters were wrong
+and change with this release. Note that the recalculated `gamma` still has no
+effect on the model while the search volume stays frozen — mizer now warns you
+about that separately, see "A change that cannot take effect now warns" above.
+Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
+the control of the species parameters.
+
 ---
 
 ## Upgrading from mizer 3.1 to 3.2


### PR DESCRIPTION
Fixes #488.

## The bug

`get_gamma_default()` works out how much energy is available to a predator by giving it a search volume coefficient of 1 and reading off the encounter rate in a power-law prey field. It obtained that unit-gamma search volume by calling `setSearchVolume()` — but that setter refuses to recalculate a `search_vol` array the user has set by hand. So mizer's own internal call was blocked along with the user's, and the available energy was measured with the *user's* array instead. The resulting `gamma` came out wrong by whatever factor separated the two arrays, which in a realistic model is many orders of magnitude:

```r
base <- NS_params

g_unfrozen <- local({
    p <- base
    sp <- species_params(p); sp$gamma <- NA; species_params(p) <- sp
    species_params(p)$gamma[1]
})

g_frozen <- local({
    p <- base
    sv <- search_vol(p); sv[] <- sv * 10; search_vol(p) <- sv   # freeze at 10x
    sp <- species_params(p); sp$gamma <- NA; species_params(p) <- sp
    species_params(p)$gamma[1]
})

g_unfrozen   #> 2.917e-11
g_frozen     #> 0.09125     — was wrong by a factor of 3.1e9, now 2.917e-11
```

The only signal was the generic "the search volume has been commented…" message, which on the `species_params<-` path is swallowed by `suppressMessages()`.

`get_f0_default()`, the documented inverse of `get_gamma_default()`, had the same problem from the other side: it measured the encounter with whatever was in the `search_vol` slot rather than with the search volume implied by the given `gamma`, so a frozen array broke the inverse relationship between the two functions.

## The fix

The freeze is a decision for the user-facing setter, not a property of the calculation, so the two are now separate. Two internal helpers in `R/setSearchVolume.R` hold the derivation from the species parameters:

- `set_q_default()` — fills in the `q` default (`lambda - 2 + n`)
- `compute_search_vol()` — evaluates $\gamma_i(w) = \gamma_i w^{q_i}$

`setSearchVolume()` keeps the comment check and is otherwise unchanged. `get_gamma_default()` and `get_f0_default()` build the search volume they need with the helpers, so the user's freeze no longer reaches them. `get_f0_default()` replaces the search volume only for the species that actually have a given `gamma`, so no `NA`s enter the encounter calculation for the others.

As a side effect `get_gamma_default()` and `get_f0_default()` now fill in the `q` default themselves rather than relying on `setSearchVolume()` having done it, so they work when called directly on a model with no `q` column.

## Audit of the other defaults

The issue asked for the other `get_*_default()` functions to be checked for the same pattern. `get_h_default()` and `get_ks_default()` read only the species parameter table and never touch a rate array, so they cannot be affected. `get_gamma_default()` and `get_f0_default()` were the only two.

## Behaviour change

Anyone who set `search_vol` by hand and then let mizer fill in a missing `gamma` or `f0` had wrong species parameters, and those values change with this release. Recorded in `NEWS.md` and in `inst/skills/upgrade-mizer-code/SKILL.md` (with a symptom-index row); `vignettes/upgrading.Rmd` regenerated with `build_cheatsheets()`.

Note that the recalculated `gamma` still has no effect on the model while the search volume stays frozen — the #489 warning now tells the user that separately. The value stored is now right, and the user is told it isn't being used.

## Testing

New regression test in `tests/testthat/test-species_params.R` asserting that both defaults are invariant under a 10× frozen `search_vol` and that the frozen array itself is left untouched. Verified it fails on the unpatched code (gamma `0.10` vs `0.00`, f0 `0.60` vs `0.94`). Full suite: `[ FAIL 0 | WARN 0 | SKIP 30 | PASS 3832 ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
