### PR TITLE
Compare observed and model yields gear by gear (#286)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,15 @@ stability of steady states.
 
 ## Other improvements
 
+- `plotYieldObservedVsModel()` gains a `gear` argument that restricts the
+  comparison to the catch of the selected gears. Both the model yield and the
+  observed yield are then taken from those gears only, so in a model where
+  several gears catch the same species you can check the gears against their
+  own observations instead of only their total. Without the argument the plot
+  keeps comparing the yield summed over all gears. Because the species
+  parameter `yield_observed` is a total over all the gears, per-gear
+  observations have to be given in `gear_params()` (#286).
+
 - `summary()` of a `MizerParams` object now reports the model's biomass drift
   and whether that counts as being at a steady state. Whether a model is settled
   is not visible from any of the other parameters shown, and getting it wrong is

--- a/R/plotYieldObservedVsModel.R
+++ b/R/plotYieldObservedVsModel.R
@@ -17,6 +17,13 @@
 #' observed yield, you should set the value in the `yield_observed` column to
 #' 0 or NA.
 #'
+#' If a species is caught by several gears, both the model yield and the
+#' observed yield are summed over the gears. With the `gear` argument you can
+#' restrict the comparison to a subset of the gears, in which case only the
+#' catch of those gears enters on both axes. Because the species parameter
+#' data frame only holds the yield summed over all gears, the observations
+#' then have to come from the gear parameters.
+#'
 #' The total relative error is shown in the caption of the plot, calculated by
 #'   \deqn{TRE = \sum_i|1-\rm{ratio_i}|}{TRE = sum_i |1-ratio_i|} where
 #'   \eqn{\rm{ratio_i}}{ratio_i} is the ratio of model yield / observed
@@ -36,8 +43,11 @@
 #' @param labels Whether to show text labels for each species (TRUE) or not
 #'   (FALSE). Default is TRUE.
 #' @param show_unobserved Whether to include also species for which no
-#'   yield observation is available. If TRUE, these species will be 
+#'   yield observation is available. If TRUE, these species will be
 #'   shown as if their observed yield was equal to the model yield.
+#' @param gear The gears to be included. Optional. By default the catch of all
+#'   gears is included. A vector of gear names. Only species caught by the
+#'   selected gears are shown.
 #' @param return_data Whether to return the data frame for the plot (TRUE) or
 #'   not (FALSE). Default is FALSE.
 #' @param ... For [plotlyYieldObservedVsModel()], additional arguments passed
@@ -66,41 +76,72 @@
 #'
 #' # Show the ratio instead
 #' plotYieldObservedVsModel(params, ratio = TRUE)
+#'
+#' # If several gears catch the same species, their yields are added up.
+#' # Give Cod a second gear that takes a quarter of the observed yield.
+#' gp <- gear_params(params)
+#' gp["Cod, Otter", "yield_observed"] <- 3e11 * 0.75
+#' extra <- gp["Cod, Otter", ]
+#' extra$gear <- "Gillnet"
+#' extra$yield_observed <- 3e11 * 0.25
+#' gear_params(params) <- rbind(gp, extra)
+#'
+#' # Compare only the catch of the Otter gear against its observation
+#' plotYieldObservedVsModel(params, gear = "Otter")
 plotYieldObservedVsModel <- function(object, species = NULL, ratio = FALSE,
-                                     log_scale = TRUE, return_data = FALSE, 
-                                     labels = TRUE, show_unobserved = FALSE, ...) {
+                                     log_scale = TRUE, return_data = FALSE,
+                                     labels = TRUE, show_unobserved = FALSE,
+                                     gear = NULL, ...) {
     UseMethod("plotYieldObservedVsModel")
 }
 #' @export
 plotYieldObservedVsModel.MizerParams <- function(object, species = NULL, ratio = FALSE,
-                                     log_scale = TRUE, return_data = FALSE, 
-                                     labels = TRUE, show_unobserved = FALSE, ...) {
-    
+                                     log_scale = TRUE, return_data = FALSE,
+                                     labels = TRUE, show_unobserved = FALSE,
+                                     gear = NULL, ...) {
+
     params <- object
     sp_params <- params@species_params
-    
-    yield_model <- getYield(params)
+
+    if (is.null(gear)) {
+        yield_model <- getYield(params)
+    } else {
+        gear <- valid_gears_arg(params, gear, error_on_empty = TRUE)
+        yield_gear <- getYieldGear(params)  # gear x species
+        yield_model <- colSums(yield_gear[gear, , drop = FALSE])
+    }
 
     # Select appropriate species
     species <- valid_species_arg(object, species)
     no_yield <- yield_model[species] == 0
     if (any(no_yield)) {
+        reason <- if (is.null(gear)) {
+            "are not being fished in your model"
+        } else {
+            paste0("are not being caught by the selected ",
+                   ngettext(length(gear), "gear", "gears"))
+        }
         signal_info("yield_model", paste0(
-            "The following species are not being fished in your model and ",
+            "The following species ", reason, " and ",
             "will not be included in the plot: ",
             paste0(species[no_yield], collapse = ", "), "."),
             level = 1, unhandled = "show")
         species <- species[!no_yield]
     }
     if (length(species) == 0) stop("No species selected, please fix.")
-    
+
     # find rows corresponding to species selected
     row_select <- match(species, sp_params$species)
-    yield_observed <- get_yield_observed(params)
+    yield_observed <- get_yield_observed(params, gear = gear)
     if (is.null(yield_observed)) {
+        if (is.null(gear)) {
+            stop("You have not provided values for the column ",
+                 "'yield_observed' in either the gear parameters or the ",
+                 "species parameters of the mizerParams/mizerSim object.")
+        }
         stop("You have not provided values for the column 'yield_observed' ",
-             "in either the gear parameters or the species parameters of the ",
-             "mizerParams/mizerSim object.")
+             "in the gear parameters of the mizerParams/mizerSim object. ",
+             "Observations for individual gears have to be given there.")
     }
 
     # Build dataframe
@@ -129,6 +170,12 @@ plotYieldObservedVsModel.MizerParams <- function(object, species = NULL, ratio =
     tre <- round(sum(abs(1 - dummy$ratio)), digits = 3)
     
     caption <- paste0("Total relative error = ", tre)
+    if (!is.null(gear)) {
+        caption <- paste(caption,
+                         paste0("\n Only the catch by the following ",
+                                ngettext(length(gear), "gear", "gears"),
+                                " is included: ", toString(gear), "."))
+    }
     if (any(!dummy$is_observed)) {
         caption <- paste(caption,
                          "\n Open circles represent species without yield observation.")
@@ -179,12 +226,14 @@ plotYieldObservedVsModel.MizerParams <- function(object, species = NULL, ratio =
 }
 #' @export
 plotYieldObservedVsModel.MizerSim <- function(object, species = NULL, ratio = FALSE,
-                                     log_scale = TRUE, return_data = FALSE, 
-                                     labels = TRUE, show_unobserved = FALSE, ...) {
+                                     log_scale = TRUE, return_data = FALSE,
+                                     labels = TRUE, show_unobserved = FALSE,
+                                     gear = NULL, ...) {
     params <- finalParams(object)
     plotYieldObservedVsModel(params, species = species, ratio = ratio,
                              log_scale = log_scale, return_data = return_data,
-                             labels = labels, show_unobserved = show_unobserved)
+                             labels = labels, show_unobserved = show_unobserved,
+                             gear = gear)
 }
 
 
@@ -193,7 +242,8 @@ plotYieldObservedVsModel.MizerSim <- function(object, species = NULL, ratio = FA
 #' @export
 plotlyYieldObservedVsModel <- function(object, species = NULL, ratio = FALSE,
                                          log_scale = TRUE,
-                                         show_unobserved = FALSE, ...) {
+                                         show_unobserved = FALSE,
+                                         gear = NULL, ...) {
     argg <- as.list(environment())
     argg$labels <- FALSE
     plotHover(do.call("plotYieldObservedVsModel", argg), ...)
@@ -205,26 +255,40 @@ plotlyYieldObservedVsModel <- function(object, species = NULL, ratio = FALSE,
 #' The observed yield lives in the `yield_observed` column of the gear
 #' parameter data frame, see [gear_params()], where it is given for each
 #' gear-species pair. This function adds the observations up over the gears to
-#' give the total observed yield of each species.
+#' give the total observed yield of each species. With the `gear` argument you
+#' can restrict the sum to a subset of the gears.
 #'
 #' Older models, and the examples in older versions of mizer, put
 #' `yield_observed` into the species parameter data frame instead. That is
 #' still accepted: a species that has no observation among the gear parameters
 #' takes its value from the species parameters. Where both tables give a value
-#' for a species, the gear parameters win.
+#' for a species, the gear parameters win. The species parameter observation is
+#' a total over all gears, so it is ignored when `gear` selects only some of
+#' the gears.
 #'
 #' @param params A MizerParams object
+#' @param gear The gears whose observations are to be added up. Optional. By
+#'   default all gears are included. A vector of gear names.
 #' @return A numeric vector with one entry for each species, named by species,
 #'   holding the observed yield in grams per year, or `NA` for species without
-#'   an observation. `NULL` if neither the gear parameters nor the species
-#'   parameters have a `yield_observed` column.
+#'   an observation. `NULL` if the observations are not available: if neither
+#'   the gear parameters nor the species parameters have a `yield_observed`
+#'   column, or, when `gear` is given, if the gear parameters have no such
+#'   column.
 #' @concept helper
-get_yield_observed <- function(params) {
+get_yield_observed <- function(params, gear = NULL) {
     species <- as.character(params@species_params$species)
     gp <- params@gear_params
     sp <- params@species_params
     in_gear <- "yield_observed" %in% names(gp)
     in_species <- "yield_observed" %in% names(sp)
+    if (!is.null(gear)) {
+        gear <- valid_gears_arg(params, gear, error_on_empty = TRUE)
+        # The species parameter column holds the yield summed over all gears,
+        # so it is no help when only some of the gears are selected.
+        in_species <- FALSE
+        gp <- gp[as.character(gp$gear) %in% gear, , drop = FALSE]
+    }
     if (!in_gear && !in_species) return(NULL)
 
     yield <- rep(NA_real_, length(species))

--- a/inst/skills/calibrate-model/SKILL.md
+++ b/inst/skills/calibrate-model/SKILL.md
@@ -89,7 +89,9 @@ passes.
 **Yields** are not a calibration target in mizer itself: put the observed
 annual yield of each gear-species pair into the `yield_observed` column of
 `gear_params()` and compare it with the model using
-`plotYieldObservedVsModel()`, which sums the observations over the gears. Use
+`plotYieldObservedVsModel()`, which sums the observations over the gears. Pass
+`gear = ` a subset of the gear names to compare only their catch against only
+their observations. Use
 `mizerExperimental::matchYield()` to adjust the catchability so that the yields
 match. Yields depend on the fishing setup, so make sure gears and effort are
 right first — see the `set-up-fishing` skill.

--- a/inst/skills/set-up-fishing/SKILL.md
+++ b/inst/skills/set-up-fishing/SKILL.md
@@ -40,7 +40,9 @@ the function's argument (see below). Row names follow the pattern
 There is one optional column, `yield_observed`, holding the observed annual
 yield of that gear–species pair in grams per year. It is not used by any rate
 calculation; `plotYieldObservedVsModel()` sums it over the gears to compare the
-observations with the model.
+observations with the model, and its `gear` argument restricts that comparison
+to the catch of selected gears, for example
+`plotYieldObservedVsModel(params, gear = "Otter")`.
 
 **Editing an existing gear table.** Pull it out, change what you need, and
 assign it back — the assignment triggers recalculation of the selectivity and

--- a/man/get_yield_observed.Rd
+++ b/man/get_yield_observed.Rd
@@ -4,28 +4,36 @@
 \alias{get_yield_observed}
 \title{Observed yield of each species}
 \usage{
-get_yield_observed(params)
+get_yield_observed(params, gear = NULL)
 }
 \arguments{
 \item{params}{A MizerParams object}
+
+\item{gear}{The gears whose observations are to be added up. Optional. By
+default all gears are included. A vector of gear names.}
 }
 \value{
 A numeric vector with one entry for each species, named by species,
 holding the observed yield in grams per year, or \code{NA} for species without
-an observation. \code{NULL} if neither the gear parameters nor the species
-parameters have a \code{yield_observed} column.
+an observation. \code{NULL} if the observations are not available: if neither
+the gear parameters nor the species parameters have a \code{yield_observed}
+column, or, when \code{gear} is given, if the gear parameters have no such
+column.
 }
 \description{
 The observed yield lives in the \code{yield_observed} column of the gear
 parameter data frame, see \code{\link[=gear_params]{gear_params()}}, where it is given for each
 gear-species pair. This function adds the observations up over the gears to
-give the total observed yield of each species.
+give the total observed yield of each species. With the \code{gear} argument you
+can restrict the sum to a subset of the gears.
 }
 \details{
 Older models, and the examples in older versions of mizer, put
 \code{yield_observed} into the species parameter data frame instead. That is
 still accepted: a species that has no observation among the gear parameters
 takes its value from the species parameters. Where both tables give a value
-for a species, the gear parameters win.
+for a species, the gear parameters win. The species parameter observation is
+a total over all gears, so it is ignored when \code{gear} selects only some of
+the gears.
 }
 \concept{helper}

--- a/man/plotYieldObservedVsModel.Rd
+++ b/man/plotYieldObservedVsModel.Rd
@@ -13,6 +13,7 @@ plotYieldObservedVsModel(
   return_data = FALSE,
   labels = TRUE,
   show_unobserved = FALSE,
+  gear = NULL,
   ...
 )
 }
@@ -42,6 +43,10 @@ not (FALSE). Default is FALSE.}
 yield observation is available. If TRUE, these species will be
 shown as if their observed yield was equal to the model yield.}
 
+\item{gear}{The gears to be included. Optional. By default the catch of all
+gears is included. A vector of gear names. Only species caught by the
+selected gears are shown.}
+
 \item{...}{For \code{\link[=plotlyYieldObservedVsModel]{plotlyYieldObservedVsModel()}}, additional arguments passed
 to \code{\link[=plotHover]{plotHover()}}. Otherwise unused.}
 }
@@ -69,6 +74,13 @@ accepted, see \code{\link[=get_yield_observed]{get_yield_observed()}}. For speci
 observed yield, you should set the value in the \code{yield_observed} column to
 0 or NA.
 
+If a species is caught by several gears, both the model yield and the
+observed yield are summed over the gears. With the \code{gear} argument you can
+restrict the comparison to a subset of the gears, in which case only the
+catch of those gears enters on both axes. Because the species parameter
+data frame only holds the yield summed over all gears, the observations
+then have to come from the gear parameters.
+
 The total relative error is shown in the caption of the plot, calculated by
 \deqn{TRE = \sum_i|1-\rm{ratio_i}|}{TRE = sum_i |1-ratio_i|} where
 \eqn{\rm{ratio_i}}{ratio_i} is the ratio of model yield / observed
@@ -91,4 +103,16 @@ plotYieldObservedVsModel(params, show_unobserved = TRUE)
 
 # Show the ratio instead
 plotYieldObservedVsModel(params, ratio = TRUE)
+
+# If several gears catch the same species, their yields are added up.
+# Give Cod a second gear that takes a quarter of the observed yield.
+gp <- gear_params(params)
+gp["Cod, Otter", "yield_observed"] <- 3e11 * 0.75
+extra <- gp["Cod, Otter", ]
+extra$gear <- "Gillnet"
+extra$yield_observed <- 3e11 * 0.25
+gear_params(params) <- rbind(gp, extra)
+
+# Compare only the catch of the Otter gear against its observation
+plotYieldObservedVsModel(params, gear = "Otter")
 }

--- a/tests/testthat/test-plotYieldObservedVsModel.R
+++ b/tests/testthat/test-plotYieldObservedVsModel.R
@@ -106,6 +106,84 @@ test_that("get_yield_observed sums over gears", {
                  c(Sprat = 1, Herring = 5, Cod = 7))
 })
 
+test_that("get_yield_observed selects gears", {
+    params <- NS_params_small
+    # Give Cod a second gear
+    gp <- gear_params(params)
+    gp2 <- rbind(gp, gp["Cod, Otter", ])
+    gp2$gear[[4]] <- "Extra"
+    gear_params(params) <- gp2
+    gear_params(params)$yield_observed <- c(NA, 5, 3, 4)
+
+    expect_equal(get_yield_observed(params, gear = "Otter"),
+                 c(Sprat = NA, Herring = NA, Cod = 3))
+    expect_equal(get_yield_observed(params, gear = c("Otter", "Extra")),
+                 c(Sprat = NA, Herring = NA, Cod = 7))
+    expect_equal(get_yield_observed(params, gear = c("Pelagic", "Otter")),
+                 c(Sprat = NA, Herring = 5, Cod = 3))
+
+    # The species parameters hold totals over all gears and so are ignored
+    species_params(params)$yield_observed <- c(1, 2, 3)
+    expect_equal(get_yield_observed(params, gear = "Otter"),
+                 c(Sprat = NA, Herring = NA, Cod = 3))
+
+    # Without observations in the gear parameters there is nothing to select
+    params2 <- NS_params_small
+    species_params(params2)$yield_observed <- c(1, 2, 3)
+    expect_null(get_yield_observed(params2, gear = "Otter"))
+
+    # Invalid gears are reported
+    expect_warning(expect_error(get_yield_observed(params, gear = "Trawl"),
+                                "No gears have been selected"),
+                   "The following gears do not exist: Trawl")
+})
+
+test_that("plotYieldObservedVsModel selects gears", {
+    params <- NS_params_small
+    # Give Cod a second gear that catches as much as the first
+    gp <- gear_params(params)
+    gp2 <- rbind(gp, gp["Cod, Otter", ])
+    gp2$gear[[4]] <- "Extra"
+    gear_params(params) <- gp2
+    initial_effort(params)["Extra"] <- initial_effort(params)[["Otter"]]
+    yield_gear <- getYieldGear(params)
+
+    gear_params(params)$yield_observed <- c(NA, 5, 3, 4)
+
+    # Only Cod is caught by the Otter gear
+    expect_message(dummy <- plotYieldObservedVsModel(params, gear = "Otter",
+                                                    return_data = TRUE),
+                   "not being caught by the selected gear")
+    expect_equal(as.character(dummy$species), "Cod")
+    expect_equal(dummy$observed, 3)
+    expect_equal(dummy$model, yield_gear[["Otter", "Cod"]])
+
+    # Selecting both of Cod's gears doubles model and observed yield
+    expect_message(dummy2 <- plotYieldObservedVsModel(params,
+                                                     gear = c("Otter", "Extra"),
+                                                     return_data = TRUE))
+    expect_equal(dummy2$observed, 7)
+    expect_equal(dummy2$model,
+                 yield_gear[["Otter", "Cod"]] + yield_gear[["Extra", "Cod"]])
+    # which is the same as the total over all gears for Cod
+    expect_message(dummy_all <- plotYieldObservedVsModel(params,
+                                                        return_data = TRUE))
+    expect_equal(dummy_all[dummy_all$species == "Cod", "model"],
+                 dummy2$model)
+
+    # Per-gear observations have to be in the gear parameters
+    params2 <- NS_params_small
+    species_params(params2)$yield_observed <- c(1, 2, 3)
+    expect_message(
+        expect_error(plotYieldObservedVsModel(params2, gear = "Otter"),
+                     "Observations for individual gears have to be given there"))
+
+    # The plot mentions the selected gear
+    expect_message(p <- plotYieldObservedVsModel(params, gear = "Otter",
+                                                 show_unobserved = TRUE))
+    expect_match(p$labels$caption, "gear is included: Otter")
+})
+
 test_that("get_yield_observed reads the species parameters", {
     params <- NS_params_small
     species_params(params)$yield_observed <- c(1, NA, 3)

--- a/vignettes/cheatsheet-calibration.Rmd
+++ b/vignettes/cheatsheet-calibration.Rmd
@@ -101,7 +101,9 @@ passes.
 **Yields** are not a calibration target in mizer itself: put the observed
 annual yield of each gear-species pair into the `yield_observed` column of
 [`gear_params()`](../reference/gear_params.html) and compare it with the model using
-[`plotYieldObservedVsModel()`](../reference/plotYieldObservedVsModel.html), which sums the observations over the gears. Use
+[`plotYieldObservedVsModel()`](../reference/plotYieldObservedVsModel.html), which sums the observations over the gears. Pass
+`gear = ` a subset of the gear names to compare only their catch against only
+their observations. Use
 `mizerExperimental::matchYield()` to adjust the catchability so that the yields
 match. Yields depend on the fishing setup, so make sure gears and effort are
 right first — see the [fishing cheatsheet](cheatsheet-fishing.html).

--- a/vignettes/cheatsheet-fishing.Rmd
+++ b/vignettes/cheatsheet-fishing.Rmd
@@ -52,7 +52,9 @@ the function's argument (see below). Row names follow the pattern
 There is one optional column, `yield_observed`, holding the observed annual
 yield of that gear–species pair in grams per year. It is not used by any rate
 calculation; [`plotYieldObservedVsModel()`](../reference/plotYieldObservedVsModel.html) sums it over the gears to compare the
-observations with the model.
+observations with the model, and its `gear` argument restricts that comparison
+to the catch of selected gears, for example
+`plotYieldObservedVsModel(params, gear = "Otter")`.
 
 **Editing an existing gear table.** Pull it out, change what you need, and
 assign it back — the assignment triggers recalculation of the selectivity and


### PR DESCRIPTION
Closes #286.

`plotYieldObservedVsModel()` assumed that each species is caught by a single gear. Summing the observations over the gears fixed one half of that in #526/#528; this adds the other half, a `gear` argument, so that in a model where several gears catch the same species you can ask how each gear compares with its own observation.

`matchYield()` and `calibrateYield()`, also named in the issue, are no longer part of mizer, so nothing was done for them.

## Changes

**`R/plotYieldObservedVsModel.R`**

- `plotYieldObservedVsModel()`, its `MizerSim` method and `plotlyYieldObservedVsModel()` gain a `gear` argument. With gears selected, the model yield is `getYieldGear()` summed over those gears and the observed yield comes from the `yield_observed` entries of those gear rows only, so both axes describe the same catch. The argument is placed last, before `...`, so existing positional calls are unaffected. With `gear = NULL` (the default) the behaviour is exactly as before.
- `get_yield_observed(params, gear = NULL)` gains the matching argument. When gears are selected it sums over just those gear parameter rows and deliberately ignores the species parameter fallback, because that column holds a total over all gears. It returns `NULL` when the gear parameters have no `yield_observed` column, and the plot then errors with a message pointing at `gear_params()` rather than the generic one.
- Species with zero yield are still dropped, but the info message now says "not being caught by the selected gear(s)" when a gear is selected, and the plot caption names the gears included.
- Documentation, and an example with a species caught by two gears.

**Tests** — new blocks in `test-plotYieldObservedVsModel.R` for gear selection in `get_yield_observed()` (single gear, several gears, species parameter column ignored, missing gear column, invalid gear name) and in the plot (per-gear model and observed yield against `getYieldGear()`, the sum over a species' two gears matching the all-gear total, the gear-params-required error, the caption). `devtools::test(filter = "plotYieldObservedVsModel|summary_methods")` passes, 200 tests, no failures.

**Docs** — regenerated `man/`, a NEWS entry under "Other improvements", and a mention of the argument in the `set-up-fishing` and `calibrate-model` skills with `build_cheatsheets()` re-run. No `upgrade-mizer-code` entry, since no existing user code changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)