### PR TITLE
Refresh search-volume defaults after resource changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -273,6 +273,14 @@ stability of steady states.
 
 ## Bug fixes
 
+- Changing the resource power-law parameters now refreshes the species search
+  volume parameters that mizer calculated from them. Changing `lambda`
+  recalculates calculated `q` and `gamma` entries, while changing `kappa`
+  recalculates calculated `gamma`; explicitly supplied species values remain
+  protected. Previously `resource_params(params)$lambda <- ...` and the
+  corresponding `setResource()` calls rebuilt the resource arrays but silently
+  left these calculated species parameters and `search_vol` stale (#497).
+
 - Setting `f0` to a value outside the interval `[0, 1)` now gives an immediate
   error, whether or not `gamma` has been supplied. Previously `f0 = 1`
   silently produced an infinite `gamma` and a non-finite `search_vol` when

--- a/R/resource_dynamics.R
+++ b/R/resource_dynamics.R
@@ -61,12 +61,15 @@ resource_constant <- function(params, n_pp, ...) {
 #'
 #' Assigning to `resource_params` only rebuilds the size-dependent resource rate
 #' and capacity arrays from these scalars (leaving any arrays you have set
-#' manually untouched). It does **not** balance the resource, i.e. it does not
-#' adjust one of the rate or capacity to keep the resource at the steady state
-#' where it replenishes at the rate at which it is consumed. This mirrors the
-#' way the species parameters feed the species rates. If you want to preserve
-#' the steady state after changing a resource scalar, call [setResource()] with
-#' the appropriate argument (which balances by default).
+#' manually untouched). Changing `lambda` also recalculates any `q` and `gamma`
+#' species parameters that mizer calculated, and changing `kappa` recalculates
+#' any calculated `gamma`; values you supplied explicitly are preserved. It
+#' does **not** balance the resource, i.e. it does not adjust one of the rate or
+#' capacity to keep the resource at the steady state where it replenishes at
+#' the rate at which it is consumed. This mirrors the way the species
+#' parameters feed the species rates. If you want to preserve the steady state
+#' after changing a resource scalar, call [setResource()] with the appropriate
+#' argument (which balances by default).
 #'
 #' @param params A MizerParams object
 #' @return A named list of resource parameters.
@@ -99,7 +102,6 @@ resource_params <- function(params) {
     changed <- scalars[vapply(scalars, function(scalar) {
         !identical(params@resource_params[[scalar]], value[[scalar]])
     }, logical(1))]
-    rp_changed <- length(changed) > 0
 
     # Warn about the changes that cannot take effect because the array they
     # feed has been set by hand, before the change is applied.
@@ -112,7 +114,7 @@ resource_params <- function(params) {
     # overrides). It does not balance the resource: that is a deliberate action
     # reserved for `setResource()`. This mirrors how `species_params<-` feeds
     # the species-parameter rates.
-    setResource(params, resource_params_changed = rp_changed, balance = FALSE)
+    setResource(params, resource_params_changed = changed, balance = FALSE)
 }
 
 

--- a/R/setResource.R
+++ b/R/setResource.R
@@ -68,6 +68,12 @@
 #' as `r_pp` and `kappa` respectively. That list can be accessed with
 #' [resource_params()].
 #'
+#' The resource power law also determines defaults for species search volume.
+#' Changing `lambda` recalculates any `q` and `gamma` values that mizer
+#' calculated, and changing `kappa` (by supplying a scalar
+#' `resource_capacity`) recalculates any calculated `gamma`. Species-specific
+#' values that you supplied explicitly remain unchanged.
+#'
 #' @param params A MizerParams object
 #' @param resource_rate Optional. A vector of per-capita resource birth
 #'   rate for each size class or a single number giving the coefficient in the
@@ -166,8 +172,18 @@ setResource.MizerParams <- function(params,
              paste0("`", unknown, "`", collapse = ", "), ".")
     }
 
-    resource_params_changed <- isTRUE(args[["resource_params_changed"]]) ||
+    resource_param_changes <- args[["resource_params_changed"]]
+    changed_resource_params <- if (is.character(resource_param_changes)) {
+        resource_param_changes
+    } else {
+        character()
+    }
+    resource_params_changed <- isTRUE(resource_param_changes) ||
+        length(changed_resource_params) > 0 ||
         !missing(lambda) || !missing(n) || !missing(w_pp_cutoff) || reset
+
+    old_lambda <- params@resource_params[["lambda"]]
+    old_kappa <- params@resource_params[["kappa"]]
 
     if ("r_pp" %in% names(args)) {
         lifecycle::deprecate_warn("1.0.0", "setResource(r_pp)",
@@ -364,6 +380,23 @@ setResource.MizerParams <- function(params,
         } else {
             resource_rate <- rate
         }
+    }
+
+    # `gamma` is calculated against the idealised resource spectrum and `q`
+    # against its slope. Rebuild from the given species parameters, just as the
+    # species-parameter setters do, so that mizer-owned values are recalculated
+    # while explicitly given values remain protected. Do this before balancing
+    # because balancing uses predation mortality, which depends on search
+    # volume.
+    resource_default_changes <- unique(c(
+        intersect(changed_resource_params, c("kappa", "lambda")),
+        if (!identical(old_kappa,
+                       params@resource_params[["kappa"]])) "kappa",
+        if (!identical(old_lambda,
+                       params@resource_params[["lambda"]])) "lambda"
+    ))
+    if (length(resource_default_changes) > 0) {
+        params <- rebuild_from_given(params, params@species_params)
     }
 
     # Balance ----

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -59,6 +59,7 @@ plots) are in the changelog and are not repeated here.
 | Repeated "`l_mat` is not consistent with `w_mat`" warning has stopped | the given species parameters are brought into line | Length and weight follow the one you gave last (3.3) |
 | Size grid or results changed in a model built with a small `min_w` | `w_min` is no longer reset to 0.001 | `w_min` survives a rebuild (3.3) |
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters (3.3) |
+| `gamma`, `q` or feeding levels change after setting resource `kappa` or `lambda` | calculated search-volume parameters now follow the resource power law | Resource scalars refresh calculated `gamma` and `q` (3.3) |
 | A recalculated `gamma` or `f0` is wildly different, in a model whose `search_vol` was set by hand | the frozen array used to block mizer's own unit-gamma calculation | Defaults for `gamma` and `f0` ignore a hand-set search volume (3.3) |
 | Setting `f0 = 1` now errors even though `gamma` is supplied | every supplied target feeding level is now validated | `f0` is always validated (3.3) |
 | `setExtMort(z0pre = ...)`, `setExtMort(z0exp = ...)` or the same arguments to `setParams()` now warns | `z0` was already present in `given_species_params()` for every species, so the arguments were ignored | `setExtMort()` warns when `z0pre` or `z0exp` is ignored (3.3) |
@@ -120,8 +121,9 @@ and are not repeated here.
 
 Most of the changes in this release are corrections. Results move only for
 models that had opted in to second-order bin-averaging, that set `min_w` below
-the default, or that specify sizes as lengths. The one change to an interface is
-in the spectrum plots.
+the default, that specify sizes as lengths, or that change the resource power
+law after constructing the model. The one change to an interface is in the
+spectrum plots.
 
 ### `biomass` and `per_log_size` replace `power`
 
@@ -338,6 +340,38 @@ the size grid it asked for, and results change accordingly.
 small-magnitude parameters such as `gamma` (~1e-8) are no longer treated as equal
 when they differ by up to ~10%. Comparisons that previously reported two models
 as identical may now report differences — those differences were always there.
+
+### Resource scalars refresh calculated `gamma` and `q`
+
+The resource power law is also the reference spectrum used to calculate search
+volume parameters. Changing `lambda` through `resource_params<-()` or
+`setResource()` now recalculates every `q` and `gamma` entry that mizer owns;
+changing `kappa` recalculates every mizer-owned `gamma`. A value you supplied
+explicitly remains protected, including when only some species in a column were
+given (#497).
+
+Previously the resource capacity was rebuilt but the calculated species
+parameters and `search_vol` were left at the values for the old resource:
+
+```r
+params <- newMultispeciesParams(sp)
+resource_params(params)$lambda <- 2.2
+
+# These now follow the new lambda automatically
+species_params(params)$q
+species_params(params)$gamma
+```
+
+If existing code deliberately wanted to keep the old values, record them as
+given before changing the resource:
+
+```r
+given <- given_species_params(params)
+given$q <- species_params(params)$q
+given$gamma <- species_params(params)$gamma
+given_species_params(params) <- given
+resource_params(params)$lambda <- 2.2
+```
 
 ### Defaults for `gamma` and `f0` ignore a hand-set search volume
 

--- a/man/newMultispeciesParams.Rd
+++ b/man/newMultispeciesParams.Rd
@@ -771,6 +771,12 @@ re-used automatically in the future. If you specify \code{resource_rate} or
 \code{resource_capacity} as a single number, that coefficient is likewise stored,
 as \code{r_pp} and \code{kappa} respectively. That list can be accessed with
 \code{\link[=resource_params]{resource_params()}}.
+
+The resource power law also determines defaults for species search volume.
+Changing \code{lambda} recalculates any \code{q} and \code{gamma} values that mizer
+calculated, and changing \code{kappa} (by supplying a scalar
+\code{resource_capacity}) recalculates any calculated \code{gamma}. Species-specific
+values that you supplied explicitly remain unchanged.
 }
 
 \examples{

--- a/man/resource_params.Rd
+++ b/man/resource_params.Rd
@@ -50,12 +50,15 @@ Unlike the carrying capacity, however, the initial resource abundance is
 
 Assigning to \code{resource_params} only rebuilds the size-dependent resource rate
 and capacity arrays from these scalars (leaving any arrays you have set
-manually untouched). It does \strong{not} balance the resource, i.e. it does not
-adjust one of the rate or capacity to keep the resource at the steady state
-where it replenishes at the rate at which it is consumed. This mirrors the
-way the species parameters feed the species rates. If you want to preserve
-the steady state after changing a resource scalar, call \code{\link[=setResource]{setResource()}} with
-the appropriate argument (which balances by default).
+manually untouched). Changing \code{lambda} also recalculates any \code{q} and \code{gamma}
+species parameters that mizer calculated, and changing \code{kappa} recalculates
+any calculated \code{gamma}; values you supplied explicitly are preserved. It
+does \strong{not} balance the resource, i.e. it does not adjust one of the rate or
+capacity to keep the resource at the steady state where it replenishes at
+the rate at which it is consumed. This mirrors the way the species
+parameters feed the species rates. If you want to preserve the steady state
+after changing a resource scalar, call \code{\link[=setResource]{setResource()}} with the appropriate
+argument (which balances by default).
 }
 \seealso{
 \code{\link[=setResource]{setResource()}}

--- a/man/setResource.Rd
+++ b/man/setResource.Rd
@@ -179,6 +179,12 @@ re-used automatically in the future. If you specify \code{resource_rate} or
 \code{resource_capacity} as a single number, that coefficient is likewise stored,
 as \code{r_pp} and \code{kappa} respectively. That list can be accessed with
 \code{\link[=resource_params]{resource_params()}}.
+
+The resource power law also determines defaults for species search volume.
+Changing \code{lambda} recalculates any \code{q} and \code{gamma} values that mizer
+calculated, and changing \code{kappa} (by supplying a scalar
+\code{resource_capacity}) recalculates any calculated \code{gamma}. Species-specific
+values that you supplied explicitly remain unchanged.
 }
 
 \examples{

--- a/tests/testthat/test-resource_dynamics.R
+++ b/tests/testthat/test-resource_dynamics.R
@@ -50,3 +50,33 @@ test_that("resource_params<- updates `time_modified`", {
     resource_params(params) <- resource_params(NS_params_small)
     expect_false(identical(params@time_modified, NS_params_small@time_modified))
 })
+
+test_that("resource_params<- refreshes calculated gamma and q (#497)", {
+    params <- newMultispeciesParams(NS_species_params_small, no_w = 20,
+                                    info_level = 0)
+    gamma0 <- species_params(params)$gamma
+    q0 <- species_params(params)$q
+
+    # Protect the first species explicitly. The other entries remain
+    # calculated even though the given columns now exist.
+    params@given_species_params$gamma <- c(gamma0[[1]], NA, NA)
+    params@given_species_params$q <- c(q0[[1]], NA, NA)
+
+    resource_params(params)$lambda <- resource_params(params)$lambda + 0.15
+
+    expect_equal(species_params(params)$gamma[[1]], gamma0[[1]])
+    gamma_ratio <- as.numeric(species_params(params)$gamma[-1] / gamma0[-1])
+    expect_false(isTRUE(all.equal(gamma_ratio, rep(1, 2))))
+    expect_equal(species_params(params)$q[[1]], q0[[1]])
+    expect_equal(species_params(params)$q[-1], q0[-1] + 0.15)
+
+    params2 <- newMultispeciesParams(NS_species_params_small, no_w = 20,
+                                     info_level = 0)
+    gamma0 <- species_params(params2)$gamma
+    q0 <- species_params(params2)$q
+    resource_params(params2)$kappa <- 2 * resource_params(params2)$kappa
+
+    expect_equal(species_params(params2)$gamma, gamma0 / 2,
+                 ignore_attr = TRUE)
+    expect_equal(species_params(params2)$q, q0, ignore_attr = TRUE)
+})

--- a/tests/testthat/test-setResource.R
+++ b/tests/testthat/test-setResource.R
@@ -343,6 +343,27 @@ test_that("resource_params<- does not balance and rate-side scalars take effect"
     expect_equal(as.numeric(resource_capacity(p)), 5 * cc_before)
 })
 
+test_that("setResource refreshes resource-dependent species defaults (#497)", {
+    params <- newMultispeciesParams(NS_species_params_small, no_w = 20,
+                                    info_level = 0)
+    gamma0 <- species_params(params)$gamma
+    q0 <- species_params(params)$q
+
+    lambda <- resource_params(params)$lambda + 0.1
+    by_lambda <- setResource(params, lambda = lambda, balance = FALSE)
+    expect_equal(species_params(by_lambda)$q, q0 + 0.1,
+                 ignore_attr = TRUE)
+    gamma_ratio <- as.numeric(species_params(by_lambda)$gamma / gamma0)
+    expect_false(isTRUE(all.equal(gamma_ratio, rep(1, length(gamma0)))))
+
+    capacity <- 2 * resource_params(params)$kappa
+    by_kappa <- setResource(params, resource_capacity = capacity,
+                            balance = FALSE)
+    expect_equal(species_params(by_kappa)$gamma, gamma0 / 2,
+                 ignore_attr = TRUE)
+    expect_equal(species_params(by_kappa)$q, q0, ignore_attr = TRUE)
+})
+
 test_that("resource setters take a balance argument", {
     p <- NS_params_small
     rr0 <- as.numeric(resource_rate(p))

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -34,8 +34,9 @@ and are not repeated here.
 
 Most of the changes in this release are corrections. Results move only for
 models that had opted in to second-order bin-averaging, that set `min_w` below
-the default, or that specify sizes as lengths. The one change to an interface is
-in the spectrum plots.
+the default, that specify sizes as lengths, or that change the resource power
+law after constructing the model. The one change to an interface is in the
+spectrum plots.
 
 ### `biomass` and `per_log_size` replace `power`
 
@@ -253,11 +254,43 @@ small-magnitude parameters such as `gamma` (~1e-8) are no longer treated as equa
 when they differ by up to ~10%. Comparisons that previously reported two models
 as identical may now report differences — those differences were always there.
 
+### Resource scalars refresh calculated `gamma` and `q`
+
+The resource power law is also the reference spectrum used to calculate search
+volume parameters. Changing `lambda` through `resource_params<-()` or
+`setResource()` now recalculates every `q` and `gamma` entry that mizer owns;
+changing `kappa` recalculates every mizer-owned `gamma`. A value you supplied
+explicitly remains protected, including when only some species in a column were
+given (#497).
+
+Previously the resource capacity was rebuilt but the calculated species
+parameters and [`search_vol`](../reference/setSearchVolume.html) were left at the values for the old resource:
+
+```{r eval=FALSE}
+params <- newMultispeciesParams(sp)
+resource_params(params)$lambda <- 2.2
+
+# These now follow the new lambda automatically
+species_params(params)$q
+species_params(params)$gamma
+```
+
+If existing code deliberately wanted to keep the old values, record them as
+given before changing the resource:
+
+```{r eval=FALSE}
+given <- given_species_params(params)
+given$q <- species_params(params)$q
+given$gamma <- species_params(params)$gamma
+given_species_params(params) <- given
+resource_params(params)$lambda <- 2.2
+```
+
 ### Defaults for `gamma` and `f0` ignore a hand-set search volume
 
 [`get_gamma_default()`](../reference/get_gamma_default.html) works out how much energy is available to a predator by
 giving it a search volume coefficient of 1. It used to obtain that search volume
-by calling [`setSearchVolume()`](../reference/setSearchVolume.html), which refuses to recalculate a [`search_vol`](../reference/setSearchVolume.html)
+by calling [`setSearchVolume()`](../reference/setSearchVolume.html), which refuses to recalculate a `search_vol`
 array you have set by hand — so mizer's own internal call was blocked along with
 yours, and the available energy was measured with *your* array. The resulting
 `gamma` was wrong by whatever factor separated your array from the unit-gamma


### PR DESCRIPTION
## Summary

- rebuild species parameters from `given_species_params` when resource `kappa` or `lambda` changes
- recalculate mizer-owned `gamma` and `q` values while preserving explicitly supplied values, including partial per-species input
- refresh dependent rates before resource balancing
- document the behaviour change and add regression coverage for both `resource_params<-()` and `setResource()`

## Why

`resource_params<-()` and `setResource()` rebuilt the resource arrays after changing `kappa` or `lambda`, but did not run the species-parameter rebuild. Consequently, calculated `gamma`, calculated `q`, and the resulting search volume remained tied to the old resource power law.

The fix reuses the same `rebuild_from_given()` path as the species-parameter setters instead of introducing separate invalidation logic.

## User impact

Calculated search-volume parameters now follow changes to the resource power law automatically. Values supplied explicitly by users remain protected as before.

## Validation

- focused resource tests: 96 assertions passed
- resource/search-volume/species-parameter tests: 364 assertions passed
- regenerated roxygen documentation and the upgrading article
- changed regions pass `lintr`
- `git diff --check`

This is a stacked draft based on #519; it can be retargeted to `master` after that PR merges.

Fixes #497