### PR TITLE
Give the species parameter diagnostics one definition of change (#524)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -396,6 +396,16 @@ stability of steady states.
   scripts and `given_species_params<-()` interactively, where the diagnostics
   are worth having (#496).
 
+- Those three diagnostics now agree about what counts as a change. Clearing a
+  given species parameter to `NA` is one: it hands the parameter back to
+  mizer's calculation, and if the rate array that calculation feeds has been
+  frozen, that instruction cannot be carried out and you are now told so.
+  Adding a column that holds only `NA` is not a change, and no longer draws a
+  warning that nothing else agreed with. Previously each of the three
+  diagnostics answered the question differently, so an all-`NA` new column
+  warned about a frozen array while clearing a value that was actually given
+  was reported by none of them (#524).
+
 - `species_params<-()` no longer records a default that mizer filled in as a
   given species parameter. A parameter that the model does not yet carry and
   that `validSpeciesParams()` supplies a default for — most commonly the

--- a/R/info_signals.R
+++ b/R/info_signals.R
@@ -385,9 +385,15 @@ overridden_species_params <- function() {
 #' no effect. This raises a warning about that. It is one of the diagnostics
 #' that only [given_species_params<-()] gives, see there.
 #'
+#' Only a value that is there can be ignored, so this is asked about the
+#' species that were *given* a value, not about every species whose value
+#' changed: clearing a value to `NA` is a change, but not one this has anything
+#' to say about.
+#'
 #' @param given The given species parameters, as they are before the change.
 #' @param changed A named list with one logical vector per changed column,
-#'   saying which species changed, as built by [given_species_params<-()].
+#'   saying which species were given a value, as built by
+#'   [given_species_params<-()].
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
 #' @concept helper

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -457,30 +457,8 @@ record_given_species_params <- function(given, value, old_sp) {
 
     common_cols <- intersect(names(value), names(old_sp))
     for (col in common_cols) {
-        old_vals <- old_sp[[col]]
         new_vals <- value[[col]]
-        # Determine, per species, which values changed. `==` is only reliable
-        # for plain atomic vectors. It is undefined (and errors) for list
-        # columns or columns holding S4/other objects, and for a matrix column
-        # it returns a matrix rather than one logical per species. In those
-        # cases fall back to a per-species `identical()` comparison.
-        simple <- is.atomic(old_vals) && is.atomic(new_vals) &&
-            is.null(dim(old_vals)) && is.null(dim(new_vals)) &&
-            length(old_vals) == no_sp && length(new_vals) == no_sp
-        if (simple) {
-            changed <- !((old_vals == new_vals) |
-                             (is.na(old_vals) & is.na(new_vals)))
-            changed[is.na(changed)] <- TRUE
-        } else {
-            get_row <- function(x, i) {
-                d <- dim(x)
-                if (!is.null(d) && length(d) >= 2) x[i, ] else x[[i]]
-            }
-            changed <- !vapply(
-                seq_len(no_sp),
-                function(i) identical(get_row(old_vals, i), get_row(new_vals, i)),
-                logical(1))
-        }
+        changed <- changed_entries(new_vals, old_sp[[col]], no_sp)
 
         if (any(changed)) {
             if (!col %in% names(given)) {
@@ -601,18 +579,72 @@ length_weight_mappings <- function() {
 }
 
 # Which entries of a species parameter column have changed, comparing entry by
-# entry. A column that did not exist before counts as changed throughout, `NA`
-# is compared as a value rather than as an unknown.
+# entry. This is mizer's single definition of "this species parameter changed":
+# `record_given_species_params()` uses it to decide what to record and
+# `given_species_params<-()` uses it to decide what to report on, so that the
+# two cannot drift apart.
+#
+# `NA` is compared as a value rather than as an unknown: `NA` staying `NA` is
+# no change, but a value replaced by `NA` is one, because that is how the user
+# hands a parameter back to mizer's calculation. A column that did not exist
+# before is compared against `NA`, so adding one that holds only `NA` changes
+# nothing.
+#
+# `new` is the column as it is now and must have one entry per species;
+# anything else is taken to say nothing about what changed. `prev` is the
+# column as it was, `NULL` where there was none.
 changed_entries <- function(new, prev, n) {
-    if (is.null(new) || !is.atomic(new) || length(new) != n) {
+    if (is.null(new) || column_length(new) != n) {
         return(rep(FALSE, n))
     }
-    if (is.null(prev) || !is.atomic(prev) || length(prev) != n) {
+    if (is.null(prev)) {
+        prev <- NA
+    } else if (column_length(prev) != n) {
+        # Nothing to compare against, so everything counts as changed.
         return(rep(TRUE, n))
     }
-    ch <- !((new == prev) | (is.na(new) & is.na(prev)))
-    ch[is.na(ch)] <- TRUE
-    ch
+    # `==` is only reliable for plain atomic vectors. It is undefined (and
+    # errors) for list columns or columns holding S4/other objects, and for a
+    # matrix column it returns a matrix rather than one logical per species. In
+    # those cases fall back to a per-species `identical()` comparison.
+    simple <- is.atomic(new) && is.atomic(prev) &&
+        is.null(dim(new)) && is.null(dim(prev))
+    if (simple) {
+        ch <- !((new == prev) | (is.na(new) & is.na(prev)))
+        ch[is.na(ch)] <- TRUE
+        return(rep_len(ch, n))
+    }
+    get_row <- function(x, i) {
+        d <- dim(x)
+        if (!is.null(d) && length(d) >= 2) {
+            x[i, ]
+        } else if (length(x) == 1) {
+            # The stand-in for a column that did not exist before
+            x[[1]]
+        } else {
+            x[[i]]
+        }
+    }
+    !vapply(seq_len(n),
+            function(i) identical(get_row(new, i), get_row(prev, i)),
+            logical(1))
+}
+
+# The number of species a species parameter column holds values for. A matrix
+# column has one row per species, any other column one entry per species.
+column_length <- function(x) {
+    d <- dim(x)
+    if (!is.null(d) && length(d) >= 2) nrow(x) else length(x)
+}
+
+# Which entries of a species parameter column hold a value. Only a plain atomic
+# column can say that it does not; a list or matrix column is taken to hold a
+# value for every species.
+entry_has_value <- function(x, n) {
+    if (is.atomic(x) && is.null(dim(x)) && length(x) == n) {
+        return(!is.na(x))
+    }
+    rep(TRUE, n)
 }
 
 # Set a column without triggering the reactive validation
@@ -1090,27 +1122,36 @@ is.given_species_params <- function(x) {
         stop("The species names in the new species parameter data frame do not match the species names in the model.")
     }
 
-    # Create data frame which contains only the values that have changed
-    common_columns <- intersect(names(value), names(params@given_species_params))
-    new_columns <- setdiff(names(value), names(params@given_species_params))
-    changes <- value[common_columns]
-    changes[changes == params@given_species_params[common_columns]] <- NA
-    # Remove columns that only contain NAs
-    changes <- changes %>% select(where(~ !all(is.na(.))))
-    # Add new columns
-    changes <- cbind(changes, value[new_columns])
+    # Which species changed in which column, for the reports below. All three
+    # reports work from this one list, so they cannot disagree about what
+    # counts as a change. A column that the given species parameters do not
+    # have yet is compared against `NA`, so that adding an all-`NA` column is
+    # no change while clearing a given value to `NA` is one: the user is then
+    # handing that parameter back to mizer's calculation.
+    old_given <- params@given_species_params
+    no_sp <- nrow(value)
+    changed <- lapply(names(value), function(col) {
+        changed_entries(value[[col]], old_given[[col]], no_sp)
+    })
+    names(changed) <- names(value)
+    changed <- changed[vapply(changed, any, logical(1))]
 
-    # Which species changed, for the reports below. In `changes` an entry that
-    # did not change has been set to NA.
-    changed <- lapply(changes, function(col) !is.na(col))
+    # Of those changes, the ones that gave a species a value. Only a value that
+    # is there can be overruled by another parameter, so this is the narrower
+    # question `signal_ignored_changes()` asks: clearing a value to `NA` is a
+    # change, but not one it has anything to say about.
+    specified <- lapply(names(changed), function(col) {
+        changed[[col]] & entry_has_value(value[[col]], no_sp)
+    })
+    names(specified) <- names(changed)
 
     # Warn about the changes that will have no impact, either because another
     # given parameter takes precedence or because the rate array they feed has
     # been set by hand.
     with_info_level({
-        signal_ignored_changes(params@given_species_params, changed)
+        signal_ignored_changes(old_given, specified)
         signal_gear_params_changes(changed)
-        signal_frozen_changes(params, names(changes))
+        signal_frozen_changes(params, names(changed))
     })
 
     params@given_species_params <- value

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -47,6 +47,8 @@ plots) are in the changelog and are not repeated here.
 | `plotCDF(per_log_size = TRUE)` errors | meaningless for a cumulative distribution | `biomass` and `per_log_size` replace `power` (3.3) |
 | New warning that a change to a species or resource parameter "has not taken effect" | the rate it feeds was set by hand and is no longer calculated | A change that cannot take effect now warns (3.3) |
 | That warning appears with `given_species_params<-()` but not with `species_params<-()` | the diagnostics belong to the given species parameter setter | The two species parameter setters divide the diagnostics between them (3.3) |
+| Setting a given species parameter to `NA` now warns that the change has not taken effect | clearing a value counts as a change, and a frozen array blocks it | The two species parameter setters divide the diagnostics between them (3.3) |
+| Adding an all-`NA` species parameter column used to warn and no longer does | nothing acquires a value, so it is not a change | The two species parameter setters divide the diagnostics between them (3.3) |
 | `given_species_params()` no longer lists `a` and `b`, or another default, after an unrelated `species_params<-()` call | a filled-in default was mistaken for user input and frozen as given | `species_params<-()` no longer freezes the defaults it fills in (3.3) |
 | A species parameter that used to keep its value now moves when you change another one | it was silently recorded as given and is now calculated again | `species_params<-()` no longer freezes the defaults it fills in (3.3) |
 | A message that used to appear no longer does, with `info_level = 0` | `info_level = 0` now silences everything | One report, one switch (3.3) |
@@ -259,6 +261,29 @@ diagnostics, and they all sit on the same side of the line:
 | `f0`, `fc`, `age_mat` | you have already given `gamma`, `ks`, `h` |
 | any parameter feeding a rate array you set by hand | the array is frozen |
 | `catchability`, `selectivity`, `l50`, `l25`, `sel_func`, `yield_observed` | these belong in `gear_params()` |
+
+All three ask the same question about what changed, and setting a value to `NA`
+is part of the answer:
+
+```r
+params <- NS_params
+search_vol(params) <- search_vol(params)   # freeze the search volume
+
+given_species_params(params)$gamma <- NA   # hand `gamma` back to mizer
+#> Warning: Your change to the species parameter `gamma` has not taken effect
+#> because the search volume has been set manually …
+
+given_species_params(params)$z0 <- NA      # a column that was not given
+                                           # anyway: nothing changes, no warning
+```
+
+Clearing a parameter that *was* given is a change, because it asks mizer to go
+back to calculating it, and that instruction is blocked by a frozen array just
+as a new value would be. Adding a column that holds only `NA` is not a change:
+nothing acquires a value. The one thing none of the three reports is a value
+handed back to mizer being overruled by another given parameter — only a value
+that is there can be overruled, so setting `f0` to `NA` on a model that gives
+`gamma` stays silent.
 
 **How this affects existing code:** nothing, which is the point — a script that
 ran clean on 3.2 using `species_params<-()` still runs clean. Use

--- a/man/signal_ignored_changes.Rd
+++ b/man/signal_ignored_changes.Rd
@@ -10,7 +10,8 @@ signal_ignored_changes(given, changed)
 \item{given}{The given species parameters, as they are before the change.}
 
 \item{changed}{A named list with one logical vector per changed column,
-saying which species changed, as built by \code{\link[=given_species_params<-]{given_species_params<-()}}.}
+saying which species were given a value, as built by
+\code{\link[=given_species_params<-]{given_species_params<-()}}.}
 }
 \value{
 \code{NULL} invisibly. Called for its side effect of signalling.
@@ -21,5 +22,11 @@ one: \code{f0} for \code{gamma}, \code{fc} for \code{ks} and \code{age_mat} for 
 one has been given, the model no longer consults them, so changing them has
 no effect. This raises a warning about that. It is one of the diagnostics
 that only \code{\link[=given_species_params<-]{given_species_params<-()}} gives, see there.
+}
+\details{
+Only a value that is there can be ignored, so this is asked about the
+species that were \emph{given} a value, not about every species whose value
+changed: clearing a value to \code{NA} is a change, but not one this has anything
+to say about.
 }
 \concept{helper}

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -403,6 +403,48 @@ test_that("given_species_params setter warns when a frozen rate blocks the chang
     expect_equal(params@search_vol, before, ignore_attr = TRUE)
 })
 
+test_that("given_species_params setter ignores a new all-NA column (#524)", {
+    params <- NS_params_small
+    ext_mort(params) <- ext_mort(params)
+    expect_false("z0" %in% names(given_species_params(params)))
+
+    # Nothing acquires a value, so none of the three diagnostics fires.
+    expect_silent(given_species_params(params)$z0 <- NA)
+    expect_false("catchability" %in% names(given_species_params(params)))
+    expect_silent(given_species_params(params)$catchability <- NA)
+})
+
+test_that("given_species_params setter treats clearing to NA as a change (#524)", {
+    params <- NS_params_small
+    search_vol(params) <- search_vol(params)
+    before <- params@search_vol
+    expect_false(any(is.na(given_species_params(params)$gamma)))
+
+    # Handing `gamma` back to mizer's calculation is an instruction that the
+    # frozen search volume cannot carry out, so the user is told.
+    expect_warning(given_species_params(params)$gamma <- NA,
+                   "Your change to the species parameter `gamma`.*search volume")
+    expect_equal(params@search_vol, before, ignore_attr = TRUE)
+})
+
+test_that("the given_species_params diagnostics agree about clearing to NA (#524)", {
+    params <- NS_params_small
+    expect_warning(given_species_params(params)$catchability <- 2,
+                   "you should use `gear_params\\(\\)<-`")
+    # Clearing it again is just as much a change, so it is reported again.
+    expect_warning(given_species_params(params)$catchability <- NA,
+                   "you should use `gear_params\\(\\)<-`")
+
+    # Only a value that is there can be overruled by `gamma`, so clearing `f0`
+    # is a change that `signal_ignored_changes()` has nothing to say about.
+    params <- NS_params_small
+    expect_false(any(is.na(given_species_params(params)$gamma)))
+    expect_false(any(is.na(given_species_params(params)$f0)))
+    expect_warning(given_species_params(params)$f0 <- 0.5,
+                   "values for `f0` that are going to be ignored")
+    expect_silent(given_species_params(params)$f0 <- NA)
+})
+
 test_that("species_params setter is quiet when no frozen rate is in the way", {
     params <- NS_params_small
     sp <- species_params(params)
@@ -966,6 +1008,41 @@ test_that("get_h_default accepts MizerParams, species_params and data.frame", {
 
     expect_equal(h_params, h_sp)
     expect_equal(h_params, h_df)
+})
+
+# changed_entries ----------------------------------------------------------
+
+test_that("changed_entries compares NA as a value", {
+    expect_identical(changed_entries(c(1, NA, 3), c(1, NA, 4), 3),
+                     c(FALSE, FALSE, TRUE))
+    # A value cleared to NA is a change, an NA that stays NA is not.
+    expect_identical(changed_entries(c(NA, NA), c(1, NA), 2), c(TRUE, FALSE))
+    # As is a value where there was none.
+    expect_identical(changed_entries(c(1, NA), c(NA, NA), 2), c(TRUE, FALSE))
+})
+
+test_that("changed_entries treats a column that did not exist as all NA", {
+    expect_identical(changed_entries(c(1, 2), NULL, 2), c(TRUE, TRUE))
+    expect_identical(changed_entries(c(1, NA), NULL, 2), c(TRUE, FALSE))
+    expect_identical(changed_entries(c(NA, NA), NULL, 2), c(FALSE, FALSE))
+})
+
+test_that("changed_entries handles list and matrix columns", {
+    expect_identical(changed_entries(list(c("a", "b"), "c"),
+                                     list(c("a", "b"), "d"), 2),
+                     c(FALSE, TRUE))
+    expect_identical(changed_entries(matrix(1:4, nrow = 2),
+                                     matrix(c(1L, 9L, 3L, 4L), nrow = 2), 2),
+                     c(FALSE, TRUE))
+    # A list column is new, so every species that has an entry has changed
+    expect_identical(changed_entries(list("a", "b"), NULL, 2), c(TRUE, TRUE))
+})
+
+test_that("changed_entries says nothing about a column of the wrong length", {
+    expect_identical(changed_entries(1, c(1, 2), 2), c(FALSE, FALSE))
+    expect_identical(changed_entries(NULL, c(1, 2), 2), c(FALSE, FALSE))
+    # Nothing to compare against, so everything counts as changed
+    expect_identical(changed_entries(c(1, 2), c(1, 2, 3), 2), c(TRUE, TRUE))
 })
 
 # record_given_species_params ---------------------------------------------

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -165,6 +165,29 @@ diagnostics, and they all sit on the same side of the line:
 | any parameter feeding a rate array you set by hand | the array is frozen |
 | [`catchability`](../reference/setFishing.html), [`selectivity`](../reference/setFishing.html), `l50`, `l25`, `sel_func`, `yield_observed` | these belong in [`gear_params()`](../reference/gear_params.html) |
 
+All three ask the same question about what changed, and setting a value to `NA`
+is part of the answer:
+
+```{r eval=FALSE}
+params <- NS_params
+search_vol(params) <- search_vol(params)   # freeze the search volume
+
+given_species_params(params)$gamma <- NA   # hand `gamma` back to mizer
+#> Warning: Your change to the species parameter `gamma` has not taken effect
+#> because the search volume has been set manually …
+
+given_species_params(params)$z0 <- NA      # a column that was not given
+                                           # anyway: nothing changes, no warning
+```
+
+Clearing a parameter that *was* given is a change, because it asks mizer to go
+back to calculating it, and that instruction is blocked by a frozen array just
+as a new value would be. Adding a column that holds only `NA` is not a change:
+nothing acquires a value. The one thing none of the three reports is a value
+handed back to mizer being overruled by another given parameter — only a value
+that is there can be overruled, so setting `f0` to `NA` on a model that gives
+`gamma` stays silent.
+
 **How this affects existing code:** nothing, which is the point — a script that
 ran clean on 3.2 using `species_params<-()` still runs clean. Use
 `given_species_params<-()` interactively, where the diagnostics are worth


### PR DESCRIPTION
Closes #524.

## The problem

`given_species_params<-()` built two things from the same `changes` data frame
and they disagreed for a column that was new to the given species parameters
and held only `NA`:

- `changed <- lapply(changes, function(col) !is.na(col))` — all `FALSE`, so
  `signal_ignored_changes()` and `signal_gear_params_changes()` stayed quiet.
- `names(changes)` — still listed the column, so `signal_frozen_changes()`
  fired.

The all-`NA` columns were dropped before the new columns were `cbind()`ed on,
so the new ones escaped the drop.

## What this does

**Clearing a given species parameter to `NA` counts as a change** — the first
of the two answers the issue offered. The user is handing the parameter back to
mizer's calculation, and if the array that calculation feeds is frozen, that
instruction is not being carried out, which is exactly what
`signal_frozen_changes()` is for.

**One definition instead of three.** The package already had a third notion of
"changed" in the internal `changed_entries()`, used by
`reconcile_length_weight()`, alongside the copy inlined in
`record_given_species_params()`. All of them are now one function, which the
setter's three reports work from, so they cannot drift apart again.

The unified rule: `NA` is compared as a value. `NA` staying `NA` is no change,
a value replaced by `NA` is one. A column that did not exist before is compared
against `NA`, so it counts as changed only for the species that acquired a
value. `changed_entries()` also picked up `record_given_species_params()`'s
handling of list and matrix columns, which the setter previously had none of.

Consequences:

```r
params <- NS_params_small
ext_mort(params) <- ext_mort(params)
given_species_params(params)$z0 <- NA   # the issue's repro: silent now

params <- NS_params_small
search_vol(params) <- search_vol(params)
given_species_params(params)$gamma <- NA
#> Warning: Your change to the species parameter `gamma` has not taken effect
#> because the search volume has been set manually …
```

The first no longer warns (nothing acquires a value); the second now does,
where before none of the three diagnostics said anything.

## One deliberate narrowing

`signal_ignored_changes()` asks a different question from the other two. Its
message is "you have specified some values … that are going to be ignored", and
only a value that is *there* can be overruled by `gamma`/`ks`/`h`. It now gets
the subset of changes that gave a species a value, so clearing `f0` on a model
that gives `gamma` stays silent. Without this the existing test at
`test-species_params.R:190` broke: a user who clears `f0` for the one species
where `gamma` is given was told their removed `f0` would be ignored.

## Testing

Full suite passes (only the usual `MIZER_TEST_EXPERIMENTAL` skips). Added unit
tests for `changed_entries()` covering the `NA` semantics, absent columns, list
and matrix columns and wrong-length columns, plus three tests on the setter for
the issue's cases. `NEWS.md` and the upgrade skill are updated, with
`vignettes/upgrading.Rmd` regenerated by `build_cheatsheets()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
