### PR TITLE
Speed up the test suite by 14% and fix an order-dependent test failure

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -111,6 +111,16 @@ delayedAssign("NS_params_default_small", suppressMessages(
 delayedAssign("NS_params_cod_small", suppressMessages(
     newMultispeciesParams(NS_species_params_gears_small[3, ], info_level = 0)
 ))
+# NS_params_small settled onto its steady state, for the many tests that need
+# *a* model at steady state rather than to test steady() itself. The tolerance
+# is the tightest any consumer needs (test-rate_functions.R checks the flux
+# gradient against the mortality loss to 1e-8), and converging once to 1e-10 is
+# cheaper than the several looser calls it replaces. Tests of steady() itself
+# belong in test-steady.R and must of course keep calling it.
+delayedAssign("NS_params_steady_small", suppressMessages(
+    steady(NS_params_small, tol = 1e-10, t_max = 500,
+           progress_bar = FALSE, info_level = 0)
+))
 
 # Test that a MizerParams or MizerSim object has not changed except for the
 # time_modified and perhaps a reordering of the species_params columns.

--- a/tests/testthat/test-extension.R
+++ b/tests/testthat/test-extension.R
@@ -346,7 +346,10 @@ test_that("Other components get a corrector step under second-order methods", {
         project(make_p(), t_max = 2, t_save = 2, dt = dt, method = method,
                 progress_bar = FALSE)@n_other[[2, "accum"]]
     }
-    ref <- accum("euler", 0.0005)            # fine-step reference
+    # Fine-step reference. dt = 0.002 is 50x smaller than the step compared
+    # against it, which leaves the margins below essentially where a much
+    # finer reference puts them at four times the cost.
+    ref <- accum("euler", 0.002)
 
     euler_err <- abs(accum("euler", 0.1) - ref)
     for (method in c("predictor_corrector", "tr_bdf2")) {

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -97,9 +97,7 @@ test_that("the calibrate functions do not claim to break the steady state", {
     # They apply one overall scaling factor, which is an exact symmetry of the
     # model, so the steady state survives them untouched. If this ever stops
     # being true they need the notice that the match functions carry.
-    p <- suppressMessages(
-        steady(NS_params_small, tol = 1e-6, t_max = 500,
-               progress_bar = FALSE, info_level = 0))
+    p <- NS_params_steady_small
     before <- steady_biomass_drift(p)
     species_params(p)$biomass_observed <- as.numeric(getBiomass(p)) * 2
     expect_equal(steady_biomass_drift(suppressMessages(calibrateBiomass(p))),

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -720,8 +720,10 @@ test_that("tlim filters time axis correctly", {
                                        tlim = c(1, 3), return_data = TRUE))
     expect_lt(limited_rows, all_rows)
 
-    # animate: deprecated time_range triggers warning
-    expect_warning(animate(sim, time_range = 1:3), "deprecated")
+    # The deprecation of animate(time_range) is tested in
+    # test-animateSpectra.R, where animate() is defined. It cannot be tested
+    # here as well: lifecycle warns only once per session, so whichever file
+    # ran second would see no warning.
 })
 
 # Legends have the correct entries ----

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -679,9 +679,7 @@ test_that("Time resampling in project behaves as documented", {
 # check_steady ----
 
 # A settled model and a copy that has been knocked off its steady state.
-steady_small <- suppressMessages(
-    steady(NS_params_small, tol = 1e-6, t_max = 500,
-           progress_bar = FALSE, info_level = 0))
+steady_small <- NS_params_steady_small
 off_steady_small <- local({
     p <- steady_small
     initialN(p)[1, ] <- initialN(p)[1, ] * 3

--- a/tests/testthat/test-project_n.R
+++ b/tests/testthat/test-project_n.R
@@ -203,7 +203,7 @@ test_that("tr_bdf2 runs and keeps densities finite and non-negative", {
 })
 
 test_that("tr_bdf2 preserves a steady state", {
-    ps <- suppressMessages(steady(NS_params_small, progress_bar = FALSE))
+    ps <- NS_params_steady_small
     sim_t <- project(ps, t_max = 5, dt = 0.1, method = "tr_bdf2",
                      progress_bar = FALSE)
     sim_e <- project(ps, t_max = 5, dt = 0.1, method = "euler",

--- a/tests/testthat/test-rate_functions.R
+++ b/tests/testthat/test-rate_functions.R
@@ -911,7 +911,7 @@ test_that("getFluxGradient balances mortality at a steady state", {
     # The McKendrick-von Foerster equation is
     #     dN/dt = -dJ/dw - mu N,
     # so at a steady state the flux gradient must cancel the mortality loss.
-    params <- suppressMessages(steady(NS_params_small, tol = 1e-10))
+    params <- NS_params_steady_small
     fg <- getFluxGradient(params)
     loss <- getMort(params) * initialN(params)
     expect_equal(unclass(fg), -unclass(loss), ignore_attr = TRUE,

--- a/tests/testthat/test-summary_methods.R
+++ b/tests/testthat/test-summary_methods.R
@@ -471,9 +471,7 @@ test_that("str works", {
 })
 
 test_that("summary of MizerParams reports the steady-state verdict", {
-    p <- suppressMessages(
-        steady(NS_params_small, tol = 1e-6, t_max = 500,
-               progress_bar = FALSE, info_level = 0))
+    p <- NS_params_steady_small
     line <- grep("biomass drift", capture.output(summary(p)), value = TRUE)
     expect_length(line, 1)
     expect_match(line, "/year")

--- a/tests/testthat/test-transport.R
+++ b/tests/testthat/test-transport.R
@@ -184,7 +184,11 @@ test_that("the second-order scheme is second order in the size step", {
              sum(ana[mask]^2 * pr@dw[mask]))
     }
 
-    no_ws <- c(200, 400, 800)
+    # Three grids an octave apart. This is the most expensive test in the
+    # suite, so the triple is kept as coarse as the fit allows: on 100/200/400
+    # the measured orders are 0.75 and 2.07, further from the thresholds below
+    # than the finer 200/400/800 triple manages, at a third of the cost.
+    no_ws <- c(100, 200, 400)
     dx <- log(1000 / 1e-3) / no_ws
     slope <- function(e) coef(lm(log(e) ~ log(dx)))[2]
     ord_upwind <- slope(sapply(no_ws, err, second_order = FALSE))


### PR DESCRIPTION
Profiling the suite serially (`NOT_CRAN=true`, experimental gate off) showed the
time concentrated in a few places where the same work was being done repeatedly,
or at a finer resolution than the assertions need. No assertion is weakened:
where a resolution was lowered, the measured margin against the threshold is
recorded in a comment and is at least as good as before.

## Changes

**`test-transport.R` — the most expensive test in the suite, 18.2 s → 6.9 s**

"the second-order scheme is second order in the size step" ran six simulations on
grids of `no_w = 200, 400, 800`. Halving the triple keeps the same three-point
convergence fit and the same two assertions:

| grid | time | upwind order (`< 1.2`) | second order (`> 1.8`) |
|---|---|---|---|
| 200, 400, 800 | 15.3 s | 0.849 | 1.899 |
| **100, 200, 400** | **5.6 s** | **0.754** | **2.073** |

Margin against both thresholds improves. Below `no_w = 100` the cost plateaus —
it is then dominated by the 280 time steps — so this is the useful floor. `dt` is
left at 0.005; raising it to 0.01 would save another 2.5 s but drops the order
estimate to 1.934 against a 1.8 threshold, too thin to be worth it.

**Shared steady-state fixture — ~7.0 s of `steady()` → 2.1 s**

`steady(NS_params_small, ...)` was being computed from scratch in six files. Five
of them only want *a* model at steady state, so they now share a new
`NS_params_steady_small` in `helper.R`, added as a `delayedAssign` alongside the
existing fixtures. Its `tol = 1e-10` is the tightest any consumer needs
(`test-rate_functions.R` checks the flux gradient against the mortality loss to
`1e-8`), and converging once to `1e-10` is cheaper than the several looser calls
it replaces. Updated: `test-rate_functions.R`, `test-match.R`,
`test-summary_methods.R`, `test-project.R`, `test-project_n.R`. `test-steady.R`
still calls `steady()` itself, since that is what it is testing.

**`test-extension.R` — over-resolved reference solution, 4.2 s → 2.3 s**

The corrector test's `ref <- accum("euler", 0.0005)` is 4000 steps for a
reference compared only against `dt = 0.1` results, with a deliberately generous
margin. At `dt = 0.002` the reference costs 0.60 s instead of 2.46 s and the
margins barely move:

| ref `dt` | cost | `predictor_corrector` err / allowance | `tr_bdf2` err / allowance |
|---|---|---|---|
| 0.0005 | 2.46 s | 0.529 | 0.433 |
| **0.002** | **0.60 s** | **0.510** | **0.413** |

**`test-plots.R` — remove a duplicate assertion that was a latent failure**

`test-plots.R` and `test-animateSpectra.R:99` both asserted that
`animate(time_range=)` warns. `lifecycle::deprecate_warn()` fires once per
session, so whichever file ran second saw no warning and failed:

```
FAILURE: 'test-animateSpectra.R:99:5'
Expected `animateSpectra(sim, time_range = c(1, 3))` to throw a warning.
```

This is invisible under the default parallel runner, which puts the two files in
different processes, but reproduces immediately when the suite runs serially. The
`test-plots.R` copy is the one removed: `animate()` is defined in
`R/animateSpectra.R`, so the test-organisation rule puts the assertion in
`test-animateSpectra.R` anyway. A comment at the removal site records why it must
not come back.

## Verification

- Serial in-test time: **103.3 s → 89.2 s (−14%)**.
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 32 | PASS 4094`, against a baseline
  of `PASS 4095`. The single difference is the removed duplicate deprecation
  assertion, still covered in `test-animateSpectra.R`.

## Considered and deliberately left alone

- `test-plots.R` plotly test (3.7 s) — 15 genuine `ggplotly()` conversions, each
  covering a distinct wrapper's tooltip fields.
- `projectToSteady()` limit-cycle test (4.2 s) — genuinely needs `t_max = 200` on
  the full NS model; at 100 it reports `not_converged`.
- vdiffr snapshot tests — shrinking `params` would force re-recording every figure.

No user-visible behaviour changes, so `NEWS.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrkBrbVZaoMTDaw9s7NLBE
