### PR TITLE
Reject invalid f0 even when gamma is supplied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -235,11 +235,11 @@ stability of steady states.
 
 ## Bug fixes
 
-- Setting `f0` to a value outside the interval `[0, 1)` when `gamma` needs to
-  be calculated now gives an immediate error. Previously `f0 = 1` silently
-  produced an infinite `gamma` and a non-finite `search_vol`, leaving an
-  invalid `MizerParams` object that failed only on a later call to
-  `validParams()`; values above 1 produced negative search volumes (#517).
+- Setting `f0` to a value outside the interval `[0, 1)` now gives an immediate
+  error, whether or not `gamma` has been supplied. Previously `f0 = 1`
+  silently produced an infinite `gamma` and a non-finite `search_vol` when
+  `gamma` was calculated, while an invalid `f0` supplied alongside `gamma`
+  could be accepted and ignored (#517).
 
 - The default values for the `gamma` and `f0` species parameters are no longer
   corrupted by a search volume that you have set by hand. `get_gamma_default()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -235,6 +235,12 @@ stability of steady states.
 
 ## Bug fixes
 
+- Setting `f0` to a value outside the interval `[0, 1)` when `gamma` needs to
+  be calculated now gives an immediate error. Previously `f0 = 1` silently
+  produced an infinite `gamma` and a non-finite `search_vol`, leaving an
+  invalid `MizerParams` object that failed only on a later call to
+  `validParams()`; values above 1 produced negative search volumes (#517).
+
 - The default values for the `gamma` and `f0` species parameters are no longer
   corrupted by a search volume that you have set by hand. `get_gamma_default()`
   measures the energy available to a predator by giving it a search volume

--- a/R/newSingleSpeciesParams.R
+++ b/R/newSingleSpeciesParams.R
@@ -22,8 +22,9 @@
 #' size. It requires `w_min < w_mat < w_max`, `ext_mort_prop` in `[0, 1)`,
 #' positive values for `n`, `lambda`, `kappa`, `alpha`, `h`, `beta`, `sigma`
 #' and `f0`, and `fc` between 0 and `f0` if `fc` is supplied. If `gamma` is
-#' supplied then `f0` is ignored. The function stops if the resulting feeding
-#' level is not sufficient to maintain the species.
+#' supplied then `f0` is ignored after its value has been validated. The
+#' function stops if the resulting feeding level is not sufficient to maintain
+#' the species.
 #'
 #' The returned model has a single foreground species with cannibalism switched
 #' off and a fixed power-law background community that provides both food and
@@ -144,6 +145,7 @@ newSingleSpeciesParams <-
         stop("The maturity size w_mat must be ",
              "smaller the maximum size w_max")
     }
+    check_f0(f0) # nolint: object_usage_linter.
     if (!all(c(n, lambda, kappa, alpha, h, beta, sigma, f0) > 0)) {
         stop("The parameters n, lambda, kappa, alpha, h, beta, sigma ",
              "and f0, if supplied, need to be positive.")

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -1269,6 +1269,15 @@ get_gamma_default <- function(params) {
         assert_that(is.number(params@resource_params$lambda),
                     is.number(params@resource_params$kappa),
                     is.numeric(species_params$f0))
+        f0 <- species_params$f0
+        invalid_f0 <- missing & (!is.finite(f0) | f0 < 0 | f0 >= 1)
+        if (any(invalid_f0)) {
+            stop("The species parameter `f0` must be finite and in the ",
+                 "interval [0, 1) for species where `gamma` is not ",
+                 "supplied. Invalid values for: ",
+                 paste(species_params$species[invalid_f0], collapse = ", "),
+                 ".")
+        }
         signal_info("gamma", "Using f0, h, lambda, kappa and the predation kernel to calculate gamma.")
         if (!"h" %in% names(params@species_params) ||
             any(is.na(species_params[["h"]]))) {
@@ -1299,7 +1308,7 @@ get_gamma_default <- function(params) {
         gamma_default <- (species_params[["h"]] / avail_energy) *
             (species_params$f0 / (1 - species_params$f0))
         # Only overwrite missing gammas with calculated values
-        if (any(is.na(gamma_default[missing]))) {
+        if (any(!is.finite(gamma_default[missing]))) {
             stop("Could not calculate gamma.")
         }
         species_params$gamma[missing] <- gamma_default[missing]

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -731,10 +731,35 @@ reconcile_length_weight <- function(x, old) {
     x
 }
 
+check_f0 <- function(f0, species = NULL) {
+    if (is.logical(f0) && all(is.na(f0))) {
+        f0 <- as.numeric(f0)
+    }
+    if (!is.numeric(f0)) {
+        stop("The species parameter `f0` must be numeric.")
+    }
+    invalid_f0 <- is.nan(f0) |
+        (!is.na(f0) & (!is.finite(f0) | f0 < 0 | f0 >= 1))
+    if (any(invalid_f0)) {
+        msg <- paste0("The species parameter `f0` must be finite and in the ",
+                      "interval [0, 1).")
+        if (!is.null(species)) {
+            msg <- paste0(msg, " Invalid values for: ",
+                          paste(species[invalid_f0], collapse = ", "), ".")
+        }
+        stop(msg)
+    }
+    invisible(NULL)
+}
+
 check_and_convert_species_params <- function(x) {
     check_for_misspellings(names(x), known_species_params_columns(),
                            "species parameter",
                            curated_species_params_misspellings())
+
+    if ("f0" %in% names(x)) {
+        check_f0(x[["f0"]], x[["species"]])
+    }
 
     # Auto convert length to weight if allometric parameters exist
     if (all(c("a", "b") %in% names(x))) {
@@ -1264,20 +1289,12 @@ get_gamma_default <- function(params) {
     if (!("gamma" %in% colnames(species_params))) {
         species_params$gamma <- rep(NA, nrow(species_params))
     }
+    check_f0(species_params$f0, species_params$species)
     missing <- is.na(species_params$gamma)
     if (any(missing)) {
         assert_that(is.number(params@resource_params$lambda),
                     is.number(params@resource_params$kappa),
                     is.numeric(species_params$f0))
-        f0 <- species_params$f0
-        invalid_f0 <- missing & (!is.finite(f0) | f0 < 0 | f0 >= 1)
-        if (any(invalid_f0)) {
-            stop("The species parameter `f0` must be finite and in the ",
-                 "interval [0, 1) for species where `gamma` is not ",
-                 "supplied. Invalid values for: ",
-                 paste(species_params$species[invalid_f0], collapse = ", "),
-                 ".")
-        }
         signal_info("gamma", "Using f0, h, lambda, kappa and the predation kernel to calculate gamma.")
         if (!"h" %in% names(params@species_params) ||
             any(is.na(species_params[["h"]]))) {

--- a/R/wrapper_functions.R
+++ b/R/wrapper_functions.R
@@ -46,7 +46,7 @@
 #' @param alpha The assimilation efficiency of the community.
 #' @param f0 The average feeding level of individuals who feed on a power-law
 #'   spectrum. This value is used to calculate the search rate parameter
-#'   `gamma`.
+#'   `gamma`. Must be finite and in the interval [0, 1).
 #' @param h The coefficient of the maximum food intake rate.
 #' @param n The allometric growth exponent. Used as allometric exponent for
 #'   the maximum intake rate of the community as well as the intrinsic growth
@@ -263,7 +263,7 @@ newCommunityParams <- function(max_w = 1e6,
 #' @param sigma Width of prey size preference.
 #' @param f0 Expected average feeding level. Used to set `gamma`, the
 #'   coefficient in the search rate. Ignored if `gamma` is given
-#'   explicitly.
+#'   explicitly, but must still be finite and in the interval (0, 1).
 #' @param gamma Volumetric search rate. If not provided, default is determined
 #'   by [get_gamma_default()] using the value of `f0`.
 #' @param ext_mort_prop The proportion of the total mortality that comes from
@@ -410,6 +410,7 @@ newTraitParams <- function(no_sp = 11,
     if (no_sp < 2) {
         stop("The number of species must be at least 2.")
     }
+    check_f0(f0) # nolint: object_usage_linter.
     if (!all(c(n, r_pp, lambda, kappa, alpha, h, beta, sigma, f0) > 0)) {
         stop("The parameters n, lambda, r_pp, kappa, alpha, h, beta, sigma ",
              "and f0, if supplied, need to be positive.")

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -58,6 +58,7 @@ plots) are in the changelog and are not repeated here.
 | Size grid or results changed in a model built with a small `min_w` | `w_min` is no longer reset to 0.001 | `w_min` survives a rebuild (3.3) |
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
 | A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
+| Setting `f0 = 1` now errors that `f0` must be in `[0, 1)` | an unattainable feeding level used to create a non-finite search volume | `f0` must be below 1 when `gamma` is calculated (3.3) |
 | `setParams()` or `setResource()` errors that it "does not have an argument" | unknown arguments are no longer silently ignored | `setParams()` rejects arguments it does not use (3.3) |
 | A `setParams(resource_rate = )` / `setParams(kappa = )` call that ran fine now errors | `setParams()` never set the resource; use `setResource()` | `setParams()` rejects arguments it does not use (3.3) |
 | A resource change made via `setParams()` never showed up in the model | the argument was silently dropped in every version before 3.3 | `setParams()` rejects arguments it does not use (3.3) |
@@ -346,6 +347,21 @@ effect on the model while the search volume stays frozen — mizer now warns you
 about that separately, see "A change that cannot take effect now warns" above.
 Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
 the control of the species parameters.
+
+### `f0` must be below 1 when `gamma` is calculated
+
+The target feeding level `f0` must now be finite and in the interval `[0, 1)`
+when mizer needs to calculate a missing search-volume coefficient `gamma`.
+Previously `f0 = 1` divided by zero in the default calculation, silently
+creating an infinite `gamma` and a non-finite `search_vol`; values above 1
+created negative search volumes. The assignment returned an invalid
+`MizerParams` object and the damage was usually reported only by a later call to
+`validParams()`.
+
+If code now errors here, choose a physically attainable feeding level below 1,
+or supply `gamma` directly when that is the parameter you intend to control.
+An `f0` value that is overruled by an explicitly given `gamma` is unaffected by
+this check (#517).
 
 ### `setParams()` rejects arguments it does not use
 

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -58,7 +58,7 @@ plots) are in the changelog and are not repeated here.
 | Size grid or results changed in a model built with a small `min_w` | `w_min` is no longer reset to 0.001 | `w_min` survives a rebuild (3.3) |
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
 | A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
-| Setting `f0 = 1` now errors that `f0` must be in `[0, 1)` | an unattainable feeding level used to create a non-finite search volume | `f0` must be below 1 when `gamma` is calculated (3.3) |
+| Setting `f0 = 1` now errors even though `gamma` is supplied | every supplied target feeding level is now validated | `f0` is always validated (3.3) |
 | `setParams()` or `setResource()` errors that it "does not have an argument" | unknown arguments are no longer silently ignored | `setParams()` rejects arguments it does not use (3.3) |
 | A `setParams(resource_rate = )` / `setParams(kappa = )` call that ran fine now errors | `setParams()` never set the resource; use `setResource()` | `setParams()` rejects arguments it does not use (3.3) |
 | A resource change made via `setParams()` never showed up in the model | the argument was silently dropped in every version before 3.3 | `setParams()` rejects arguments it does not use (3.3) |
@@ -348,20 +348,18 @@ about that separately, see "A change that cannot take effect now warns" above.
 Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
 the control of the species parameters.
 
-### `f0` must be below 1 when `gamma` is calculated
+### `f0` is always validated
 
-The target feeding level `f0` must now be finite and in the interval `[0, 1)`
-when mizer needs to calculate a missing search-volume coefficient `gamma`.
-Previously `f0 = 1` divided by zero in the default calculation, silently
-creating an infinite `gamma` and a non-finite `search_vol`; values above 1
-created negative search volumes. The assignment returned an invalid
-`MizerParams` object and the damage was usually reported only by a later call to
-`validParams()`.
+Every non-missing target feeding level `f0` must now be finite and in the
+interval `[0, 1)`, whether or not a search-volume coefficient `gamma` is also
+supplied. Previously `f0 = 1` divided by zero when mizer calculated `gamma`,
+silently creating an infinite `gamma` and a non-finite `search_vol`; values
+above 1 created negative search volumes. If `gamma` was supplied explicitly,
+the same invalid `f0` could instead be accepted and ignored.
 
-If code now errors here, choose a physically attainable feeding level below 1,
-or supply `gamma` directly when that is the parameter you intend to control.
-An `f0` value that is overruled by an explicitly given `gamma` is unaffected by
-this check (#517).
+If code now errors here, choose a physically attainable feeding level below 1.
+When `gamma` is the parameter you intend to control, omit the `f0` value or use
+a valid value; `gamma` will still take precedence (#517).
 
 ### `setParams()` rejects arguments it does not use
 

--- a/man/MizerParams.Rd
+++ b/man/MizerParams.Rd
@@ -46,7 +46,7 @@ species by including a \code{n} column in the \code{species_params}.}
 
 \item{f0}{Expected average feeding level. Used to set \code{gamma}, the
 coefficient in the search rate. Ignored if \code{gamma} is given
-explicitly.}
+explicitly, but must still be finite and in the interval (0, 1).}
 
 \item{kappa}{The coefficient \eqn{\kappa} of the resource carrying capacity
 power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial

--- a/man/newCommunityParams.Rd
+++ b/man/newCommunityParams.Rd
@@ -43,7 +43,7 @@ is set to the smallest value at which any of the consumers can feed.}
 
 \item{f0}{The average feeding level of individuals who feed on a power-law
 spectrum. This value is used to calculate the search rate parameter
-\code{gamma}.}
+\code{gamma}. Must be finite and in the interval [0, 1).}
 
 \item{h}{The coefficient of the maximum food intake rate.}
 

--- a/man/newSingleSpeciesParams.Rd
+++ b/man/newSingleSpeciesParams.Rd
@@ -70,7 +70,7 @@ equal to the exponent \code{n}.}
 
 \item{f0}{Expected average feeding level. Used to set \code{gamma}, the
 coefficient in the search rate. Ignored if \code{gamma} is given
-explicitly.}
+explicitly, but must still be finite and in the interval (0, 1).}
 
 \item{fc}{Critical feeding level. Used to determine \code{ks} if it is not given
 explicitly.}
@@ -134,8 +134,9 @@ necessary so that there are at least 5 size bins per factor 10 in body
 size. It requires \verb{w_min < w_mat < w_max}, \code{ext_mort_prop} in \verb{[0, 1)},
 positive values for \code{n}, \code{lambda}, \code{kappa}, \code{alpha}, \code{h}, \code{beta}, \code{sigma}
 and \code{f0}, and \code{fc} between 0 and \code{f0} if \code{fc} is supplied. If \code{gamma} is
-supplied then \code{f0} is ignored. The function stops if the resulting feeding
-level is not sufficient to maintain the species.
+supplied then \code{f0} is ignored after its value has been validated. The
+function stops if the resulting feeding level is not sufficient to maintain
+the species.
 
 The returned model has a single foreground species with cannibalism switched
 off and a fixed power-law background community that provides both food and

--- a/man/newTraitParams.Rd
+++ b/man/newTraitParams.Rd
@@ -98,7 +98,7 @@ equal to the exponent \code{n}.}
 
 \item{f0}{Expected average feeding level. Used to set \code{gamma}, the
 coefficient in the search rate. Ignored if \code{gamma} is given
-explicitly.}
+explicitly, but must still be finite and in the interval (0, 1).}
 
 \item{fc}{Critical feeding level. Used to determine \code{ks} if it is not given
 explicitly.}

--- a/man/set_multispecies_model.Rd
+++ b/man/set_multispecies_model.Rd
@@ -46,7 +46,7 @@ species by including a \code{n} column in the \code{species_params}.}
 
 \item{f0}{Expected average feeding level. Used to set \code{gamma}, the
 coefficient in the search rate. Ignored if \code{gamma} is given
-explicitly.}
+explicitly, but must still be finite and in the interval (0, 1).}
 
 \item{kappa}{The coefficient \eqn{\kappa} of the resource carrying capacity
 power law \eqn{c_R(w) = \kappa\, w^{-\lambda}}, which also sets the initial

--- a/tests/testthat/test-newSingleSpeciesParams.R
+++ b/tests/testthat/test-newSingleSpeciesParams.R
@@ -7,6 +7,8 @@ test_that("newSingleSpeciesParams works", {
     expect_equal(params@w[no_w], params@species_params$w_max, ignore_attr = TRUE)
     sim <- project(params, t_max = 1)
     expect_equal(sim@n[1, 1, ], sim@n[2, 1, ])
+    expect_error(newSingleSpeciesParams(f0 = 1, gamma = 1, info_level = 0),
+                 "`f0` must be finite and in the interval")
 })
 
 test_that("newSingleSpeciesParams documents and applies grid and deprecation behaviour", {

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -81,7 +81,7 @@ test_that("gamma and f0 defaults ignore a frozen search volume (#488)", {
     expect_equal(search_vol(frozen), sv, ignore_attr = TRUE)
 })
 
-test_that("invalid f0 values do not create non-finite gamma (#517)", {
+test_that("invalid f0 is rejected even when gamma is given (#517)", {
     sp <- data.frame(species = "a", w_inf = 100)
     params <- newMultispeciesParams(sp, info_level = 0)
     expect_false("gamma" %in% names(given_species_params(params)))
@@ -91,6 +91,21 @@ test_that("invalid f0 values do not create non-finite gamma (#517)", {
     expect_error(given_species_params(params)$f0 <- 2,
                  "`f0` must be finite and in the interval")
     expect_error(given_species_params(params)$f0 <- Inf,
+                 "`f0` must be finite and in the interval")
+    expect_error(given_species_params(params)$f0 <- NaN,
+                 "`f0` must be finite and in the interval")
+
+    sp$gamma <- 1
+    params <- newMultispeciesParams(sp, info_level = 0)
+    expect_true("gamma" %in% names(given_species_params(params)))
+    expect_error(given_species_params(params)$f0 <- 1,
+                 "`f0` must be finite and in the interval")
+    sp_invalid <- data.frame(species = "a", w_inf = 100, gamma = 1, f0 = 1)
+    expect_error(given_species_params(sp_invalid),
+                 "`f0` must be finite and in the interval")
+
+    params@species_params$f0 <- 1
+    expect_error(get_gamma_default(params),
                  "`f0` must be finite and in the interval")
 })
 
@@ -166,7 +181,7 @@ test_that("`given_species_params<-()` gives correct warnings", {
     params <- NS_params_small
 
     no_sp <- nrow(params@species_params)
-    expect_warning(given_species_params(params)$f0 <- 1)
+    expect_warning(given_species_params(params)$f0 <- 0.5)
     expect_warning(given_species_params(params)$fc <- 1)
     expect_warning(given_species_params(params)$age_mat <- 1)
     expect_warning(given_species_params(params)$catchability <- 2)

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -81,6 +81,19 @@ test_that("gamma and f0 defaults ignore a frozen search volume (#488)", {
     expect_equal(search_vol(frozen), sv, ignore_attr = TRUE)
 })
 
+test_that("invalid f0 values do not create non-finite gamma (#517)", {
+    sp <- data.frame(species = "a", w_inf = 100)
+    params <- newMultispeciesParams(sp, info_level = 0)
+    expect_false("gamma" %in% names(given_species_params(params)))
+
+    expect_error(given_species_params(params)$f0 <- 1,
+                 "`f0` must be finite and in the interval")
+    expect_error(given_species_params(params)$f0 <- 2,
+                 "`f0` must be finite and in the interval")
+    expect_error(given_species_params(params)$f0 <- Inf,
+                 "`f0` must be finite and in the interval")
+})
+
 
 test_that("Setting species params works", {
     params <- newMultispeciesParams(NS_species_params_small, info_level = 0)
@@ -161,8 +174,8 @@ test_that("`given_species_params<-()` gives correct warnings", {
 
     # No warning if NA
     params@given_species_params$gamma[-1] <- NA
-    expect_warning(given_species_params(params)$f0 <- c(NA, rep(2, no_sp - 1)),
-                   NA)
+    f0 <- c(NA, rep(0.2, no_sp - 1))
+    expect_warning(given_species_params(params)$f0 <- f0, NA)
 
 })
 

--- a/tests/testthat/test-wrapper_functions.R
+++ b/tests/testthat/test-wrapper_functions.R
@@ -4,6 +4,8 @@ test_that("Providing gamma overrules f0 in newTraitParams()", {
     params <- newTraitParams(f0 = 0.4, gamma = gamma, info_level = 0)
     expect_identical(params@species_params$gamma,
                      rep(gamma, nrow(params@species_params)), ignore_attr = TRUE)
+    expect_error(newTraitParams(f0 = 1, gamma = gamma, info_level = 0),
+                 "`f0` must be finite and in the interval")
 })
 
 test_that("newTraitParams uses documented gear and resource-cutoff behaviour", {
@@ -158,6 +160,8 @@ test_that("Sets given_species_params", {
 test_that("newCommunityParams works", {
     expect_message(newCommunityParams(z0 = 0.05, f0 = 0.5, info_level = 3),
                    "Using f0, h, lambda, kappa")
+    expect_error(newCommunityParams(f0 = 1, gamma = 1, info_level = 0),
+                 "`f0` must be finite and in the interval")
 })
 
 test_that("newCommunityParams sets constant-reproduction community state", {

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -267,20 +267,18 @@ about that separately, see "A change that cannot take effect now warns" above.
 Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
 the control of the species parameters.
 
-### `f0` must be below 1 when `gamma` is calculated
+### `f0` is always validated
 
-The target feeding level `f0` must now be finite and in the interval `[0, 1)`
-when mizer needs to calculate a missing search-volume coefficient `gamma`.
-Previously `f0 = 1` divided by zero in the default calculation, silently
-creating an infinite `gamma` and a non-finite `search_vol`; values above 1
-created negative search volumes. The assignment returned an invalid
-[`MizerParams`](../reference/MizerParams.html) object and the damage was usually reported only by a later call to
-`validParams()`.
+Every non-missing target feeding level `f0` must now be finite and in the
+interval `[0, 1)`, whether or not a search-volume coefficient `gamma` is also
+supplied. Previously `f0 = 1` divided by zero when mizer calculated `gamma`,
+silently creating an infinite `gamma` and a non-finite `search_vol`; values
+above 1 created negative search volumes. If `gamma` was supplied explicitly,
+the same invalid `f0` could instead be accepted and ignored.
 
-If code now errors here, choose a physically attainable feeding level below 1,
-or supply `gamma` directly when that is the parameter you intend to control.
-An `f0` value that is overruled by an explicitly given `gamma` is unaffected by
-this check (#517).
+If code now errors here, choose a physically attainable feeding level below 1.
+When `gamma` is the parameter you intend to control, omit the `f0` value or use
+a valid value; `gamma` will still take precedence (#517).
 
 ### `setParams()` rejects arguments it does not use
 
@@ -632,7 +630,7 @@ params <- finalParams(sim)
 
 or, when averaging over a time range, with
 [`getParams(sim, time_range, geometric_mean)`](../reference/getParams.html). This reflects a shift in
-interpretation: a `MizerParams` object now represents not just the model
+interpretation: a [`MizerParams`](../reference/MizerParams.html) object now represents not just the model
 specification but also its current state (the abundances), which can be
 extracted from a simulation with `getParams()`, [`finalParams()`](../reference/finalParams.html) and
 [`initialParams()`](../reference/initialParams.html).

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -267,6 +267,21 @@ about that separately, see "A change that cannot take effect now warns" above.
 Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
 the control of the species parameters.
 
+### `f0` must be below 1 when `gamma` is calculated
+
+The target feeding level `f0` must now be finite and in the interval `[0, 1)`
+when mizer needs to calculate a missing search-volume coefficient `gamma`.
+Previously `f0 = 1` divided by zero in the default calculation, silently
+creating an infinite `gamma` and a non-finite `search_vol`; values above 1
+created negative search volumes. The assignment returned an invalid
+[`MizerParams`](../reference/MizerParams.html) object and the damage was usually reported only by a later call to
+`validParams()`.
+
+If code now errors here, choose a physically attainable feeding level below 1,
+or supply `gamma` directly when that is the parameter you intend to control.
+An `f0` value that is overruled by an explicitly given `gamma` is unaffected by
+this check (#517).
+
 ### `setParams()` rejects arguments it does not use
 
 [`setParams()`](../reference/setParams.html) passes its `...` on to the rate setters, each of which declares
@@ -617,7 +632,7 @@ params <- finalParams(sim)
 
 or, when averaging over a time range, with
 [`getParams(sim, time_range, geometric_mean)`](../reference/getParams.html). This reflects a shift in
-interpretation: a [`MizerParams`](../reference/MizerParams.html) object now represents not just the model
+interpretation: a `MizerParams` object now represents not just the model
 specification but also its current state (the abundances), which can be
 extracted from a simulation with `getParams()`, [`finalParams()`](../reference/finalParams.html) and
 [`initialParams()`](../reference/initialParams.html).


### PR DESCRIPTION
## Summary

- validate every non-missing `f0` as finite and in `[0, 1)`, whether or not `gamma` is supplied
- apply the invariant at species-parameter table boundaries and before trait/single-species constructors discard an overridden `f0`
- keep `gamma` precedence unchanged while making `get_gamma_default()` validate `f0` unconditionally and reject any non-finite calculated `gamma`
- add regression coverage and update the changelog, API documentation, and generated upgrading guide

## Root cause

`get_gamma_default()` calculates `f0 / (1 - f0)`. At `f0 = 1` this produces `Inf`, but the old guard checked only `is.na()`, leaving an invalid `MizerParams` object whose `search_vol` failed only during a later `validParams()` call. Values above 1 could similarly produce negative search volumes.

The initial fix checked `f0` only for species whose `gamma` was missing. That was too narrow: `f0` is itself a target feeding level, so any supplied value should satisfy its invariant even when `gamma` takes precedence. Some wrapper constructors also replaced `f0` with `NA` before the species table was validated.

## Impact

Invalid target feeding levels now fail immediately on all supported parameter-table and constructor paths. A valid explicitly supplied `gamma` still takes precedence over a valid `f0`; the change is only that an invalid `f0` can no longer be stored or silently discarded.

## Validation

- `devtools::load_all()` followed by targeted tests for `species_params`, `wrapper_functions`, `newSingleSpeciesParams`, `setSearchVolume`, `newMultispeciesParams`, and `helpers`: 446 passed
- changed-line lint: clean
- `git diff --check`: clean
- `devtools::document()`
- `source("dev_scripts/build_cheatsheets.R"); build_cheatsheets()`

Closes #517
