### PR TITLE
Warn when setExtMort() default arguments are ignored

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -245,11 +245,14 @@ stability of steady states.
   the run.
 
 - `setExtMort()` now warns when explicitly supplied `z0pre` or `z0exp`
-  arguments are ignored because `z0` is already complete or because
-  `ext_mort` was supplied. When either argument is explicitly supplied and is
-  used to fill missing `z0`, the resulting values are now recorded in
-  `given_species_params()`. Values calculated from the arguments' defaults
-  remain calculated parameters and are not recorded there (#493).
+  arguments are ignored because `z0` is already present in
+  `given_species_params()` for every species or because `ext_mort` was
+  supplied. A `z0` value that is present only in `species_params()` is now
+  recognised as calculated and is recalculated from `z0pre`, `w_inf` and
+  `z0exp`. When either argument is explicitly supplied and used, the resulting
+  values are recorded in `given_species_params()`. Values calculated from the
+  arguments' defaults remain calculated parameters and are not recorded there
+  (#493).
 
 ## Deprecations
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -244,14 +244,14 @@ stability of steady states.
   `extinction_threshold` fraction (default `1e-6`) of its value at the start of
   the run.
 
-## Deprecations
+- `setExtMort()` now warns when explicitly supplied `z0pre` or `z0exp`
+  arguments are ignored because `z0` is already complete or because
+  `ext_mort` was supplied. When either argument is explicitly supplied and is
+  used to fill missing `z0`, the resulting values are now recorded in
+  `given_species_params()`. Values calculated from the arguments' defaults
+  remain calculated parameters and are not recorded there (#493).
 
-- The `z0pre` and `z0exp` arguments of `setExtMort()` are deprecated. They only
-  supplied a default for missing values of the `z0` species parameter, so they
-  had no effect on a built model, where `z0` is already populated—even with
-  `reset = TRUE`. Set `species_params(params)$z0` instead. The arguments remain
-  available on `newMultispeciesParams()`, where they are meaningful while the
-  model is being constructed (#493).
+## Deprecations
 
 - Eleven accessors that returned a rate array stored in the MizerParams object
   had two names that did exactly the same thing. The `get`-prefixed name is now

--- a/NEWS.md
+++ b/NEWS.md
@@ -246,6 +246,13 @@ stability of steady states.
 
 ## Deprecations
 
+- The `z0pre` and `z0exp` arguments of `setExtMort()` are deprecated. They only
+  supplied a default for missing values of the `z0` species parameter, so they
+  had no effect on a built model, where `z0` is already populated—even with
+  `reset = TRUE`. Set `species_params(params)$z0` instead. The arguments remain
+  available on `newMultispeciesParams()`, where they are meaningful while the
+  model is being constructed (#493).
+
 - Eleven accessors that returned a rate array stored in the MizerParams object
   had two names that did exactly the same thing. The `get`-prefixed name is now
   soft-deprecated in favour of the bare name, which is the one that also has a

--- a/R/newMultispeciesParams.R
+++ b/R/newMultispeciesParams.R
@@ -29,10 +29,6 @@
 #'   species by including a `n` column in the `species_params`.
 #' @param p The allometric metabolic exponent. This can be overruled for
 #'   individual species by including a `p` column in the `species_params`.
-#' @param z0pre If `z0` is missing from the species parameter data frame,
-#'   calculate it as `z0pre * w_inf ^ z0exp`. Defaults to 0.6.
-#' @param z0exp The exponent used with `z0pre` to calculate a missing `z0`.
-#'   Defaults to `n - 1`.
 #' @param second_order_w `r lifecycle::badge("experimental")` Selects the
 #'   second-order numerical scheme for the new model. Accepts the same values as
 #'   the [second_order_w()] setter: a single logical (`TRUE` switches on both
@@ -168,18 +164,13 @@ newMultispeciesParams <- function(
                                   "newMultispeciesParams(ext_mort)")
         ext_mort <- z0
     }
+    z0pre_given <- !missing(z0pre)
+    z0exp_given <- !missing(z0exp)
 
     # Collect the information signals raised while the model is built and
     # report them together at the end.
     with_info_level(info_level = info_level, {
     no_sp <- nrow(species_params)
-    z0_missing <- if ("z0" %in% names(species_params)) {
-        is.na(species_params$z0)
-    } else {
-        rep(TRUE, no_sp)
-    }
-    assert_that(is.number(z0pre), z0pre >= 0,
-                is.number(z0exp))
 
     species_params <- set_species_param_default(species_params, "n", n)
     species_params <- set_species_param_default(species_params, "p", p)
@@ -225,8 +216,8 @@ newMultispeciesParams <- function(
     params@resource_params$n <- n
     params@resource_params$w_pp_cutoff <- w_pp_cutoff
 
-    params <- setParams(
-        params,
+    set_params_args <- list(
+        object = params,
         # setInteraction
         interaction = interaction,
         # setPredKernel()
@@ -251,17 +242,16 @@ newMultispeciesParams <- function(
         selectivity = selectivity,
         catchability = catchability,
         initial_effort = initial_effort)
-
-    # `z0pre` and `z0exp` are construction arguments. `setParams()` has
-    # installed the ordinary `z0` default at the same point in the species
-    # table as before; now replace only the values that were missing from the
-    # user's table with the requested construction default and update external
-    # mortality. Do not add these calculated values to `given_species_params`.
-    if (is.null(ext_mort) && any(z0_missing)) {
-        z0_default <- z0pre * params@species_params$w_inf^z0exp
-        params@species_params$z0[z0_missing] <- z0_default[z0_missing]
-        params <- setExtMort(params)
+    # Preserve whether these arguments were actually supplied. This lets
+    # setExtMort() record z0 derived from an explicit argument while leaving
+    # z0 derived from the argument defaults out of given_species_params.
+    if (z0pre_given) {
+        set_params_args$z0pre <- z0pre
     }
+    if (z0exp_given) {
+        set_params_args$z0exp <- z0exp
+    }
+    params <- do.call(setParams, set_params_args)
 
     params <- setResource(
         params,

--- a/R/newMultispeciesParams.R
+++ b/R/newMultispeciesParams.R
@@ -29,6 +29,10 @@
 #'   species by including a `n` column in the `species_params`.
 #' @param p The allometric metabolic exponent. This can be overruled for
 #'   individual species by including a `p` column in the `species_params`.
+#' @param z0pre If `z0` is missing from the species parameter data frame,
+#'   calculate it as `z0pre * w_inf ^ z0exp`. Defaults to 0.6.
+#' @param z0exp The exponent used with `z0pre` to calculate a missing `z0`.
+#'   Defaults to `n - 1`.
 #' @param second_order_w `r lifecycle::badge("experimental")` Selects the
 #'   second-order numerical scheme for the new model. Accepts the same values as
 #'   the [second_order_w()] setter: a single logical (`TRUE` switches on both
@@ -169,6 +173,13 @@ newMultispeciesParams <- function(
     # report them together at the end.
     with_info_level(info_level = info_level, {
     no_sp <- nrow(species_params)
+    z0_missing <- if ("z0" %in% names(species_params)) {
+        is.na(species_params$z0)
+    } else {
+        rep(TRUE, no_sp)
+    }
+    assert_that(is.number(z0pre), z0pre >= 0,
+                is.number(z0exp))
 
     species_params <- set_species_param_default(species_params, "n", n)
     species_params <- set_species_param_default(species_params, "p", p)
@@ -209,49 +220,62 @@ newMultispeciesParams <- function(
                                                 w_max = w_pp_cutoff)
     params@resource_params$kappa <- kappa
     params@resource_params$lambda <- lambda
+    # Needed by rate defaults, including the construction default for `z0`,
+    # before `setResource()` installs the complete resource parameters below.
+    params@resource_params$n <- n
     params@resource_params$w_pp_cutoff <- w_pp_cutoff
 
-    params <- params  %>%
-        setParams(
-                  # setInteraction
-                  interaction = interaction,
-                  # setPredKernel()
-                  pred_kernel = pred_kernel,
-                  # setSearchVolume()
-                  search_vol = search_vol,
-                  # setMaxIntakeRate()
-                  intake_max = intake_max,
-                  # setMetabolicRate()
-                  metab = metab,
-                  # setExtMort
-                  ext_mort = ext_mort,
-                  z0pre = z0pre,
-                  z0exp = z0exp,
-                  # setExtEncounter
-                  ext_encounter = ext_encounter,
-                  # setReproduction
-                  maturity = maturity,
-                  repro_prop = repro_prop,
-                  RDD = RDD,
-                  # setFishing. The `gear_params` are not passed here: they are
-                  # already stored in the params object by emptyParams() above
-                  # and setFishing() reads them from there.
-                  selectivity = selectivity,
-                  catchability = catchability,
-                  initial_effort = initial_effort) %>%
-        setResource(
-            # setResource
-            resource_rate = resource_rate,
-            resource_capacity = resource_capacity,
-            resource_dynamics = resource_dynamics,
-            lambda = lambda,
-            n = n,
-            w_pp_cutoff = w_pp_cutoff,
-            balance = FALSE)
+    params <- setParams(
+        params,
+        # setInteraction
+        interaction = interaction,
+        # setPredKernel()
+        pred_kernel = pred_kernel,
+        # setSearchVolume()
+        search_vol = search_vol,
+        # setMaxIntakeRate()
+        intake_max = intake_max,
+        # setMetabolicRate()
+        metab = metab,
+        # setExtMort
+        ext_mort = ext_mort,
+        # setExtEncounter
+        ext_encounter = ext_encounter,
+        # setReproduction
+        maturity = maturity,
+        repro_prop = repro_prop,
+        RDD = RDD,
+        # setFishing. The `gear_params` are not passed here: they are already
+        # stored in the params object by emptyParams() above and setFishing()
+        # reads them from there.
+        selectivity = selectivity,
+        catchability = catchability,
+        initial_effort = initial_effort)
 
-        params@initial_n[] <- get_initial_n(params)
-        # TODO: The next line can be removed after release of mizer 3.0
-        params@A <- rep(1, nrow(species_params))
+    # `z0pre` and `z0exp` are construction arguments. `setParams()` has
+    # installed the ordinary `z0` default at the same point in the species
+    # table as before; now replace only the values that were missing from the
+    # user's table with the requested construction default and update external
+    # mortality. Do not add these calculated values to `given_species_params`.
+    if (is.null(ext_mort) && any(z0_missing)) {
+        z0_default <- z0pre * params@species_params$w_inf^z0exp
+        params@species_params$z0[z0_missing] <- z0_default[z0_missing]
+        params <- setExtMort(params)
+    }
+
+    params <- setResource(
+        params,
+        resource_rate = resource_rate,
+        resource_capacity = resource_capacity,
+        resource_dynamics = resource_dynamics,
+        lambda = lambda,
+        n = n,
+        w_pp_cutoff = w_pp_cutoff,
+        balance = FALSE)
+
+    params@initial_n[] <- get_initial_n(params)
+    # TODO: The next line can be removed after release of mizer 3.0
+    params@A <- rep(1, nrow(species_params))
     })
     # Now that the initial abundances have been computed with the robust upwind
     # solver, switch on the requested advective-flux scheme for projection.

--- a/R/setExtMort.R
+++ b/R/setExtMort.R
@@ -23,15 +23,15 @@
 #' taken from the species parameters as
 #' \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 #' The value of the constant \eqn{z_0} for each species is taken from the `z0`
-#' column of the species parameter data frame, if that column exists. When a
-#' model is constructed with [newMultispeciesParams()], missing values are
-#' calculated as
+#' column of the species parameter data frame, if that column exists. Missing
+#' values are calculated as
 #' \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-#' using that constructor's `z0pre` and `z0exp` arguments. On an existing model,
-#' change `z0` with [species_params<-()] and let mizer recalculate the rate.
-#' If `z0` has been removed from the species parameters entirely,
-#' `setExtMort()` restores the construction defaults `z0pre = 0.6` and
-#' `z0exp = n - 1`.
+#' When `z0pre` or `z0exp` is supplied explicitly and used to fill missing
+#' `z0`, the resulting values are recorded in [given_species_params()]. Values
+#' calculated from the defaults `z0pre = 0.6` and `z0exp = n - 1` are not
+#' recorded there. If either argument is supplied but cannot be used because
+#' `z0` is already complete or because `ext_mort` was supplied, a warning is
+#' issued.
 #' Missing values of `z_ext` are set to 0 and missing values of `d` are set to
 #' `n - 1`.
 #'
@@ -57,12 +57,11 @@
 #'   previously overwritten with a custom value. If set to FALSE (default) then
 #'   a recalculation from the species parameters will take place only if no
 #'   custom value has been set.
-#' @param z0pre `r lifecycle::badge("deprecated")` Set the `z0` species
-#'   parameter instead. The argument remains available on
-#'   [newMultispeciesParams()] for use while constructing a model.
-#' @param z0exp `r lifecycle::badge("deprecated")` Set the `z0` species
-#'   parameter instead. The argument remains available on
-#'   [newMultispeciesParams()] for use while constructing a model.
+#' @param z0pre If `z0`, the mortality from other sources, is missing from the
+#'   species parameter data frame, it is calculated as
+#'   `z0pre * w_inf ^ z0exp`. Default value is 0.6.
+#' @param z0exp The exponent used with `z0pre` to calculate missing `z0`.
+#'   Default value is `n - 1`.
 #' @param z0 `r lifecycle::badge("deprecated")` Use `ext_mort` instead. Not to
 #'   be confused with the species_parameter `z0`.
 #' @param ... Unused
@@ -85,43 +84,27 @@
 #'
 #' # Change the external mortality rate in the params object
 #' ext_mort(params) <- allo_mort
-setExtMort <- function(params, ext_mort = NULL, z0pre = deprecated(),
-                       z0exp = deprecated(), reset = FALSE,
+setExtMort <- function(params, ext_mort = NULL, z0pre = 0.6,
+                       z0exp = params@resource_params$n - 1, reset = FALSE,
                        z0 = deprecated(), ...) {
     UseMethod("setExtMort")
 }
 #' @export
 setExtMort.MizerParams <- function(params, ext_mort = NULL,
-                                   z0pre = deprecated(),
-                                   z0exp = deprecated(), reset = FALSE,
+                                   z0pre = 0.6,
+                                   z0exp = params@resource_params$n - 1,
+                                   reset = FALSE,
                                    z0 = deprecated(), ...) {
-    z0pre_default <- 0.6
-    z0exp_default <- NULL
-    if (lifecycle::is_present(z0pre)) {
-        details <- paste0("Set the `z0` species parameter instead. The ",
-                          "`z0pre` argument remains available on ",
-                          "`newMultispeciesParams()` for use while ",
-                          "constructing a model.")
-        lifecycle::deprecate_warn("3.3.0", "setExtMort(z0pre)",
-                                  details = details)
-        assert_that(is.number(z0pre), z0pre >= 0)
-        z0pre_default <- z0pre
-    }
-    if (lifecycle::is_present(z0exp)) {
-        details <- paste0("Set the `z0` species parameter instead. The ",
-                          "`z0exp` argument remains available on ",
-                          "`newMultispeciesParams()` for use while ",
-                          "constructing a model.")
-        lifecycle::deprecate_warn("3.3.0", "setExtMort(z0exp)",
-                                  details = details)
-        assert_that(is.number(z0exp))
-        z0exp_default <- z0exp
-    }
+    z0pre_given <- !missing(z0pre)
+    z0exp_given <- !missing(z0exp)
+    z0_args_given <- z0pre_given || z0exp_given
     if (lifecycle::is_present(z0)) {
         lifecycle::deprecate_warn("2.2.3", "setExtMort(z0)", "setExtMort(ext_mort)")
         ext_mort <- z0
     }
-    assert_that(is.flag(reset))
+    assert_that(is.flag(reset),
+                is.number(z0pre), z0pre >= 0,
+                is.number(z0exp))
 
     if (reset) {
         if (!is.null(ext_mort)) {
@@ -134,6 +117,10 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
     }
 
     if (!is.null(ext_mort)) {
+        if (z0_args_given) {
+            signal_ignored_z0_args(z0pre_given, z0exp_given,
+                                   "`ext_mort` was supplied")
+        }
         if (is.null(comment(ext_mort))) {
             if (is.null(comment(params@mu_b))) {
                 comment(ext_mort) <- "set manually"
@@ -153,14 +140,24 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
     species_params <- params@species_params
     assert_that(noNA(species_params$w_inf))
     # Sort out z0 (external mortality)
-    missing_z0 <- !("z0" %in% names(species_params)) ||
-        any(is.na(species_params$z0))
-    if (missing_z0) {
-        if (is.null(z0exp_default)) {
-            z0exp_default <- params@resource_params$n - 1
+    missing_z0 <- if ("z0" %in% names(species_params)) {
+        is.na(species_params$z0)
+    } else {
+        rep(TRUE, nrow(species_params))
+    }
+    if (any(missing_z0)) {
+        params <- set_z0_default(params, z0pre = z0pre, z0exp = z0exp)
+        if (z0_args_given) {
+            if (!"z0" %in% names(params@given_species_params)) {
+                params@given_species_params$z0 <-
+                    rep(NA_real_, nrow(params@given_species_params))
+            }
+            params@given_species_params$z0[missing_z0] <-
+                params@species_params$z0[missing_z0]
         }
-        params <- set_z0_default(params, z0pre = z0pre_default,
-                                 z0exp = z0exp_default)
+    } else if (z0_args_given) {
+        signal_ignored_z0_args(z0pre_given, z0exp_given,
+                               "the `z0` species parameter is already set")
     }
     params <- set_species_param_default(params, "z_ext", 0)
     params <- set_species_param_default(params, "d",
@@ -206,6 +203,16 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
 
     params@time_modified <- lubridate::now()
     return(params)
+}
+
+signal_ignored_z0_args <- function(z0pre_given, z0exp_given, reason) {
+    args <- c(if (z0pre_given) "`z0pre`", if (z0exp_given) "`z0exp`")
+    message <- paste0(
+        paste(args, collapse = " and "),
+        if (length(args) == 1) " was" else " were",
+        " ignored because ", reason, ".")
+    signal_info("z0", message, level = 1, severity = "warning",
+                unhandled = "show")
 }
 
 # Fill in missing constant external mortality parameters. This remains in the

--- a/R/setExtMort.R
+++ b/R/setExtMort.R
@@ -23,9 +23,15 @@
 #' taken from the species parameters as
 #' \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 #' The value of the constant \eqn{z_0} for each species is taken from the `z0`
-#' column of the species parameter data frame, if that column exists.
-#' Otherwise it is calculated as
+#' column of the species parameter data frame, if that column exists. When a
+#' model is constructed with [newMultispeciesParams()], missing values are
+#' calculated as
 #' \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
+#' using that constructor's `z0pre` and `z0exp` arguments. On an existing model,
+#' change `z0` with [species_params<-()] and let mizer recalculate the rate.
+#' If `z0` has been removed from the species parameters entirely,
+#' `setExtMort()` restores the construction defaults `z0pre = 0.6` and
+#' `z0exp = n - 1`.
 #' Missing values of `z_ext` are set to 0 and missing values of `d` are set to
 #' `n - 1`.
 #'
@@ -51,12 +57,12 @@
 #'   previously overwritten with a custom value. If set to FALSE (default) then
 #'   a recalculation from the species parameters will take place only if no
 #'   custom value has been set.
-#' @param z0pre If `z0`, the mortality from other sources, is not a column
-#'   in the species data frame, it is calculated as z0pre * w_inf ^ z0exp.
-#'   Default value is 0.6.
-#' @param z0exp If `z0`, the mortality from other sources, is not a column in
-#'   the species data frame, it is calculated as \code{z0pre * w_inf ^ z0exp}.
-#'   Default value is \code{n-1}.
+#' @param z0pre `r lifecycle::badge("deprecated")` Set the `z0` species
+#'   parameter instead. The argument remains available on
+#'   [newMultispeciesParams()] for use while constructing a model.
+#' @param z0exp `r lifecycle::badge("deprecated")` Set the `z0` species
+#'   parameter instead. The argument remains available on
+#'   [newMultispeciesParams()] for use while constructing a model.
 #' @param z0 `r lifecycle::badge("deprecated")` Use `ext_mort` instead. Not to
 #'   be confused with the species_parameter `z0`.
 #' @param ... Unused
@@ -79,21 +85,43 @@
 #'
 #' # Change the external mortality rate in the params object
 #' ext_mort(params) <- allo_mort
-setExtMort <- function(params, ext_mort = NULL, z0pre = 0.6,
-                       z0exp = params@resource_params$n - 1, reset = FALSE,
+setExtMort <- function(params, ext_mort = NULL, z0pre = deprecated(),
+                       z0exp = deprecated(), reset = FALSE,
                        z0 = deprecated(), ...) {
     UseMethod("setExtMort")
 }
 #' @export
 setExtMort.MizerParams <- function(params, ext_mort = NULL,
-                       z0pre = 0.6, z0exp = params@resource_params$n - 1,
-                       reset = FALSE, z0 = deprecated(), ...) {
+                                   z0pre = deprecated(),
+                                   z0exp = deprecated(), reset = FALSE,
+                                   z0 = deprecated(), ...) {
+    z0pre_default <- 0.6
+    z0exp_default <- NULL
+    if (lifecycle::is_present(z0pre)) {
+        details <- paste0("Set the `z0` species parameter instead. The ",
+                          "`z0pre` argument remains available on ",
+                          "`newMultispeciesParams()` for use while ",
+                          "constructing a model.")
+        lifecycle::deprecate_warn("3.3.0", "setExtMort(z0pre)",
+                                  details = details)
+        assert_that(is.number(z0pre), z0pre >= 0)
+        z0pre_default <- z0pre
+    }
+    if (lifecycle::is_present(z0exp)) {
+        details <- paste0("Set the `z0` species parameter instead. The ",
+                          "`z0exp` argument remains available on ",
+                          "`newMultispeciesParams()` for use while ",
+                          "constructing a model.")
+        lifecycle::deprecate_warn("3.3.0", "setExtMort(z0exp)",
+                                  details = details)
+        assert_that(is.number(z0exp))
+        z0exp_default <- z0exp
+    }
     if (lifecycle::is_present(z0)) {
         lifecycle::deprecate_warn("2.2.3", "setExtMort(z0)", "setExtMort(ext_mort)")
         ext_mort <- z0
     }
-    assert_that(is.flag(reset),
-                is.number(z0pre), is.number(z0exp))
+    assert_that(is.flag(reset))
 
     if (reset) {
         if (!is.null(ext_mort)) {
@@ -122,15 +150,18 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
         return(params)
     }
 
-    assert_that(is.number(z0pre), z0pre >= 0,
-                is.number(z0exp))
     species_params <- params@species_params
     assert_that(noNA(species_params$w_inf))
     # Sort out z0 (external mortality)
-    message <- ("Using z0 = z0pre * w_inf ^ z0exp for missing z0 values.")
-    params <- set_species_param_default(params, "z0",
-                                        z0pre * species_params$w_inf^z0exp,
-                                        message)
+    missing_z0 <- !("z0" %in% names(species_params)) ||
+        any(is.na(species_params$z0))
+    if (missing_z0) {
+        if (is.null(z0exp_default)) {
+            z0exp_default <- params@resource_params$n - 1
+        }
+        params <- set_z0_default(params, z0pre = z0pre_default,
+                                 z0exp = z0exp_default)
+    }
     params <- set_species_param_default(params, "z_ext", 0)
     params <- set_species_param_default(params, "d",
                                         params@species_params$n - 1)
@@ -175,6 +206,20 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
 
     params@time_modified <- lubridate::now()
     return(params)
+}
+
+# Fill in missing constant external mortality parameters. This remains in the
+# external-mortality setter's file because `z0` is owned by `setExtMort()`.
+set_z0_default <- function(params, z0pre = 0.6,
+                           z0exp = params@resource_params$n - 1) {
+    assert_that(is(params, "MizerParams"),
+                is.number(z0pre), z0pre >= 0,
+                is.number(z0exp))
+    species_params <- params@species_params
+    assert_that(noNA(species_params$w_inf))
+    message <- "Using z0 = z0pre * w_inf ^ z0exp for missing z0 values."
+    default <- z0pre * species_params$w_inf^z0exp
+    set_species_param_default(params, "z0", default, message)
 }
 
 #' @rdname setExtMort

--- a/R/setExtMort.R
+++ b/R/setExtMort.R
@@ -23,15 +23,16 @@
 #' taken from the species parameters as
 #' \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 #' The value of the constant \eqn{z_0} for each species is taken from the `z0`
-#' column of the species parameter data frame, if that column exists. Missing
-#' values are calculated as
+#' column of [given_species_params()] if it is present there. Otherwise it is
+#' recalculated, even if a value from an earlier calculation is still present
+#' in `species_params`, as
 #' \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-#' When `z0pre` or `z0exp` is supplied explicitly and used to fill missing
-#' `z0`, the resulting values are recorded in [given_species_params()]. Values
-#' calculated from the defaults `z0pre = 0.6` and `z0exp = n - 1` are not
-#' recorded there. If either argument is supplied but cannot be used because
-#' `z0` is already complete or because `ext_mort` was supplied, a warning is
-#' issued.
+#' When `z0pre` or `z0exp` is supplied explicitly and used to calculate
+#' non-given `z0`, the resulting values are recorded in
+#' [given_species_params()]. Values calculated from the defaults
+#' `z0pre = 0.6` and `z0exp = n - 1` are not recorded there. If either argument
+#' is supplied but cannot be used because `z0` is given for every species or
+#' because `ext_mort` was supplied, a warning is issued.
 #' Missing values of `z_ext` are set to 0 and missing values of `d` are set to
 #' `n - 1`.
 #'
@@ -57,10 +58,10 @@
 #'   previously overwritten with a custom value. If set to FALSE (default) then
 #'   a recalculation from the species parameters will take place only if no
 #'   custom value has been set.
-#' @param z0pre If `z0`, the mortality from other sources, is missing from the
-#'   species parameter data frame, it is calculated as
+#' @param z0pre If `z0`, the mortality from other sources, is not present in
+#'   [given_species_params()], it is calculated as
 #'   `z0pre * w_inf ^ z0exp`. Default value is 0.6.
-#' @param z0exp The exponent used with `z0pre` to calculate missing `z0`.
+#' @param z0exp The exponent used with `z0pre` to calculate non-given `z0`.
 #'   Default value is `n - 1`.
 #' @param z0 `r lifecycle::badge("deprecated")` Use `ext_mort` instead. Not to
 #'   be confused with the species_parameter `z0`.
@@ -137,27 +138,31 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
         return(params)
     }
 
-    species_params <- params@species_params
-    assert_that(noNA(species_params$w_inf))
-    # Sort out z0 (external mortality)
-    missing_z0 <- if ("z0" %in% names(species_params)) {
-        is.na(species_params$z0)
+    assert_that(noNA(params@species_params$w_inf))
+    # A z0 value is fixed only if it is present in given_species_params. A
+    # value found only in species_params was calculated previously and must be
+    # recalculated so that changes to its inputs propagate.
+    z0_is_given <- if ("z0" %in% names(params@given_species_params)) {
+        !is.na(params@given_species_params$z0)
     } else {
-        rep(TRUE, nrow(species_params))
+        rep(FALSE, nrow(params@species_params))
     }
-    if (any(missing_z0)) {
-        params <- set_z0_default(params, z0pre = z0pre, z0exp = z0exp)
+    calculate_z0 <- !z0_is_given
+    params <- set_z0_default(params, z0pre = z0pre, z0exp = z0exp)
+    if (any(calculate_z0)) {
         if (z0_args_given) {
             if (!"z0" %in% names(params@given_species_params)) {
                 params@given_species_params$z0 <-
                     rep(NA_real_, nrow(params@given_species_params))
             }
-            params@given_species_params$z0[missing_z0] <-
-                params@species_params$z0[missing_z0]
+            params@given_species_params$z0[calculate_z0] <-
+                params@species_params$z0[calculate_z0]
         }
     } else if (z0_args_given) {
         signal_ignored_z0_args(z0pre_given, z0exp_given,
-                               "the `z0` species parameter is already set")
+                               paste0("`z0` is already present in ",
+                                      "`given_species_params` for every ",
+                                      "species"))
     }
     params <- set_species_param_default(params, "z_ext", 0)
     params <- set_species_param_default(params, "d",
@@ -207,26 +212,41 @@ setExtMort.MizerParams <- function(params, ext_mort = NULL,
 
 signal_ignored_z0_args <- function(z0pre_given, z0exp_given, reason) {
     args <- c(if (z0pre_given) "`z0pre`", if (z0exp_given) "`z0exp`")
-    message <- paste0(
-        paste(args, collapse = " and "),
-        if (length(args) == 1) " was" else " were",
-        " ignored because ", reason, ".")
+    argument_names <- paste(args, collapse = " and ")
+    verb <- if (length(args) == 1) " was" else " were"
+    message <- paste0(argument_names, verb, " ignored because ", reason, ".")
     signal_info("z0", message, level = 1, severity = "warning",
                 unhandled = "show")
 }
 
-# Fill in missing constant external mortality parameters. This remains in the
-# external-mortality setter's file because `z0` is owned by `setExtMort()`.
+# Recalculate non-given constant external mortality parameters. This remains in
+# the external-mortality setter's file because `z0` is owned by `setExtMort()`.
 set_z0_default <- function(params, z0pre = 0.6,
                            z0exp = params@resource_params$n - 1) {
     assert_that(is(params, "MizerParams"),
                 is.number(z0pre), z0pre >= 0,
                 is.number(z0exp))
-    species_params <- params@species_params
-    assert_that(noNA(species_params$w_inf))
-    message <- "Using z0 = z0pre * w_inf ^ z0exp for missing z0 values."
-    default <- z0pre * species_params$w_inf^z0exp
-    set_species_param_default(params, "z0", default, message)
+    no_sp <- nrow(params@species_params)
+    given_z0 <- if ("z0" %in% names(params@given_species_params)) {
+        params@given_species_params$z0
+    } else {
+        rep(NA_real_, no_sp)
+    }
+    calculate_z0 <- is.na(given_z0)
+    default <- z0pre * params@species_params$w_inf^z0exp
+    z0_was_missing <- !"z0" %in% names(params@species_params)
+    if (z0_was_missing) {
+        params@species_params$z0 <- rep(NA_real_, no_sp)
+    }
+    z0_is_given <- !calculate_z0
+    params@species_params$z0[z0_is_given] <- given_z0[z0_is_given]
+    params@species_params$z0[calculate_z0] <- default[calculate_z0]
+    if (z0_was_missing && any(calculate_z0)) {
+        message <- paste0("Using z0 = z0pre * w_inf ^ z0exp for calculated ",
+                          "z0 values.")
+        signal_info("z0", message)
+    }
+    params
 }
 
 #' @rdname setExtMort

--- a/inst/skills/change-parameters/SKILL.md
+++ b/inst/skills/change-parameters/SKILL.md
@@ -196,13 +196,12 @@ Defaults fill in `NA`s. Once a column exists in `species_params()` — which,
 after the model is built, is true of every parameter — the machinery that would
 have calculated it is bypassed. Two practical consequences:
 
-**Arguments that only feed a default are construction-only.**
-`newMultispeciesParams()` computes `z0 = z0pre * w_inf^z0exp`, but only for
-missing `z0` values while the model is being built. The corresponding
-`setExtMort(z0pre = )` and `setExtMort(z0exp = )` arguments are deprecated:
-on a built model `z0` is already present, so they could not take effect—not
-even with `reset = TRUE`, which clears the rate array's comment and not the
-species parameter. Set the species parameter instead:
+**Arguments that only feed a default work only while values are missing.**
+`setExtMort()` computes `z0 = z0pre * w_inf^z0exp`, but only for missing `z0`
+values. On a built model `z0` is already present, so supplying `z0pre` or
+`z0exp` normally cannot take effect and now gives a warning. `reset = TRUE`
+does not help: it clears the rate array's comment, not the species parameter.
+Set the species parameter instead:
 
 ```r
 sp <- species_params(params)
@@ -211,6 +210,11 @@ sp$z0 <- 2 * sp$w_inf^z0exp
 species_params(params) <- sp
 # Setting `sp$z0 <- NA` instead hands it back to the default calculation.
 ```
+
+If you do remove or set some `z0` values to `NA`, an explicitly supplied
+`z0pre` or `z0exp` is used and the resulting values are recorded in
+`given_species_params()`. Values filled from the arguments' defaults are not
+recorded there.
 
 **Giving a value switches off the calculation that would have used another one.**
 Mizer warns about three of these, but only from `given_species_params<-()` —

--- a/inst/skills/change-parameters/SKILL.md
+++ b/inst/skills/change-parameters/SKILL.md
@@ -190,31 +190,36 @@ given_species_params(params)$q <- NA       # let mizer re-derive q ...
 given_species_params(params)$gamma <- NA   # ... and gamma with it
 ```
 
-### A default is only consulted while the column is missing
+### Whether a value is given determines whether it is recalculated
 
-Defaults fill in `NA`s. Once a column exists in `species_params()` — which,
-after the model is built, is true of every parameter — the machinery that would
-have calculated it is bypassed. Two practical consequences:
+For derived parameters, `given_species_params()` distinguishes fixed input from
+a cached calculated value. In particular, `setExtMort()` recalculates `z0`
+wherever it is absent or `NA` in `given_species_params()`, even though an older
+calculated value is still present in `species_params()`. Two practical
+consequences:
 
 **Arguments that only feed a default work only while values are missing.**
-`setExtMort()` computes `z0 = z0pre * w_inf^z0exp`, but only for missing `z0`
-values. On a built model `z0` is already present, so supplying `z0pre` or
-`z0exp` normally cannot take effect and now gives a warning. `reset = TRUE`
-does not help: it clears the rate array's comment, not the species parameter.
-Set the species parameter instead:
+`setExtMort()` computes `z0 = z0pre * w_inf^z0exp` for non-given `z0` values.
+If `z0` is present in `given_species_params()` for every species, supplying
+`z0pre` or `z0exp` cannot take effect and gives a warning. `reset = TRUE` does
+not help: it clears the rate array's comment, not the given species parameter.
+To hand `z0` back to the calculation, set it to `NA` in
+`given_species_params()`:
 
 ```r
 sp <- species_params(params)
 z0exp <- resource_params(params)$n - 1   # the construction default
 sp$z0 <- 2 * sp$w_inf^z0exp
 species_params(params) <- sp
-# Setting `sp$z0 <- NA` instead hands it back to the default calculation.
+
+# Or hand z0 back to the default calculation.
+given_species_params(params)$z0 <- NA
 ```
 
-If you do remove or set some `z0` values to `NA`, an explicitly supplied
-`z0pre` or `z0exp` is used and the resulting values are recorded in
-`given_species_params()`. Values filled from the arguments' defaults are not
-recorded there.
+An explicitly supplied `z0pre` or `z0exp` is used for every non-given `z0` and
+the resulting values are recorded in `given_species_params()`. Values filled
+from the arguments' defaults are not recorded there and will be recalculated
+on the next call.
 
 **Giving a value switches off the calculation that would have used another one.**
 Mizer warns about three of these, but only from `given_species_params<-()` —

--- a/inst/skills/change-parameters/SKILL.md
+++ b/inst/skills/change-parameters/SKILL.md
@@ -196,16 +196,17 @@ Defaults fill in `NA`s. Once a column exists in `species_params()` — which,
 after the model is built, is true of every parameter — the machinery that would
 have calculated it is bypassed. Two practical consequences:
 
-**Arguments that only feed a default are dead after construction.**
-`setExtMort()` computes `z0 = z0pre * w_inf^z0exp`, but only for missing `z0`
-values. On a built model `z0` is always present, so `setExtMort(params, z0pre =
-2)` changes nothing at all — not even with `reset = TRUE`, which clears the rate
-array's comment and not the species parameter. Set the species parameter
-instead:
+**Arguments that only feed a default are construction-only.**
+`newMultispeciesParams()` computes `z0 = z0pre * w_inf^z0exp`, but only for
+missing `z0` values while the model is being built. The corresponding
+`setExtMort(z0pre = )` and `setExtMort(z0exp = )` arguments are deprecated:
+on a built model `z0` is already present, so they could not take effect—not
+even with `reset = TRUE`, which clears the rate array's comment and not the
+species parameter. Set the species parameter instead:
 
 ```r
 sp <- species_params(params)
-z0exp <- resource_params(params)$n - 1   # the exponent setExtMort() would use
+z0exp <- resource_params(params)$n - 1   # the construction default
 sp$z0 <- 2 * sp$w_inf^z0exp
 species_params(params) <- sp
 # Setting `sp$z0 <- NA` instead hands it back to the default calculation.

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -61,7 +61,7 @@ plots) are in the changelog and are not repeated here.
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
 | A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
 | Setting `f0 = 1` now errors even though `gamma` is supplied | every supplied target feeding level is now validated | `f0` is always validated (3.3) |
-| `setExtMort(z0pre = ...)`, `setExtMort(z0exp = ...)` or the same arguments to `setParams()` now warns | those arguments never changed an existing model | `z0pre` and `z0exp` are construction-only (3.3) |
+| `setExtMort(z0pre = ...)`, `setExtMort(z0exp = ...)` or the same arguments to `setParams()` now warns | `z0` was already complete, so the arguments were ignored | `setExtMort()` warns when `z0pre` or `z0exp` is ignored (3.3) |
 | `setParams()` or `setResource()` errors that it "does not have an argument" | unknown arguments are no longer silently ignored | `setParams()` rejects arguments it does not use (3.3) |
 | A `setParams(resource_rate = )` / `setParams(kappa = )` call that ran fine now errors | `setParams()` never set the resource; use `setResource()` | `setParams()` rejects arguments it does not use (3.3) |
 | A resource change made via `setParams()` never showed up in the model | the argument was silently dropped in every version before 3.3 | `setParams()` rejects arguments it does not use (3.3) |
@@ -385,21 +385,21 @@ If code now errors here, choose a physically attainable feeding level below 1.
 When `gamma` is the parameter you intend to control, omit the `f0` value or use
 a valid value; `gamma` will still take precedence (#517).
 
-### `z0pre` and `z0exp` are construction-only
+### `setExtMort()` warns when `z0pre` or `z0exp` is ignored
 
-The `z0pre` and `z0exp` arguments of `setExtMort()` are deprecated, as are the
-same arguments when passed through `setParams()`. They were used only to fill
-missing values of the `z0` species parameter. A built model already has `z0`
-for every species, so calls such as
+The `z0pre` and `z0exp` arguments of `setExtMort()` are used only to fill
+missing values of the `z0` species parameter. A built model normally already
+has `z0` for every species, so calls such as
 
 ```r
 params <- setExtMort(params, z0pre = 2)
 params <- setParams(params, z0exp = -0.25)
 ```
 
-were accepted but changed nothing. `reset = TRUE` did not help: it hands the
-external-mortality array back to the species parameters but does not remove
-the existing `z0` values.
+were accepted but changed nothing. They now warn that the arguments were
+ignored. `reset = TRUE` does not make them applicable: it hands the
+external-mortality array back to the species parameters but does not remove the
+existing `z0` values.
 
 Set `z0` explicitly when changing an existing model:
 
@@ -409,9 +409,11 @@ sp$z0 <- 2 * sp$w_inf^(-0.25)
 species_params(params) <- sp
 ```
 
-The `z0pre` and `z0exp` arguments of `newMultispeciesParams()` are not
-deprecated. There they still calculate missing `z0` values while the model is
-being constructed (#493).
+The arguments still work whenever `z0` is missing. If either argument was
+supplied explicitly, the calculated `z0` values are recorded in
+`given_species_params()` so that they survive later rebuilds. Values calculated
+from the default `z0pre = 0.6` and `z0exp = n - 1` remain calculated parameters
+and are not recorded there (#493).
 
 ### `setParams()` rejects arguments it does not use
 

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -61,6 +61,7 @@ plots) are in the changelog and are not repeated here.
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
 | A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
 | Setting `f0 = 1` now errors even though `gamma` is supplied | every supplied target feeding level is now validated | `f0` is always validated (3.3) |
+| `setExtMort(z0pre = ...)`, `setExtMort(z0exp = ...)` or the same arguments to `setParams()` now warns | those arguments never changed an existing model | `z0pre` and `z0exp` are construction-only (3.3) |
 | `setParams()` or `setResource()` errors that it "does not have an argument" | unknown arguments are no longer silently ignored | `setParams()` rejects arguments it does not use (3.3) |
 | A `setParams(resource_rate = )` / `setParams(kappa = )` call that ran fine now errors | `setParams()` never set the resource; use `setResource()` | `setParams()` rejects arguments it does not use (3.3) |
 | A resource change made via `setParams()` never showed up in the model | the argument was silently dropped in every version before 3.3 | `setParams()` rejects arguments it does not use (3.3) |
@@ -383,6 +384,34 @@ the same invalid `f0` could instead be accepted and ignored.
 If code now errors here, choose a physically attainable feeding level below 1.
 When `gamma` is the parameter you intend to control, omit the `f0` value or use
 a valid value; `gamma` will still take precedence (#517).
+
+### `z0pre` and `z0exp` are construction-only
+
+The `z0pre` and `z0exp` arguments of `setExtMort()` are deprecated, as are the
+same arguments when passed through `setParams()`. They were used only to fill
+missing values of the `z0` species parameter. A built model already has `z0`
+for every species, so calls such as
+
+```r
+params <- setExtMort(params, z0pre = 2)
+params <- setParams(params, z0exp = -0.25)
+```
+
+were accepted but changed nothing. `reset = TRUE` did not help: it hands the
+external-mortality array back to the species parameters but does not remove
+the existing `z0` values.
+
+Set `z0` explicitly when changing an existing model:
+
+```r
+sp <- species_params(params)
+sp$z0 <- 2 * sp$w_inf^(-0.25)
+species_params(params) <- sp
+```
+
+The `z0pre` and `z0exp` arguments of `newMultispeciesParams()` are not
+deprecated. There they still calculate missing `z0` values while the model is
+being constructed (#493).
 
 ### `setParams()` rejects arguments it does not use
 

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -61,7 +61,7 @@ plots) are in the changelog and are not repeated here.
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
 | A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
 | Setting `f0 = 1` now errors even though `gamma` is supplied | every supplied target feeding level is now validated | `f0` is always validated (3.3) |
-| `setExtMort(z0pre = ...)`, `setExtMort(z0exp = ...)` or the same arguments to `setParams()` now warns | `z0` was already complete, so the arguments were ignored | `setExtMort()` warns when `z0pre` or `z0exp` is ignored (3.3) |
+| `setExtMort(z0pre = ...)`, `setExtMort(z0exp = ...)` or the same arguments to `setParams()` now warns | `z0` was already present in `given_species_params()` for every species, so the arguments were ignored | `setExtMort()` warns when `z0pre` or `z0exp` is ignored (3.3) |
 | `setParams()` or `setResource()` errors that it "does not have an argument" | unknown arguments are no longer silently ignored | `setParams()` rejects arguments it does not use (3.3) |
 | A `setParams(resource_rate = )` / `setParams(kappa = )` call that ran fine now errors | `setParams()` never set the resource; use `setResource()` | `setParams()` rejects arguments it does not use (3.3) |
 | A resource change made via `setParams()` never showed up in the model | the argument was silently dropped in every version before 3.3 | `setParams()` rejects arguments it does not use (3.3) |
@@ -387,9 +387,9 @@ a valid value; `gamma` will still take precedence (#517).
 
 ### `setExtMort()` warns when `z0pre` or `z0exp` is ignored
 
-The `z0pre` and `z0exp` arguments of `setExtMort()` are used only to fill
-missing values of the `z0` species parameter. A built model normally already
-has `z0` for every species, so calls such as
+The `z0pre` and `z0exp` arguments of `setExtMort()` are used only to calculate
+values of the `z0` species parameter that are not present in
+`given_species_params()`. If `z0` is given for every species, calls such as
 
 ```r
 params <- setExtMort(params, z0pre = 2)
@@ -399,7 +399,7 @@ params <- setParams(params, z0exp = -0.25)
 were accepted but changed nothing. They now warn that the arguments were
 ignored. `reset = TRUE` does not make them applicable: it hands the
 external-mortality array back to the species parameters but does not remove the
-existing `z0` values.
+given `z0` values.
 
 Set `z0` explicitly when changing an existing model:
 
@@ -409,11 +409,12 @@ sp$z0 <- 2 * sp$w_inf^(-0.25)
 species_params(params) <- sp
 ```
 
-The arguments still work whenever `z0` is missing. If either argument was
-supplied explicitly, the calculated `z0` values are recorded in
-`given_species_params()` so that they survive later rebuilds. Values calculated
-from the default `z0pre = 0.6` and `z0exp = n - 1` remain calculated parameters
-and are not recorded there (#493).
+The arguments still work wherever `z0` is not given. A `z0` value present only
+in `species_params()` is the cached result of an earlier calculation and is
+recalculated. If either argument was supplied explicitly, the newly calculated
+`z0` values are recorded in `given_species_params()` so that they survive later
+rebuilds. Values calculated from the default `z0pre = 0.6` and
+`z0exp = n - 1` remain calculated parameters and are not recorded there (#493).
 
 ### `setParams()` rejects arguments it does not use
 

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -83,11 +83,11 @@ individual species by including a \code{p} column in the \code{species_params}.}
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
 
-\item{z0pre}{If \code{z0}, the mortality from other sources, is missing from the
-species parameter data frame, it is calculated as
+\item{z0pre}{If \code{z0}, the mortality from other sources, is not present in
+\code{\link[=given_species_params]{given_species_params()}}, it is calculated as
 \code{z0pre * w_inf ^ z0exp}. Default value is 0.6.}
 
-\item{z0exp}{The exponent used with \code{z0pre} to calculate missing \code{z0}.
+\item{z0exp}{The exponent used with \code{z0pre} to calculate non-given \code{z0}.
 Default value is \code{n - 1}.}
 
 \item{ext_encounter}{Optional. An array (species x size) holding the external
@@ -468,15 +468,16 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists. Missing
-values are calculated as
+column of \code{\link[=given_species_params]{given_species_params()}} if it is present there. Otherwise it is
+recalculated, even if a value from an earlier calculation is still present
+in \code{species_params}, as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-When \code{z0pre} or \code{z0exp} is supplied explicitly and used to fill missing
-\code{z0}, the resulting values are recorded in \code{\link[=given_species_params]{given_species_params()}}. Values
-calculated from the defaults \code{z0pre = 0.6} and \code{z0exp = n - 1} are not
-recorded there. If either argument is supplied but cannot be used because
-\code{z0} is already complete or because \code{ext_mort} was supplied, a warning is
-issued.
+When \code{z0pre} or \code{z0exp} is supplied explicitly and used to calculate
+non-given \code{z0}, the resulting values are recorded in
+\code{\link[=given_species_params]{given_species_params()}}. Values calculated from the defaults
+\code{z0pre = 0.6} and \code{z0exp = n - 1} are not recorded there. If either argument
+is supplied but cannot be used because \code{z0} is given for every species or
+because \code{ext_mort} was supplied, a warning is issued.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -83,11 +83,12 @@ individual species by including a \code{p} column in the \code{species_params}.}
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
 
-\item{z0pre}{If \code{z0} is missing from the species parameter data frame,
-calculate it as \code{z0pre * w_inf ^ z0exp}. Defaults to 0.6.}
+\item{z0pre}{If \code{z0}, the mortality from other sources, is missing from the
+species parameter data frame, it is calculated as
+\code{z0pre * w_inf ^ z0exp}. Default value is 0.6.}
 
-\item{z0exp}{The exponent used with \code{z0pre} to calculate a missing \code{z0}.
-Defaults to \code{n - 1}.}
+\item{z0exp}{The exponent used with \code{z0pre} to calculate missing \code{z0}.
+Default value is \code{n - 1}.}
 
 \item{ext_encounter}{Optional. An array (species x size) holding the external
 encounter rate.  If not supplied, a default is calculated from the \code{E_ext}
@@ -467,15 +468,15 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists. When a
-model is constructed with \code{\link[=newMultispeciesParams]{newMultispeciesParams()}}, missing values are
-calculated as
+column of the species parameter data frame, if that column exists. Missing
+values are calculated as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-using that constructor's \code{z0pre} and \code{z0exp} arguments. On an existing model,
-change \code{z0} with \code{\link[=species_params<-]{species_params<-()}} and let mizer recalculate the rate.
-If \code{z0} has been removed from the species parameters entirely,
-\code{setExtMort()} restores the construction defaults \code{z0pre = 0.6} and
-\code{z0exp = n - 1}.
+When \code{z0pre} or \code{z0exp} is supplied explicitly and used to fill missing
+\code{z0}, the resulting values are recorded in \code{\link[=given_species_params]{given_species_params()}}. Values
+calculated from the defaults \code{z0pre = 0.6} and \code{z0exp = n - 1} are not
+recorded there. If either argument is supplied but cannot be used because
+\code{z0} is already complete or because \code{ext_mort} was supplied, a warning is
+issued.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -83,13 +83,11 @@ individual species by including a \code{p} column in the \code{species_params}.}
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
 
-\item{z0pre}{If \code{z0}, the mortality from other sources, is not a column
-in the species data frame, it is calculated as z0pre * w_inf ^ z0exp.
-Default value is 0.6.}
+\item{z0pre}{If \code{z0} is missing from the species parameter data frame,
+calculate it as \code{z0pre * w_inf ^ z0exp}. Defaults to 0.6.}
 
-\item{z0exp}{If \code{z0}, the mortality from other sources, is not a column in
-the species data frame, it is calculated as \code{z0pre * w_inf ^ z0exp}.
-Default value is \code{n-1}.}
+\item{z0exp}{The exponent used with \code{z0pre} to calculate a missing \code{z0}.
+Defaults to \code{n - 1}.}
 
 \item{ext_encounter}{Optional. An array (species x size) holding the external
 encounter rate.  If not supplied, a default is calculated from the \code{E_ext}
@@ -469,9 +467,15 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists.
-Otherwise it is calculated as
+column of the species parameter data frame, if that column exists. When a
+model is constructed with \code{\link[=newMultispeciesParams]{newMultispeciesParams()}}, missing values are
+calculated as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
+using that constructor's \code{z0pre} and \code{z0exp} arguments. On an existing model,
+change \code{z0} with \code{\link[=species_params<-]{species_params<-()}} and let mizer recalculate the rate.
+If \code{z0} has been removed from the species parameters entirely,
+\code{setExtMort()} restores the construction defaults \code{z0pre = 0.6} and
+\code{z0exp = n - 1}.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/setExtMort.Rd
+++ b/man/setExtMort.Rd
@@ -9,8 +9,8 @@
 setExtMort(
   params,
   ext_mort = NULL,
-  z0pre = deprecated(),
-  z0exp = deprecated(),
+  z0pre = 0.6,
+  z0exp = params@resource_params$n - 1,
   reset = FALSE,
   z0 = deprecated(),
   ...
@@ -27,13 +27,12 @@ ext_mort(params) <- value
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
 
-\item{z0pre}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
-parameter instead. The argument remains available on
-\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
+\item{z0pre}{If \code{z0}, the mortality from other sources, is missing from the
+species parameter data frame, it is calculated as
+\code{z0pre * w_inf ^ z0exp}. Default value is 0.6.}
 
-\item{z0exp}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
-parameter instead. The argument remains available on
-\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
+\item{z0exp}{The exponent used with \code{z0pre} to calculate missing \code{z0}.
+Default value is \code{n - 1}.}
 
 \item{reset}{If set to TRUE, then the external mortality rate will be reset
 to the value calculated from the species parameters, even if it was
@@ -80,15 +79,15 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists. When a
-model is constructed with \code{\link[=newMultispeciesParams]{newMultispeciesParams()}}, missing values are
-calculated as
+column of the species parameter data frame, if that column exists. Missing
+values are calculated as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-using that constructor's \code{z0pre} and \code{z0exp} arguments. On an existing model,
-change \code{z0} with \code{\link[=species_params<-]{species_params<-()}} and let mizer recalculate the rate.
-If \code{z0} has been removed from the species parameters entirely,
-\code{setExtMort()} restores the construction defaults \code{z0pre = 0.6} and
-\code{z0exp = n - 1}.
+When \code{z0pre} or \code{z0exp} is supplied explicitly and used to fill missing
+\code{z0}, the resulting values are recorded in \code{\link[=given_species_params]{given_species_params()}}. Values
+calculated from the defaults \code{z0pre = 0.6} and \code{z0exp = n - 1} are not
+recorded there. If either argument is supplied but cannot be used because
+\code{z0} is already complete or because \code{ext_mort} was supplied, a warning is
+issued.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/setExtMort.Rd
+++ b/man/setExtMort.Rd
@@ -9,8 +9,8 @@
 setExtMort(
   params,
   ext_mort = NULL,
-  z0pre = 0.6,
-  z0exp = params@resource_params$n - 1,
+  z0pre = deprecated(),
+  z0exp = deprecated(),
   reset = FALSE,
   z0 = deprecated(),
   ...
@@ -27,13 +27,13 @@ ext_mort(params) <- value
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
 
-\item{z0pre}{If \code{z0}, the mortality from other sources, is not a column
-in the species data frame, it is calculated as z0pre * w_inf ^ z0exp.
-Default value is 0.6.}
+\item{z0pre}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
+parameter instead. The argument remains available on
+\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
 
-\item{z0exp}{If \code{z0}, the mortality from other sources, is not a column in
-the species data frame, it is calculated as \code{z0pre * w_inf ^ z0exp}.
-Default value is \code{n-1}.}
+\item{z0exp}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
+parameter instead. The argument remains available on
+\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
 
 \item{reset}{If set to TRUE, then the external mortality rate will be reset
 to the value calculated from the species parameters, even if it was
@@ -80,9 +80,15 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists.
-Otherwise it is calculated as
+column of the species parameter data frame, if that column exists. When a
+model is constructed with \code{\link[=newMultispeciesParams]{newMultispeciesParams()}}, missing values are
+calculated as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
+using that constructor's \code{z0pre} and \code{z0exp} arguments. On an existing model,
+change \code{z0} with \code{\link[=species_params<-]{species_params<-()}} and let mizer recalculate the rate.
+If \code{z0} has been removed from the species parameters entirely,
+\code{setExtMort()} restores the construction defaults \code{z0pre = 0.6} and
+\code{z0exp = n - 1}.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/setExtMort.Rd
+++ b/man/setExtMort.Rd
@@ -27,11 +27,11 @@ ext_mort(params) <- value
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
 
-\item{z0pre}{If \code{z0}, the mortality from other sources, is missing from the
-species parameter data frame, it is calculated as
+\item{z0pre}{If \code{z0}, the mortality from other sources, is not present in
+\code{\link[=given_species_params]{given_species_params()}}, it is calculated as
 \code{z0pre * w_inf ^ z0exp}. Default value is 0.6.}
 
-\item{z0exp}{The exponent used with \code{z0pre} to calculate missing \code{z0}.
+\item{z0exp}{The exponent used with \code{z0pre} to calculate non-given \code{z0}.
 Default value is \code{n - 1}.}
 
 \item{reset}{If set to TRUE, then the external mortality rate will be reset
@@ -79,15 +79,16 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists. Missing
-values are calculated as
+column of \code{\link[=given_species_params]{given_species_params()}} if it is present there. Otherwise it is
+recalculated, even if a value from an earlier calculation is still present
+in \code{species_params}, as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-When \code{z0pre} or \code{z0exp} is supplied explicitly and used to fill missing
-\code{z0}, the resulting values are recorded in \code{\link[=given_species_params]{given_species_params()}}. Values
-calculated from the defaults \code{z0pre = 0.6} and \code{z0exp = n - 1} are not
-recorded there. If either argument is supplied but cannot be used because
-\code{z0} is already complete or because \code{ext_mort} was supplied, a warning is
-issued.
+When \code{z0pre} or \code{z0exp} is supplied explicitly and used to calculate
+non-given \code{z0}, the resulting values are recorded in
+\code{\link[=given_species_params]{given_species_params()}}. Values calculated from the defaults
+\code{z0pre = 0.6} and \code{z0exp = n - 1} are not recorded there. If either argument
+is supplied but cannot be used because \code{z0} is given for every species or
+because \code{ext_mort} was supplied, a warning is issued.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/setParams.Rd
+++ b/man/setParams.Rd
@@ -47,12 +47,11 @@ the section "Setting metabolic rate".}
     \item{\code{ext_mort}}{Optional. An array (species x size) holding the external
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
-    \item{\code{z0pre}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
-parameter instead. The argument remains available on
-\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
-    \item{\code{z0exp}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
-parameter instead. The argument remains available on
-\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
+    \item{\code{z0pre}}{If \code{z0}, the mortality from other sources, is missing from the
+species parameter data frame, it is calculated as
+\code{z0pre * w_inf ^ z0exp}. Default value is 0.6.}
+    \item{\code{z0exp}}{The exponent used with \code{z0pre} to calculate missing \code{z0}.
+Default value is \code{n - 1}.}
     \item{\code{z0}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{ext_mort} instead. Not to
 be confused with the species_parameter \code{z0}.}
     \item{\code{ext_encounter}}{Optional. An array (species x size) holding the external
@@ -364,15 +363,15 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists. When a
-model is constructed with \code{\link[=newMultispeciesParams]{newMultispeciesParams()}}, missing values are
-calculated as
+column of the species parameter data frame, if that column exists. Missing
+values are calculated as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-using that constructor's \code{z0pre} and \code{z0exp} arguments. On an existing model,
-change \code{z0} with \code{\link[=species_params<-]{species_params<-()}} and let mizer recalculate the rate.
-If \code{z0} has been removed from the species parameters entirely,
-\code{setExtMort()} restores the construction defaults \code{z0pre = 0.6} and
-\code{z0exp = n - 1}.
+When \code{z0pre} or \code{z0exp} is supplied explicitly and used to fill missing
+\code{z0}, the resulting values are recorded in \code{\link[=given_species_params]{given_species_params()}}. Values
+calculated from the defaults \code{z0pre = 0.6} and \code{z0exp = n - 1} are not
+recorded there. If either argument is supplied but cannot be used because
+\code{z0} is already complete or because \code{ext_mort} was supplied, a warning is
+issued.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/setParams.Rd
+++ b/man/setParams.Rd
@@ -47,12 +47,12 @@ the section "Setting metabolic rate".}
     \item{\code{ext_mort}}{Optional. An array (species x size) holding the external
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
-    \item{\code{z0pre}}{If \code{z0}, the mortality from other sources, is not a column
-in the species data frame, it is calculated as z0pre * w_inf ^ z0exp.
-Default value is 0.6.}
-    \item{\code{z0exp}}{If \code{z0}, the mortality from other sources, is not a column in
-the species data frame, it is calculated as \code{z0pre * w_inf ^ z0exp}.
-Default value is \code{n-1}.}
+    \item{\code{z0pre}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
+parameter instead. The argument remains available on
+\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
+    \item{\code{z0exp}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Set the \code{z0} species
+parameter instead. The argument remains available on
+\code{\link[=newMultispeciesParams]{newMultispeciesParams()}} for use while constructing a model.}
     \item{\code{z0}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{ext_mort} instead. Not to
 be confused with the species_parameter \code{z0}.}
     \item{\code{ext_encounter}}{Optional. An array (species x size) holding the external
@@ -364,9 +364,15 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists.
-Otherwise it is calculated as
+column of the species parameter data frame, if that column exists. When a
+model is constructed with \code{\link[=newMultispeciesParams]{newMultispeciesParams()}}, missing values are
+calculated as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
+using that constructor's \code{z0pre} and \code{z0exp} arguments. On an existing model,
+change \code{z0} with \code{\link[=species_params<-]{species_params<-()}} and let mizer recalculate the rate.
+If \code{z0} has been removed from the species parameters entirely,
+\code{setExtMort()} restores the construction defaults \code{z0pre = 0.6} and
+\code{z0exp = n - 1}.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/man/setParams.Rd
+++ b/man/setParams.Rd
@@ -47,10 +47,10 @@ the section "Setting metabolic rate".}
     \item{\code{ext_mort}}{Optional. An array (species x size) holding the external
 mortality rate.  If not supplied, a default is set as described in the
 section "Setting external mortality rate".}
-    \item{\code{z0pre}}{If \code{z0}, the mortality from other sources, is missing from the
-species parameter data frame, it is calculated as
+    \item{\code{z0pre}}{If \code{z0}, the mortality from other sources, is not present in
+\code{\link[=given_species_params]{given_species_params()}}, it is calculated as
 \code{z0pre * w_inf ^ z0exp}. Default value is 0.6.}
-    \item{\code{z0exp}}{The exponent used with \code{z0pre} to calculate missing \code{z0}.
+    \item{\code{z0exp}}{The exponent used with \code{z0pre} to calculate non-given \code{z0}.
 Default value is \code{n - 1}.}
     \item{\code{z0}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{ext_mort} instead. Not to
 be confused with the species_parameter \code{z0}.}
@@ -363,15 +363,16 @@ If the \code{ext_mort} argument is not supplied, then the external mortality is
 taken from the species parameters as
 \deqn{\mu_{ext.i}(w) = z_{0.i} + z_{ext.i} w^{d_i}.}{mu_ext,i(w) = z0_i + z_ext,i w ^ d_i.}
 The value of the constant \eqn{z_0} for each species is taken from the \code{z0}
-column of the species parameter data frame, if that column exists. Missing
-values are calculated as
+column of \code{\link[=given_species_params]{given_species_params()}} if it is present there. Otherwise it is
+recalculated, even if a value from an earlier calculation is still present
+in \code{species_params}, as
 \deqn{z_{0.i} = {\tt z0pre}_i\, w_{inf}^{\tt z0exp}.}{z_{0.i} = z0pre_i w_{inf}^{z0exp}.}
-When \code{z0pre} or \code{z0exp} is supplied explicitly and used to fill missing
-\code{z0}, the resulting values are recorded in \code{\link[=given_species_params]{given_species_params()}}. Values
-calculated from the defaults \code{z0pre = 0.6} and \code{z0exp = n - 1} are not
-recorded there. If either argument is supplied but cannot be used because
-\code{z0} is already complete or because \code{ext_mort} was supplied, a warning is
-issued.
+When \code{z0pre} or \code{z0exp} is supplied explicitly and used to calculate
+non-given \code{z0}, the resulting values are recorded in
+\code{\link[=given_species_params]{given_species_params()}}. Values calculated from the defaults
+\code{z0pre = 0.6} and \code{z0exp = n - 1} are not recorded there. If either argument
+is supplied but cannot be used because \code{z0} is given for every species or
+because \code{ext_mort} was supplied, a warning is issued.
 Missing values of \code{z_ext} are set to 0 and missing values of \code{d} are set to
 \code{n - 1}.
 

--- a/tests/testthat/test-newMultispeciesParams.R
+++ b/tests/testthat/test-newMultispeciesParams.R
@@ -148,6 +148,23 @@ test_that("constructor records z0 only when z0 arguments are explicit", {
     defaults <- suppressMessages(newMultispeciesParams(sp, no_w = 20))
     expect_false("z0" %in% names(given_species_params(defaults)))
 
+    # Each argument is forwarded independently to setExtMort().
+    pre_only <- suppressMessages(newMultispeciesParams(
+        sp, z0pre = 2, no_w = 20))
+    expected_pre <- 2 * sp$w_inf^(2 / 3 - 1)
+    expect_equal(species_params(pre_only)$z0, expected_pre,
+                 ignore_attr = TRUE)
+    expect_equal(given_species_params(pre_only)$z0, expected_pre,
+                 ignore_attr = TRUE)
+
+    exp_only <- suppressMessages(newMultispeciesParams(
+        sp, z0exp = -0.5, no_w = 20))
+    expected_exp <- 0.6 * sp$w_inf^(-0.5)
+    expect_equal(species_params(exp_only)$z0, expected_exp,
+                 ignore_attr = TRUE)
+    expect_equal(given_species_params(exp_only)$z0, expected_exp,
+                 ignore_attr = TRUE)
+
     expect_no_warning(params <- suppressMessages(
         newMultispeciesParams(sp, z0pre = 2, z0exp = -0.5, no_w = 20)))
 

--- a/tests/testthat/test-newMultispeciesParams.R
+++ b/tests/testthat/test-newMultispeciesParams.R
@@ -132,21 +132,28 @@ test_that("setParams rejects arguments it does not use", {
     # Unnamed arguments beyond `interaction` and `info_level` are rejected
     expect_error(setParams(params, NULL, 0, 1),
                  "must be named")
-    # Deprecated setter arguments are still recognised during transition
+    # Setter arguments are still recognised and warn when they are ignored.
     expect_warning(setParams(params, z0pre = 0.5,
                              RDD = "BevertonHoltRDD", info_level = 0),
-                   "deprecated")
+                   NA)
+    expect_warning(setParams(params, z0pre = 0.5,
+                             RDD = "BevertonHoltRDD", info_level = 1),
+                   "ignored because the `z0` species parameter is already set")
 })
 
-test_that("z0pre and z0exp remain construction arguments", {
+test_that("constructor records z0 only when z0 arguments are explicit", {
     sp <- data.frame(species = c("a", "b"), w_inf = c(100, 1000))
+
+    defaults <- suppressMessages(newMultispeciesParams(sp, no_w = 20))
+    expect_false("z0" %in% names(given_species_params(defaults)))
 
     expect_no_warning(params <- suppressMessages(
         newMultispeciesParams(sp, z0pre = 2, z0exp = -0.5, no_w = 20)))
 
     expected <- 2 * sp$w_inf^(-0.5)
     expect_equal(species_params(params)$z0, expected, ignore_attr = TRUE)
-    expect_false("z0" %in% names(given_species_params(params)))
+    expect_equal(given_species_params(params)$z0, expected,
+                 ignore_attr = TRUE)
     expect_equal(params@mu_b,
                  outer(expected, rep(1, length(params@w))),
                  ignore_attr = TRUE)
@@ -158,8 +165,14 @@ test_that("z0pre and z0exp remain construction arguments", {
         sp, z0pre = 2, z0exp = -0.5, no_w = 20))
     expect_equal(species_params(params)$z0, c(0.1, expected[[2]]),
                  ignore_attr = TRUE)
-    expect_equal(given_species_params(params)$z0, c(0.1, NA),
+    expect_equal(given_species_params(params)$z0, c(0.1, expected[[2]]),
                  ignore_attr = TRUE)
+
+    # Explicit default arguments are still given arguments.
+    params <- suppressMessages(newMultispeciesParams(
+        sp[c("species", "w_inf")], z0pre = 0.6, no_w = 20))
+    expect_equal(given_species_params(params)$z0,
+                 species_params(params)$z0, ignore_attr = TRUE)
 })
 
 test_that("setParams passes reset on to all the setters", {

--- a/tests/testthat/test-newMultispeciesParams.R
+++ b/tests/testthat/test-newMultispeciesParams.R
@@ -132,9 +132,34 @@ test_that("setParams rejects arguments it does not use", {
     # Unnamed arguments beyond `interaction` and `info_level` are rejected
     expect_error(setParams(params, NULL, 0, 1),
                  "must be named")
-    # Arguments the setters do accept are fine
-    expect_no_error(setParams(params, z0pre = 0.5, RDD = "BevertonHoltRDD",
-                              info_level = 0))
+    # Deprecated setter arguments are still recognised during transition
+    expect_warning(setParams(params, z0pre = 0.5,
+                             RDD = "BevertonHoltRDD", info_level = 0),
+                   "deprecated")
+})
+
+test_that("z0pre and z0exp remain construction arguments", {
+    sp <- data.frame(species = c("a", "b"), w_inf = c(100, 1000))
+
+    expect_no_warning(params <- suppressMessages(
+        newMultispeciesParams(sp, z0pre = 2, z0exp = -0.5, no_w = 20)))
+
+    expected <- 2 * sp$w_inf^(-0.5)
+    expect_equal(species_params(params)$z0, expected, ignore_attr = TRUE)
+    expect_false("z0" %in% names(given_species_params(params)))
+    expect_equal(params@mu_b,
+                 outer(expected, rep(1, length(params@w))),
+                 ignore_attr = TRUE)
+
+    # Explicit z0 values still win, while only missing entries use the
+    # construction arguments.
+    sp$z0 <- c(0.1, NA)
+    params <- suppressMessages(newMultispeciesParams(
+        sp, z0pre = 2, z0exp = -0.5, no_w = 20))
+    expect_equal(species_params(params)$z0, c(0.1, expected[[2]]),
+                 ignore_attr = TRUE)
+    expect_equal(given_species_params(params)$z0, c(0.1, NA),
+                 ignore_attr = TRUE)
 })
 
 test_that("setParams passes reset on to all the setters", {

--- a/tests/testthat/test-newMultispeciesParams.R
+++ b/tests/testthat/test-newMultispeciesParams.R
@@ -133,12 +133,13 @@ test_that("setParams rejects arguments it does not use", {
     expect_error(setParams(params, NULL, 0, 1),
                  "must be named")
     # Setter arguments are still recognised and warn when they are ignored.
+    params@given_species_params$z0 <- params@species_params$z0
     expect_warning(setParams(params, z0pre = 0.5,
                              RDD = "BevertonHoltRDD", info_level = 0),
                    NA)
     expect_warning(setParams(params, z0pre = 0.5,
                              RDD = "BevertonHoltRDD", info_level = 1),
-                   "ignored because the `z0` species parameter is already set")
+                   "already present in `given_species_params` for every species")
 })
 
 test_that("constructor records z0 only when z0 arguments are explicit", {

--- a/tests/testthat/test-setExtMort.R
+++ b/tests/testthat/test-setExtMort.R
@@ -4,6 +4,7 @@ params <- NS_params_small
 test_that("setExtMort works", {
     params <- NS_params_small
     params@species_params$z0 <- 2 * params@species_params$z0
+    params@given_species_params$z0 <- params@species_params$z0
     p2 <- setExtMort(params)
     expect_equal(p2@mu_b, 2 * params@mu_b, ignore_attr = TRUE)
     # only mu_b changed
@@ -26,6 +27,7 @@ test_that("setExtMort works", {
 test_that("setExtMort uses z_ext and d species parameters", {
     params <- NS_params_small
     params@species_params$z0 <- rep(0.2, nrow(params@species_params))
+    params@given_species_params$z0 <- params@species_params$z0
     params@species_params$z_ext <- seq_len(nrow(params@species_params)) / 10
     params@species_params$d <- seq(-0.25, by = 0.01,
                                    length.out = nrow(params@species_params))
@@ -56,14 +58,27 @@ test_that("setExtMort defaults z_ext to 0 and d to n - 1", {
 
 test_that("setExtMort warns when z0pre or z0exp is ignored", {
     params <- NS_params_small
+    params@given_species_params$z0 <- params@species_params$z0
 
     expect_warning(p2 <- setExtMort(params, z0pre = 2),
-                   "ignored because the `z0` species parameter is already set")
+                   "already present in `given_species_params` for every species")
     expect_equal(p2@mu_b, params@mu_b, ignore_attr = TRUE)
     expect_warning(setExtMort(params, z0exp = -0.5),
-                   "ignored because the `z0` species parameter is already set")
+                   "already present in `given_species_params` for every species")
     expect_warning(setExtMort(params, ext_mort = params@mu_b, z0pre = 2),
                    "ignored because `ext_mort` was supplied")
+})
+
+test_that("setExtMort recalculates z0 that is not given", {
+    params <- NS_params_small
+    expect_false("z0" %in% names(params@given_species_params))
+    params@species_params$z0 <- 99
+
+    p2 <- setExtMort(params)
+    expected <- 0.6 * p2@species_params$w_inf^(
+        p2@resource_params$n - 1)
+    expect_equal(p2@species_params$z0, expected, ignore_attr = TRUE)
+    expect_false("z0" %in% names(p2@given_species_params))
 })
 
 test_that("setExtMort records z0 calculated from explicit arguments", {
@@ -84,11 +99,14 @@ test_that("setExtMort records z0 calculated from explicit arguments", {
     params <- NS_params_small
     original_z0 <- params@species_params$z0
     params@species_params$z0[[2]] <- NA
-    params@given_species_params$z0 <- NULL
+    params@given_species_params$z0 <- original_z0
+    params@given_species_params$z0[[2]] <- NA
     p4 <- setExtMort(params, z0pre = 2, z0exp = -0.5)
     expect_equal(p4@species_params$z0[[1]], original_z0[[1]])
     expect_equal(p4@given_species_params$z0,
-                 c(NA, 2 * p4@species_params$w_inf[[2]]^(-0.5), NA),
+                 c(original_z0[[1]],
+                   2 * p4@species_params$w_inf[[2]]^(-0.5),
+                   original_z0[[3]]),
                  ignore_attr = TRUE)
 })
 
@@ -113,6 +131,7 @@ test_that("Comment works on mu_b", {
     expect_message(setExtMort(params), NA)
     # but message when a change is not stored due to comment
     params@species_params$z0 <- 1
+    params@given_species_params$z0 <- params@species_params$z0
     expect_message(setExtMort(params),  "has been set manually")
     # Can reset
     p <- setExtMort(params, reset = TRUE)
@@ -126,6 +145,7 @@ test_that("Comment works on mu_b", {
 test_that("setExtMort bin_average path matches the analytic closed form", {
     params <- NS_params_small
     params@species_params$z0 <- rep(0.2, nrow(params@species_params))
+    params@given_species_params$z0 <- params@species_params$z0
     params@species_params$z_ext <- seq_len(nrow(params@species_params)) / 10
     params@species_params$d <- seq(-1, by = 0.3,
                                    length.out = nrow(params@species_params))
@@ -155,6 +175,7 @@ test_that("setExtMort bin_average path matches the analytic closed form", {
 test_that("setExtMort default (point-sampling) path is unchanged", {
     params <- NS_params_small
     params@species_params$z0 <- rep(0.2, nrow(params@species_params))
+    params@given_species_params$z0 <- params@species_params$z0
     params@species_params$z_ext <- seq_len(nrow(params@species_params)) / 10
     params@species_params$d <- seq(-0.25, by = 0.01,
                                    length.out = nrow(params@species_params))

--- a/tests/testthat/test-setExtMort.R
+++ b/tests/testthat/test-setExtMort.R
@@ -54,6 +54,27 @@ test_that("setExtMort defaults z_ext to 0 and d to n - 1", {
     expect_equal(p2@species_params$d, p2@species_params$n - 1)
 })
 
+test_that("setExtMort construction arguments are deprecated", {
+    params <- NS_params_small
+
+    expect_warning(p2 <- setExtMort(params, z0pre = 2), "deprecated")
+    expect_equal(p2@mu_b, params@mu_b, ignore_attr = TRUE)
+    expect_warning(setExtMort(params, z0exp = -0.5), "deprecated")
+
+    # Setting the species parameter is the replacement and does work.
+    species_params(params)$z0 <-
+        2 * species_params(params)$w_inf^(-0.5)
+    expect_false(isTRUE(all.equal(c(params@mu_b), c(NS_params_small@mu_b))))
+
+    # The deprecated arguments still supply the default if package code calls
+    # the setter with an incomplete species parameter table during transition.
+    params <- NS_params_small
+    params@species_params$z0 <- NULL
+    p3 <- suppressWarnings(setExtMort(params, z0pre = 2, z0exp = -0.5))
+    expect_equal(p3@species_params$z0,
+                 2 * p3@species_params$w_inf^(-0.5), ignore_attr = TRUE)
+})
+
 test_that("Comment works on mu_b", {
     params <- NS_params_small
     # if no comment, it is set automatically

--- a/tests/testthat/test-setExtMort.R
+++ b/tests/testthat/test-setExtMort.R
@@ -54,25 +54,42 @@ test_that("setExtMort defaults z_ext to 0 and d to n - 1", {
     expect_equal(p2@species_params$d, p2@species_params$n - 1)
 })
 
-test_that("setExtMort construction arguments are deprecated", {
+test_that("setExtMort warns when z0pre or z0exp is ignored", {
     params <- NS_params_small
 
-    expect_warning(p2 <- setExtMort(params, z0pre = 2), "deprecated")
+    expect_warning(p2 <- setExtMort(params, z0pre = 2),
+                   "ignored because the `z0` species parameter is already set")
     expect_equal(p2@mu_b, params@mu_b, ignore_attr = TRUE)
-    expect_warning(setExtMort(params, z0exp = -0.5), "deprecated")
+    expect_warning(setExtMort(params, z0exp = -0.5),
+                   "ignored because the `z0` species parameter is already set")
+    expect_warning(setExtMort(params, ext_mort = params@mu_b, z0pre = 2),
+                   "ignored because `ext_mort` was supplied")
+})
 
-    # Setting the species parameter is the replacement and does work.
-    species_params(params)$z0 <-
-        2 * species_params(params)$w_inf^(-0.5)
-    expect_false(isTRUE(all.equal(c(params@mu_b), c(NS_params_small@mu_b))))
-
-    # The deprecated arguments still supply the default if package code calls
-    # the setter with an incomplete species parameter table during transition.
+test_that("setExtMort records z0 calculated from explicit arguments", {
     params <- NS_params_small
     params@species_params$z0 <- NULL
-    p3 <- suppressWarnings(setExtMort(params, z0pre = 2, z0exp = -0.5))
-    expect_equal(p3@species_params$z0,
-                 2 * p3@species_params$w_inf^(-0.5), ignore_attr = TRUE)
+    params@given_species_params$z0 <- NULL
+
+    p2 <- setExtMort(params, z0pre = 2, z0exp = -0.5)
+    expected <- 2 * p2@species_params$w_inf^(-0.5)
+    expect_equal(p2@species_params$z0, expected, ignore_attr = TRUE)
+    expect_equal(p2@given_species_params$z0, expected, ignore_attr = TRUE)
+
+    # Values calculated from the argument defaults are not given parameters.
+    p3 <- setExtMort(params)
+    expect_false("z0" %in% names(p3@given_species_params))
+
+    # Only missing entries are calculated and recorded.
+    params <- NS_params_small
+    original_z0 <- params@species_params$z0
+    params@species_params$z0[[2]] <- NA
+    params@given_species_params$z0 <- NULL
+    p4 <- setExtMort(params, z0pre = 2, z0exp = -0.5)
+    expect_equal(p4@species_params$z0[[1]], original_z0[[1]])
+    expect_equal(p4@given_species_params$z0,
+                 c(NA, 2 * p4@species_params$w_inf[[2]]^(-0.5), NA),
+                 ignore_attr = TRUE)
 })
 
 test_that("Comment works on mu_b", {

--- a/vignettes/cheatsheet-changing-parameters.Rmd
+++ b/vignettes/cheatsheet-changing-parameters.Rmd
@@ -210,16 +210,17 @@ Defaults fill in `NA`s. Once a column exists in `species_params()` — which,
 after the model is built, is true of every parameter — the machinery that would
 have calculated it is bypassed. Two practical consequences:
 
-**Arguments that only feed a default are dead after construction.**
-`setExtMort()` computes `z0 = z0pre * w_inf^z0exp`, but only for missing `z0`
-values. On a built model `z0` is always present, so `setExtMort(params, z0pre =
-2)` changes nothing at all — not even with `reset = TRUE`, which clears the rate
-array's comment and not the species parameter. Set the species parameter
-instead:
+**Arguments that only feed a default are construction-only.**
+[`newMultispeciesParams()`](../reference/newMultispeciesParams.html) computes `z0 = z0pre * w_inf^z0exp`, but only for
+missing `z0` values while the model is being built. The corresponding
+`setExtMort(z0pre = )` and `setExtMort(z0exp = )` arguments are deprecated:
+on a built model `z0` is already present, so they could not take effect—not
+even with `reset = TRUE`, which clears the rate array's comment and not the
+species parameter. Set the species parameter instead:
 
 ```{r eval=FALSE}
 sp <- species_params(params)
-z0exp <- resource_params(params)$n - 1   # the exponent setExtMort() would use
+z0exp <- resource_params(params)$n - 1   # the construction default
 sp$z0 <- 2 * sp$w_inf^z0exp
 species_params(params) <- sp
 # Setting `sp$z0 <- NA` instead hands it back to the default calculation.

--- a/vignettes/cheatsheet-changing-parameters.Rmd
+++ b/vignettes/cheatsheet-changing-parameters.Rmd
@@ -210,13 +210,12 @@ Defaults fill in `NA`s. Once a column exists in `species_params()` — which,
 after the model is built, is true of every parameter — the machinery that would
 have calculated it is bypassed. Two practical consequences:
 
-**Arguments that only feed a default are construction-only.**
-[`newMultispeciesParams()`](../reference/newMultispeciesParams.html) computes `z0 = z0pre * w_inf^z0exp`, but only for
-missing `z0` values while the model is being built. The corresponding
-`setExtMort(z0pre = )` and `setExtMort(z0exp = )` arguments are deprecated:
-on a built model `z0` is already present, so they could not take effect—not
-even with `reset = TRUE`, which clears the rate array's comment and not the
-species parameter. Set the species parameter instead:
+**Arguments that only feed a default work only while values are missing.**
+`setExtMort()` computes `z0 = z0pre * w_inf^z0exp`, but only for missing `z0`
+values. On a built model `z0` is already present, so supplying `z0pre` or
+`z0exp` normally cannot take effect and now gives a warning. `reset = TRUE`
+does not help: it clears the rate array's comment, not the species parameter.
+Set the species parameter instead:
 
 ```{r eval=FALSE}
 sp <- species_params(params)
@@ -225,6 +224,11 @@ sp$z0 <- 2 * sp$w_inf^z0exp
 species_params(params) <- sp
 # Setting `sp$z0 <- NA` instead hands it back to the default calculation.
 ```
+
+If you do remove or set some `z0` values to `NA`, an explicitly supplied
+`z0pre` or `z0exp` is used and the resulting values are recorded in
+`given_species_params()`. Values filled from the arguments' defaults are not
+recorded there.
 
 **Giving a value switches off the calculation that would have used another one.**
 Mizer warns about three of these, but only from `given_species_params<-()` —

--- a/vignettes/cheatsheet-changing-parameters.Rmd
+++ b/vignettes/cheatsheet-changing-parameters.Rmd
@@ -204,31 +204,36 @@ given_species_params(params)$q <- NA       # let mizer re-derive q ...
 given_species_params(params)$gamma <- NA   # ... and gamma with it
 ```
 
-### A default is only consulted while the column is missing
+### Whether a value is given determines whether it is recalculated
 
-Defaults fill in `NA`s. Once a column exists in `species_params()` — which,
-after the model is built, is true of every parameter — the machinery that would
-have calculated it is bypassed. Two practical consequences:
+For derived parameters, `given_species_params()` distinguishes fixed input from
+a cached calculated value. In particular, `setExtMort()` recalculates `z0`
+wherever it is absent or `NA` in `given_species_params()`, even though an older
+calculated value is still present in `species_params()`. Two practical
+consequences:
 
 **Arguments that only feed a default work only while values are missing.**
-`setExtMort()` computes `z0 = z0pre * w_inf^z0exp`, but only for missing `z0`
-values. On a built model `z0` is already present, so supplying `z0pre` or
-`z0exp` normally cannot take effect and now gives a warning. `reset = TRUE`
-does not help: it clears the rate array's comment, not the species parameter.
-Set the species parameter instead:
+`setExtMort()` computes `z0 = z0pre * w_inf^z0exp` for non-given `z0` values.
+If `z0` is present in `given_species_params()` for every species, supplying
+`z0pre` or `z0exp` cannot take effect and gives a warning. `reset = TRUE` does
+not help: it clears the rate array's comment, not the given species parameter.
+To hand `z0` back to the calculation, set it to `NA` in
+`given_species_params()`:
 
 ```{r eval=FALSE}
 sp <- species_params(params)
 z0exp <- resource_params(params)$n - 1   # the construction default
 sp$z0 <- 2 * sp$w_inf^z0exp
 species_params(params) <- sp
-# Setting `sp$z0 <- NA` instead hands it back to the default calculation.
+
+# Or hand z0 back to the default calculation.
+given_species_params(params)$z0 <- NA
 ```
 
-If you do remove or set some `z0` values to `NA`, an explicitly supplied
-`z0pre` or `z0exp` is used and the resulting values are recorded in
-`given_species_params()`. Values filled from the arguments' defaults are not
-recorded there.
+An explicitly supplied `z0pre` or `z0exp` is used for every non-given `z0` and
+the resulting values are recorded in `given_species_params()`. Values filled
+from the arguments' defaults are not recorded there and will be recalculated
+on the next call.
 
 **Giving a value switches off the calculation that would have used another one.**
 Mizer warns about three of these, but only from `given_species_params<-()` —

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -299,9 +299,37 @@ If code now errors here, choose a physically attainable feeding level below 1.
 When `gamma` is the parameter you intend to control, omit the `f0` value or use
 a valid value; `gamma` will still take precedence (#517).
 
+### `z0pre` and `z0exp` are construction-only
+
+The `z0pre` and `z0exp` arguments of [`setExtMort()`](../reference/setExtMort.html) are deprecated, as are the
+same arguments when passed through [`setParams()`](../reference/setParams.html). They were used only to fill
+missing values of the `z0` species parameter. A built model already has `z0`
+for every species, so calls such as
+
+```{r eval=FALSE}
+params <- setExtMort(params, z0pre = 2)
+params <- setParams(params, z0exp = -0.25)
+```
+
+were accepted but changed nothing. `reset = TRUE` did not help: it hands the
+external-mortality array back to the species parameters but does not remove
+the existing `z0` values.
+
+Set `z0` explicitly when changing an existing model:
+
+```{r eval=FALSE}
+sp <- species_params(params)
+sp$z0 <- 2 * sp$w_inf^(-0.25)
+species_params(params) <- sp
+```
+
+The `z0pre` and `z0exp` arguments of `newMultispeciesParams()` are not
+deprecated. There they still calculate missing `z0` values while the model is
+being constructed (#493).
+
 ### `setParams()` rejects arguments it does not use
 
-[`setParams()`](../reference/setParams.html) passes its `...` on to the rate setters, each of which declares
+`setParams()` passes its `...` on to the rate setters, each of which declares
 its own `...` as unused. Any argument that none of them recognises was
 therefore accepted and ignored without a word. It is now an error, and the
 error says where the argument belongs when it belongs somewhere:

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -301,9 +301,9 @@ a valid value; `gamma` will still take precedence (#517).
 
 ### `setExtMort()` warns when `z0pre` or `z0exp` is ignored
 
-The `z0pre` and `z0exp` arguments of [`setExtMort()`](../reference/setExtMort.html) are used only to fill
-missing values of the `z0` species parameter. A built model normally already
-has `z0` for every species, so calls such as
+The `z0pre` and `z0exp` arguments of [`setExtMort()`](../reference/setExtMort.html) are used only to calculate
+values of the `z0` species parameter that are not present in
+`given_species_params()`. If `z0` is given for every species, calls such as
 
 ```{r eval=FALSE}
 params <- setExtMort(params, z0pre = 2)
@@ -313,7 +313,7 @@ params <- setParams(params, z0exp = -0.25)
 were accepted but changed nothing. They now warn that the arguments were
 ignored. `reset = TRUE` does not make them applicable: it hands the
 external-mortality array back to the species parameters but does not remove the
-existing `z0` values.
+given `z0` values.
 
 Set `z0` explicitly when changing an existing model:
 
@@ -323,11 +323,12 @@ sp$z0 <- 2 * sp$w_inf^(-0.25)
 species_params(params) <- sp
 ```
 
-The arguments still work whenever `z0` is missing. If either argument was
-supplied explicitly, the calculated `z0` values are recorded in
-`given_species_params()` so that they survive later rebuilds. Values calculated
-from the default `z0pre = 0.6` and `z0exp = n - 1` remain calculated parameters
-and are not recorded there (#493).
+The arguments still work wherever `z0` is not given. A `z0` value present only
+in `species_params()` is the cached result of an earlier calculation and is
+recalculated. If either argument was supplied explicitly, the newly calculated
+`z0` values are recorded in `given_species_params()` so that they survive later
+rebuilds. Values calculated from the default `z0pre = 0.6` and
+`z0exp = n - 1` remain calculated parameters and are not recorded there (#493).
 
 ### `setParams()` rejects arguments it does not use
 

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -299,21 +299,21 @@ If code now errors here, choose a physically attainable feeding level below 1.
 When `gamma` is the parameter you intend to control, omit the `f0` value or use
 a valid value; `gamma` will still take precedence (#517).
 
-### `z0pre` and `z0exp` are construction-only
+### `setExtMort()` warns when `z0pre` or `z0exp` is ignored
 
-The `z0pre` and `z0exp` arguments of [`setExtMort()`](../reference/setExtMort.html) are deprecated, as are the
-same arguments when passed through [`setParams()`](../reference/setParams.html). They were used only to fill
-missing values of the `z0` species parameter. A built model already has `z0`
-for every species, so calls such as
+The `z0pre` and `z0exp` arguments of [`setExtMort()`](../reference/setExtMort.html) are used only to fill
+missing values of the `z0` species parameter. A built model normally already
+has `z0` for every species, so calls such as
 
 ```{r eval=FALSE}
 params <- setExtMort(params, z0pre = 2)
 params <- setParams(params, z0exp = -0.25)
 ```
 
-were accepted but changed nothing. `reset = TRUE` did not help: it hands the
-external-mortality array back to the species parameters but does not remove
-the existing `z0` values.
+were accepted but changed nothing. They now warn that the arguments were
+ignored. `reset = TRUE` does not make them applicable: it hands the
+external-mortality array back to the species parameters but does not remove the
+existing `z0` values.
 
 Set `z0` explicitly when changing an existing model:
 
@@ -323,13 +323,15 @@ sp$z0 <- 2 * sp$w_inf^(-0.25)
 species_params(params) <- sp
 ```
 
-The `z0pre` and `z0exp` arguments of `newMultispeciesParams()` are not
-deprecated. There they still calculate missing `z0` values while the model is
-being constructed (#493).
+The arguments still work whenever `z0` is missing. If either argument was
+supplied explicitly, the calculated `z0` values are recorded in
+`given_species_params()` so that they survive later rebuilds. Values calculated
+from the default `z0pre = 0.6` and `z0exp = n - 1` remain calculated parameters
+and are not recorded there (#493).
 
 ### `setParams()` rejects arguments it does not use
 
-`setParams()` passes its `...` on to the rate setters, each of which declares
+[`setParams()`](../reference/setParams.html) passes its `...` on to the rate setters, each of which declares
 its own `...` as unused. Any argument that none of them recognises was
 therefore accepted and ignored without a word. It is now an error, and the
 error says where the argument belongs when it belongs somewhere:


### PR DESCRIPTION
## Summary

- keep `z0pre` and `z0exp` as supported arguments of `setExtMort()` and `setParams()`
- treat `species_params$z0` as a cached calculated value unless the corresponding entry is present in `given_species_params()`
- recalculate every non-given `z0` from `z0pre * w_inf ^ z0exp`
- warn when explicitly supplied arguments are ignored because `z0` is given for every species or because `ext_mort` was supplied
- when either argument is explicitly supplied and used, record the resulting entries in `given_species_params()`
- leave `z0` calculated from the arguments' defaults out of `given_species_params()`
- preserve that distinction through `newMultispeciesParams()` by forwarding only arguments the caller actually supplied
- update NEWS, reference documentation, parameter-changing guidance, the upgrade guide, and regression tests

## Why

A `z0` value that is only in `species_params()` is the result of an earlier calculation, not a user-fixed parameter. It must therefore be recalculated so changes to `z0pre`, `w_inf`, or `z0exp` propagate. Only a non-`NA` value in `given_species_params$z0` prevents recalculation.

## User impact

Calls that pass `z0pre` or `z0exp` to `setExtMort()` or `setParams()` now recalculate non-given `z0` values. They warn only when the argument cannot be used. If an explicit argument is used, the result is protected as a given species parameter. Ordinary defaults remain recalculable.

## Validation

- broader related suite: 432 assertions passed
- final focused suite: 115 assertions passed
- `devtools::check_man()`
- generated cheatsheet link validation
- `git diff --check`

Fixes #493