### PR TITLE
Improve parameter defaults handling, skills and cheatsheets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,19 @@ stability of steady states.
 
 ## Bug fixes
 
+- `get_f0_default()` now respects `interaction_resource` under `defaults_edition() >= 2`,
+  making it the exact inverse of `get_gamma_default()`.
+
+- `get_gamma_default()` and `get_ks_default()` now provide informative error messages
+  when called on a model with `h = Inf`, indicating that `gamma` or `ks` must be
+  supplied explicitly.
+
+- `given_species_params<-()` now warns when `k_vb` is specified on a model where
+  `h` or `age_mat` is already given and will override `k_vb`.
+
+- `repair_params()` now suggests `adjustSizeGrid()` instead of the deprecated `expandSizeGrid()`
+  when `w_min` is smaller than the grid minimum.
+
 - `plotCDF()`, `plotCDF2()`, `plotSpectra2()`, and `plotSpectraRelative()` now
   support `size_axis = "l"` together with `total = TRUE`. The total spectrum and
   cumulative distributions are summed across species on the length axis.

--- a/R/MizerParams-class.R
+++ b/R/MizerParams-class.R
@@ -1108,8 +1108,8 @@ repair_params <- function(params) {
                 "minimum weight of the weight grid in the model: ",
                 paste(params@species_params$species[wrong], collapse = ", "),
                 ". I have increased it to ", w_min, ". Before you can decrease ",
-                "it further you will need expand the weight grid with ",
-                "`expandSizeGrid()`.")
+                "it further you will need to expand the weight grid with ",
+                "`adjustSizeGrid()`.")
     }
     params@w_min_idx <- get_w_min_idx(params@species_params, params@w)
     # w_max should not be larger than the maximum weight of the model

--- a/R/info_signals.R
+++ b/R/info_signals.R
@@ -412,9 +412,9 @@ signal_ignored_changes <- function(given, changed) {
             overridden <- active_changes & !is.na(given[[takes_precedence]])
             if (any(overridden)) {
                 signal_info(par, paste0(
-                    "You have specified some values for `", par, "` that are ",
-                    "going to be ignored because values for `", takes_precedence,
-                    "` have already been given."),
+                    "The values you specified for `", par, "` will not lead ",
+                    "to a re-calculation of `", takes_precedence,
+                    "` because its value was explicitly given."),
                     level = 1, severity = "warning", unhandled = "show")
                 active_changes[overridden] <- FALSE
             }

--- a/R/info_signals.R
+++ b/R/info_signals.R
@@ -371,19 +371,20 @@ signal_frozen_changes <- function(params, changed) {
 
 # The species parameters that mizer only uses to calculate a default for
 # another one, and so ignores once that other one has been given. Each entry is
-# named after the parameter that is ignored and gives the parameter that takes
+# named after the parameter that is ignored and gives the parameter(s) that take
 # precedence over it.
 overridden_species_params <- function() {
-    c(f0 = "gamma", fc = "ks", age_mat = "h")
+    list(f0 = "gamma", fc = "ks", age_mat = "h", k_vb = c("h", "age_mat"))
 }
 
 #' Signal the changes that are ignored because another parameter was given
 #'
 #' Some species parameters are only used to calculate a default for another
-#' one: `f0` for `gamma`, `fc` for `ks` and `age_mat` for `h`. Once the other
-#' one has been given, the model no longer consults them, so changing them has
-#' no effect. This raises a warning about that. It is one of the diagnostics
-#' that only [given_species_params<-()] gives, see there.
+#' one: `f0` for `gamma`, `fc` for `ks`, `age_mat` for `h`, and `k_vb` for
+#' `h` or `age_mat`. Once the other one has been given, the model no longer
+#' consults them, so changing them has no effect. This raises a warning about
+#' that. It is one of the diagnostics that only [given_species_params<-()]
+#' gives, see there.
 #'
 #' Only a value that is there can be ignored, so this is asked about the
 #' species that were *given* a value, not about every species whose value
@@ -399,17 +400,24 @@ overridden_species_params <- function() {
 #' @concept helper
 signal_ignored_changes <- function(given, changed) {
     for (par in names(overridden_species_params())) {
-        takes_precedence <- overridden_species_params()[[par]]
-        if (!(par %in% names(changed)) ||
-            !(takes_precedence %in% names(given))) {
+        if (!(par %in% names(changed))) {
             next
         }
-        if (any(!is.na(given[[takes_precedence]][changed[[par]]]))) {
-            signal_info(par, paste0(
-                "You have specified some values for `", par, "` that are ",
-                "going to be ignored because values for `", takes_precedence,
-                "` have already been given."),
-                level = 1, severity = "warning", unhandled = "show")
+        takes_precedence_list <- overridden_species_params()[[par]]
+        active_changes <- changed[[par]]
+        for (takes_precedence in takes_precedence_list) {
+            if (!(takes_precedence %in% names(given))) {
+                next
+            }
+            overridden <- active_changes & !is.na(given[[takes_precedence]])
+            if (any(overridden)) {
+                signal_info(par, paste0(
+                    "You have specified some values for `", par, "` that are ",
+                    "going to be ignored because values for `", takes_precedence,
+                    "` have already been given."),
+                    level = 1, severity = "warning", unhandled = "show")
+                active_changes[overridden] <- FALSE
+            }
         }
     }
     invisible(NULL)

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -1376,6 +1376,9 @@ get_gamma_default <- function(params) {
             params@w[length(params@w)] ^
             (2 + params@species_params[["q"]] - params@resource_params$lambda)
         # Now set gamma so that this available energy leads to f0
+        if (any(is.infinite(species_params[["h"]][missing]))) {
+            stop("Cannot calculate default `gamma` for species with `h = Inf`. Please supply `gamma` explicitly.")
+        }
         gamma_default <- (species_params[["h"]] / avail_energy) *
             (species_params$f0 / (1 - species_params$f0))
         # Only overwrite missing gammas with calculated values
@@ -1435,7 +1438,9 @@ get_f0_default <- function(params) {
         params@search_vol[given, ] <- compute_search_vol(params)[given, ]
         # Calculate available energy by setting a power-law prey spectrum
         params@initial_n[] <- 0
-        params@species_params$interaction_resource <- 1
+        if (defaults_edition() < 2) {
+            params@species_params$interaction_resource <- 1
+        }
         params@initial_n_pp[] <- resource_power_law(
             params, params@resource_params$kappa,
             params@resource_params$lambda)
@@ -1480,6 +1485,13 @@ get_ks_default <- function(params) {
     }
     params <- set_species_param_default(params, "fc", 0.2)
     sp <- params@species_params
+    if (!"ks" %in% names(sp)) {
+        sp$ks <- rep(NA_real_, nrow(sp))
+    }
+    missing_ks <- is.na(sp$ks)
+    if (any(missing_ks) && any(is.infinite(sp[["h"]][missing_ks]))) {
+        stop("Cannot calculate default `ks` for species with `h = Inf`. Please supply `ks` explicitly.")
+    }
     ks_default <- sp$fc * sp$alpha * sp[["h"]] * sp$w_mat^(sp[["n"]] - sp[["p"]])
 
     message <- ("No ks column so calculating from critical feeding level.")

--- a/inst/skills/build-multispecies-model/SKILL.md
+++ b/inst/skills/build-multispecies-model/SKILL.md
@@ -4,11 +4,12 @@ description: >-
   Build a multi-species mizer model from a species-parameter data frame. Use
   whenever the user wants to create a MizerParams object with
   newMultispeciesParams() (or newTraitParams, newCommunityParams,
-  newSingleSpeciesParams), set up an interaction matrix or fishing gears, choose
-  the size grid, or save and reload a finished model. Follow this ordered
-  workflow rather than guessing at parameters or writing the dynamics by hand.
-  Once the object exists, bringing it to steady state and calibrating it to data
-  is covered by the calibrate-model skill.
+  newSingleSpeciesParams), set up an interaction matrix, choose the size grid,
+  or save and reload a finished model. Follow this ordered workflow rather than
+  guessing at parameters or writing the dynamics by hand. Once the object
+  exists, setting up fishing is covered by the set-up-fishing skill, and
+  bringing it to steady state and calibrating it to data is covered by the
+  calibrate-model skill.
 ---
 
 # Building a multi-species mizer model
@@ -53,11 +54,13 @@ Commonly supplied:
 
 | Column | Meaning |
 |---|---|
+| `w_min` | Egg size (g, default 0.001) |
 | `w_mat` | Maturity weight (g) |
 | `beta` | Preferred predator/prey mass ratio (default 30) |
 | `sigma` | Width of the lognormal predation kernel (default 2) |
 | `k_vb` | von Bertalanffy K — used to derive `h` (and then `gamma`) if `h`/`gamma` absent |
 | `h`, `gamma` | Max intake coefficient and search-volume coefficient (alternative to `k_vb`) |
+| `a`, `b` | Length–weight conversion parameters ($w = a l^b$, defaults 0.006 and 3) |
 | `alpha` | Assimilation efficiency (default 0.6) |
 | `biomass_observed` | Observed biomass, for calibration |
 
@@ -80,8 +83,9 @@ Useful optional arguments to `newMultispeciesParams()`:
 | Argument | Effect |
 |---|---|
 | `interaction` | species × species matrix of dimensionless overlaps in `[0, 1]` (1 = full interaction, the default for every pair); scales encounter and predation mortality |
-| `gear_params` | fishing gear definitions — columns `gear`, `species`, `sel_func`, `catchability` and the selectivity parameters. Omit it and mizer builds a default knife-edge gear catching every species |
-| `no_w`, `min_w`, `max_w` | size-grid resolution and range (`no_w = 100` by default) |
+| `kappa`, `lambda`, `w_pp_cutoff` | resource spectrum coefficient, exponent, and cutoff size |
+| `no_w` | number of size bins on the logarithmic grid (default 100; the size range is determined automatically from the species parameters) |
+| `gear_params` | fishing gear definitions (usually omitted and configured later with the `set-up-fishing` skill; defaults to a knife-edge gear catching every species) |
 | `second_order_w` | use the second-order size-advection scheme; see the section "Numerical scheme: watch for numerical diffusion" in the `run-simulation` skill |
 
 Change gears later with `gear_params(params) <- ...` or `setFishing()` — see the
@@ -92,7 +96,7 @@ Change gears later with `gear_params(params) <- ...` or `setFishing()` — see t
 ```r
 summary(params)
 species_params(params)     # given + calculated, one row per species
-getInteraction(params)     # the interaction matrix
+interaction_matrix(params) # the interaction matrix
 gear_params(params)        # the fishing gears
 resource_params(params)    # the resource scalars
 ```
@@ -129,17 +133,3 @@ getMetadata(params)     # read the metadata back
 
 All fields are optional and you can add fields of your own. mizer also fills in
 `mizer_version`, `extensions`, `time_created` and `time_modified` automatically.
-
-## Common pitfalls
-
-- Forgetting to reassign the return value (`steady(params)` without `params <-`)
-  silently discards the work.
-- Skipping `steady()` after a `match…`/`calibrate…` step leaves the model off
-  its steady state.
-- Editing a species parameter on a bare data frame instead of through
-  `species_params(params) <-` means no dependent quantity is recalculated. See
-  the `change-parameters` skill.
-- Passing `max_w = w_inf` to `newMultispeciesParams()` errors, because `w_max`
-  still defaults to `1.5 * w_inf` and the grid then stops below it. To run the
-  grid up to the asymptotic size, give the species parameter data frame a
-  `w_max` column equal to `w_inf` as well.

--- a/inst/skills/build-multispecies-model/quick-reference.md
+++ b/inst/skills/build-multispecies-model/quick-reference.md
@@ -2,13 +2,13 @@
 # ── Build ─────────────────────────────────────────────────────────────────────
 species_params <- read.csv(
     system.file("extdata", "NS_species_params.csv", package = "mizer"))
-params <- newMultispeciesParams(species_params, interaction)
+params <- newMultispeciesParams(species_params)
 params <- newTraitParams()  # or newCommunityParams(), newSingleSpeciesParams()
 
 # ── Inspect ───────────────────────────────────────────────────────────────────
 summary(params)
 species_params(params)      # given + calculated, one row per species
-getInteraction(params)      # the interaction matrix
+interaction_matrix(params)  # the interaction matrix
 gear_params(params)         # the fishing gears
 resource_params(params)     # the resource scalars
 

--- a/inst/skills/change-parameters/SKILL.md
+++ b/inst/skills/change-parameters/SKILL.md
@@ -19,9 +19,6 @@ one to reach for. The guiding principle:
 > mizer propagate the change downwards.** Drop to a lower level only when you
 > deliberately want to override mizer's calculation.
 
-Every setter returns a **new** `MizerParams` — always reassign
-(`params <- setResource(params, ...)`).
-
 ## The levels of a mizer model
 
 A mizer model is built in layers, and almost every change is a choice of which
@@ -29,7 +26,7 @@ layer to reach into:
 
 | Level | What it is | Change it with |
 |---|---|---|
-| **1. Size-independent parameters** | the high-level inputs: per-species scalars (`w_inf`, `beta`, `gamma`, `h`, `erepro`, …), fishing gears, resource scalars, and interactions | `species_params(params) <-`, `gear_params(params) <-`, `resource_params(params) <-`, `setInteraction()` |
+| **1. Size-independent parameters** | the high-level inputs: per-species scalars (`w_inf`, `beta`, `gamma`, `h`, `erepro`, …), fishing gears, resource scalars, and interactions | `species_params(params) <-`, `gear_params(params) <-`, `resource_params(params) <-`, `interaction_matrix()` |
 | **2. Size-dependent rates** | arrays over size that mizer **calculates** from those parameters (search volume, metabolic rate, predation kernel, resource capacity, selectivity, …) | the `set…()` functions |
 | **3. Rate functions** | the functions mizer calls to compute the rates during a simulation | `setRateFunction()`, `setComponent()` |
 
@@ -57,7 +54,7 @@ track of which values you **gave** and which it **calculated**.
 | `calculated_species_params(params)` | the parameters mizer derived or defaulted |
 | `species_params(params)` | everything (given, with calculated filling the gaps) |
 
-**Rule (mizer ≥ 3.2): change species parameters with `species_params(params) <-`.**
+**Rule: change species parameters with `species_params(params) <-`.**
 It detects what you changed, records it as *given* (so defaults can no longer
 overwrite it), and triggers recalculation of the derived scalars **and** the
 size-dependent rate arrays that depend on it.
@@ -66,7 +63,7 @@ size-dependent rate arrays that depend on it.
 species_params(params)$beta <- 150   # recorded as given; also rebuilds the predation kernel
 ```
 
-`given_species_params(params) <-` reaches the same model and is preferable in
+`given_species_params(params) <-` makes the same changes and is preferable in
 **interactive** sessions, because it additionally *warns* whenever a change you
 asked for cannot take effect: the parameter is overridden by another one you
 have already given, or it feeds a rate array you set by hand, or it is a gear
@@ -106,12 +103,7 @@ touched — on `NS_params` it turns 312 given entries into 396.
 
 > **Version note.** Older guidance said to avoid `species_params(params) <-`
 > because it bypassed the `given_species_params` protection and skipped
-> recalculation. That was fixed in mizer 3.2. On mizer **< 3.2**, still prefer
-> `given_species_params(params) <-` for edits. On mizer **< 3.3** the two are
-> not interchangeable on a model that specifies sizes as lengths: only
-> `species_params(params) <-` applied the length/weight precedence rule, so a
-> length changed through `given_species_params(params) <-` left the weight at
-> its old value.
+> recalculation. That is now fixed.
 
 Columns come back as named vectors:
 
@@ -160,49 +152,98 @@ parameters `a`, `b`.
 
 Mizer fills in what you did not supply, and the derivations are chained:
 `age_mat` → `h` → `gamma` and `ks`. Changing one parameter therefore rarely
-changes just that one thing. The three sections below cover the traps this
-creates; for the derivations themselves see
+changes just that one thing.
+
+The three sections below cover the traps this creates; for the mathematical
+derivations themselves see
 [Calculation of Default Parameter Values](default_parameters.html).
 
-### A parameter and its derived partner cancel out
+### Whether a value is given determines whether it is recalculated
+
+For derived parameters, `given_species_params()` distinguishes fixed input from
+a cached calculated value.
+
+**Giving a value switches off the recalculation from another parameter.**
+`given_species_params<-()` warns when you set a parameter that would usually
+be used to recalculate another parameter but this recalculation is
+suppressed because that other parameter has been given explicitly.
+
+| If you have given… | this is ignored |
+|---|---|---|
+| `gamma` | `f0` |
+| `ks` | `fc` |
+| `h` | `age_mat`, `k_vb` |
+| `age_mat` | `k_vb` |
+
+To let mizer re-calculate a parameter you previously supplied, clear it by setting
+it to `NA` in `given_species_params(params)`.
+
+Finally, `w_inf` is not a purely dynamic parameter. Changing it re-derives
+`w_mat`, `h`, `gamma` and `ks`, but the **size grid is fixed at construction**,
+so enlarging `w_inf` beyond the maximum grid size gives repeated warnings that
+"the maximum weight of a species is larger than the maximum weight of the model".
+To expand the size range, use `adjustSizeGrid(params, new_max_w = ...)` or
+rebuild the model.
+
+### Chained derivations and the cancellation trap
+
+When parameters are not given, mizer calculates them along a dependency chain:
+
+```
+Inputs: [age_mat / k_vb, w_mat, w_min, alpha, f0, fc]
+                         │
+                         ▼
+                      [  h  ] ─────────┬─────────┐
+                         │             │         │
+                         │             │ (with f0, kappa, lambda, kernel)
+                         │             │         │ (with fc, alpha, w_mat)
+                         ▼             ▼         ▼
+                  [ intake_max ]   [ gamma ]   [ ks ]
+```
 
 When `gamma` (the search-volume coefficient) is not supplied, mizer **derives it
 from the target feeding level `f0`** — roughly `gamma ∝ h · f0 / (1 - f0)` — so
-that the feeding level comes out at `f0`. A consequence often missed: raising
-`h` does **not** lower the feeding level, because the derived `gamma`
-compensates and the feeding level stays pinned at `f0`. To make growth more or
-less resource-dependent (a stronger or weaker density dependence, the
-"phantom-jam" feedback), change **`f0`**, not `h`: low `f0` makes juvenile
-growth strongly resource-limited, `f0` near 1 makes it nearly saturated and
-resource-insensitive.
+that the feeding level comes out at `f0`.
+
+A consequence often missed: raising `h` does **not** lower the feeding level,
+because the derived `gamma` compensates and the feeding level stays pinned at
+`f0`. To make growth more or less resource-dependent (a stronger or weaker
+density dependence, the "phantom-jam" feedback), change **`f0`**, not `h`: low
+`f0` makes juvenile growth strongly resource-limited, `f0` near 1 makes it nearly
+saturated and resource-insensitive.
 
 `ks` does the same thing one level down. When it is not supplied it is derived
 as `ks = fc · alpha · h · w_mat^(n - p)`, so raising `h` does **not** bring a
 species closer to starvation: the metabolic coefficient scales with it and the
 critical feeding level stays pinned at `fc`.
 
-| To change… | change | not |
-|---|---|---|
-| the feeding level, how resource-limited growth is | `f0` | `h` |
-| the critical feeding level, how close to starvation a species is | `fc` | `ks`, `h` |
-| growth speed, with both feeding levels held fixed | `h` | — |
+**Intent-first guide:**
+
+| Desired Goal | Change This | Do NOT Change | Why / What Happens |
+|---|---|---|---|
+| the feeding level (resource sensitivity of growth) | `f0` | `h` | Raising `h` auto-scales `gamma`, keeping feeding level at `f0`. |
+| the critical feeding level (starvation risk) | `fc` | `ks`, `h` | Raising `h` auto-scales `ks`, keeping critical level at `fc`. |
+| growth speed across all sizes, holding feeding level fixed | `h` | `f0` | `h` scales maximum intake while feeding levels stay fixed. |
+| bespoke search volume / metabolism | `gamma`, `ks` | `f0`, `fc` | Giving `gamma` or `ks` disconnects the automatic derivation. |
 
 Corollary: `h = Inf` (a deliberately "no-satiation" model) makes the derived
-`gamma` non-finite and throws `search_vol must not contain non-finite values` —
-supply `gamma` explicitly in that case.
+`gamma` and `ks` non-finite and throws an error asking you to supply `gamma` and
+`ks` explicitly.
 
-The chain also runs the other way, which is easy to forget. When `age_mat` is
-given (or `k_vb`, from which mizer estimates it), `h` is *derived* from it:
+**The reverse ripple effect from age at maturity.**
+The chain also runs the other way. When `age_mat` is given (or `k_vb`, from
+which mizer estimates it), `h` is *derived* from it:
 
 ```
 h = (w_mat^(1-n) - w_min^(1-n)) / (age_mat * (1-n) * alpha * (f0 - fc))
 ```
 
-So `f0` and `fc` are not local edits to the feeding level — they move `h`, and
-`h` carries the change on into `gamma` and `ks`. The same goes for `w_mat`,
-which is never just the maturity size: it feeds `h` through the formula above,
-`ks` through the `w_mat^(n - p)` factor, and `w_mat25`. And `beta`/`sigma` feed
-the `gamma` derivation, because that integrates the predation kernel.
+So `f0` and `fc` are not local edits to feeding levels — when `age_mat` is
+given they move `h`, and `h` carries the change on into `gamma` and `ks`. The
+same goes for `w_mat`, which is never just the maturity size: it feeds `h`
+through the formula above, `ks` through the `w_mat^(n - p)` factor, and
+`w_mat25`. And `beta`/`sigma` feed the `gamma` derivation because that
+integrates the predation kernel.
 
 If a user is puzzled that "changing `w_mat` changed my growth curve everywhere",
 this is why. To pin a parameter against the chain, give it explicitly — a given
@@ -223,9 +264,11 @@ forced to 1. So `f0` is the feeding level a species *would* have in that world.
   levels.
 - Setting `interaction_resource` to anything other than 1 leaves `gamma`
   untouched under edition 1, so the reduction falls straight through to the
-  realised feeding level and can starve a species outright.
+  realised feeding level and can starve a species outright. Under
+  `defaults_edition() >= 2`, `interaction_resource` is included in the
+  calibration.
 - The resource scalars that enter the calibration **do** trigger a
-  re-derivation, but only of the values mizer owns. Since mizer 3.3, changing
+  re-derivation. Since mizer 3.3, changing
   `lambda` recalculates every `q` and `gamma` that mizer calculated, and
   changing `kappa` recalculates every calculated `gamma`; the condition
   `q = n + lambda - 2` that makes the feeding level size-independent is
@@ -247,66 +290,11 @@ given_species_params(params)$q <- species_params(params)$q
 resource_params(params)$lambda <- 2.2       # q now stays put
 ```
 
-On mizer **< 3.3** neither refresh happened: the resource arrays were rebuilt but
-`gamma` and `q` were left at the values for the old resource, and had to be set
-to `NA` by hand.
-
-### Whether a value is given determines whether it is recalculated
-
-For derived parameters, `given_species_params()` distinguishes fixed input from
-a cached calculated value. In particular, `setExtMort()` recalculates `z0`
-wherever it is absent or `NA` in `given_species_params()`, even though an older
-calculated value is still present in `species_params()`. Two practical
-consequences:
-
-**Arguments that only feed a default work only while values are missing.**
-`setExtMort()` computes `z0 = z0pre * w_inf^z0exp` for non-given `z0` values.
-If `z0` is present in `given_species_params()` for every species, supplying
-`z0pre` or `z0exp` cannot take effect and gives a warning. `reset = TRUE` does
-not help: it clears the rate array's comment, not the given species parameter.
-To hand `z0` back to the calculation, set it to `NA` in
-`given_species_params()`:
-
-```r
-z0exp <- resource_params(params)$n - 1   # the construction default
-given_species_params(params)$z0 <- 2 * species_params(params)$w_inf^z0exp
-
-# Or hand z0 back to the default calculation.
-given_species_params(params)$z0 <- NA
-```
-
-An explicitly supplied `z0pre` or `z0exp` is used for every non-given `z0` and
-the resulting values are recorded in `given_species_params()`. Values filled
-from the arguments' defaults are not recorded there and will be recalculated
-on the next call.
-
-**Giving a value switches off the calculation that would have used another one.**
-`given_species_params<-()` warns about the first three, `species_params<-()`
-about none of them — another reason to prefer the former interactively:
-
-| If you have given… | this is ignored | warns |
-|---|---|---|
-| `gamma` | `f0` | yes |
-| `ks` | `fc` | yes |
-| `h` | `age_mat` | yes |
-| `h` | `k_vb` | no |
-
-Two more are silent: `h` falls back to **30** when there is no growth
-information at all (no `age_mat`, no `k_vb`), and with `n != p` the derivation
-of `h` is only approximate — mizer says so at message level 1, which is easily
-missed.
-
-Finally, `w_inf` is not a purely dynamic parameter. Changing it re-derives
-`w_mat`, `h`, `gamma` and `ks`, but the **size grid is fixed at construction**,
-so enlarging `w_inf` gives repeated warnings that "the maximum weight of a
-species is larger than the maximum weight of the model". To change the size
-range, rebuild the model rather than edit the parameter.
-
 ## Level 1: fishing gear parameters
 
 Gears, selectivity, and catchability live in `gear_params(params)`, one row per
-gear–species pair (row names `"species, gear"`). Assigning to it **does**
-recompute the fishing arrays.
+gear–species pair (row names `"species, gear"`). Assigning to it recomputes the
+fishing arrays.
 
 ```r
 gp <- gear_params(params)
@@ -319,10 +307,10 @@ setting baseline effort. See the `set-up-fishing` skill.
 
 ## Level 1: resource parameters
 
-The resource works just like the species parameters.
-`resource_params(params)` returns a named list of scalars (`kappa`, `lambda`,
-`r_pp`, `n`, `w_pp_cutoff`) that set up the resource size-spectrum arrays, and —
-like `species_params<-` — assigning to it **rebuilds those arrays** by calling
+The resource works just like the species parameters. `resource_params(params)`
+returns a named list of scalars (`kappa`, `lambda`, `r_pp`, `n`, `w_pp_cutoff`).
+These parameters set up the resource size-spectrum arrays, and — like
+`species_params<-` — assigning to it **rebuilds those arrays** by calling
 `setResource()`:
 
 ```r
@@ -348,14 +336,14 @@ level-2 change and is covered under
 
 ## Level 1: the interaction matrix
 
-The species × species interaction matrix is set with `setInteraction()` and read
-with `getInteraction()`. The resource interaction is the `interaction_resource`
-species-parameter column instead.
+The species × species interaction matrix is read with `interaction_matrix()` and
+set with `interaction_matrix<-` or `setInteraction()`. The resource interaction
+is the `interaction_resource` species-parameter column instead.
 
 ```r
-inter <- getInteraction(params)
+inter <- interaction_matrix(params)
 inter["Cod", "Herring"] <- 0.5
-params <- setInteraction(params, inter)
+interaction_matrix(params) <- inter        # or params <- setInteraction(params, inter)
 ```
 
 ## Level 2: setting a rate array directly — and the freeze trap

--- a/man/signal_ignored_changes.Rd
+++ b/man/signal_ignored_changes.Rd
@@ -18,10 +18,11 @@ saying which species were given a value, as built by
 }
 \description{
 Some species parameters are only used to calculate a default for another
-one: \code{f0} for \code{gamma}, \code{fc} for \code{ks} and \code{age_mat} for \code{h}. Once the other
-one has been given, the model no longer consults them, so changing them has
-no effect. This raises a warning about that. It is one of the diagnostics
-that only \code{\link[=given_species_params<-]{given_species_params<-()}} gives, see there.
+one: \code{f0} for \code{gamma}, \code{fc} for \code{ks}, \code{age_mat} for \code{h}, and \code{k_vb} for
+\code{h} or \code{age_mat}. Once the other one has been given, the model no longer
+consults them, so changing them has no effect. This raises a warning about
+that. It is one of the diagnostics that only \code{\link[=given_species_params<-]{given_species_params<-()}}
+gives, see there.
 }
 \details{
 Only a value that is there can be ignored, so this is asked about the

--- a/tests/testthat/test-MizerParams-class.R
+++ b/tests/testthat/test-MizerParams-class.R
@@ -111,7 +111,7 @@ test_that("validParams checks w_min and w_max", {
     # w_min
     params <- NS_params_small
     params@species_params$w_min[1:3] <- 1e-6
-    expect_warning(params <- validParams(params), "smaller than the minimum")
+    expect_warning(params <- validParams(params), "adjustSizeGrid")
     expect_true(validObject(params))
     expect_equal(params@w_min_idx[1:3], rep(1, 3), ignore_attr = TRUE)
 })

--- a/tests/testthat/test-info_signals.R
+++ b/tests/testthat/test-info_signals.R
@@ -242,7 +242,7 @@ test_that("signal_ignored_changes() warns about a parameter that is overruled", 
     expect_true(all(!is.na(given$gamma)))
     expect_warning(
         with_info_level(signal_ignored_changes(given, list(f0 = all_sp))),
-        "values for `f0` that are going to be ignored because values for `gamma`")
+        "The values you specified for `f0` will not lead to a re-calculation of `gamma`")
     # but not for a species whose `gamma` is not given
     given$gamma[[1]] <- NA
     expect_silent(
@@ -260,10 +260,10 @@ test_that("signal_ignored_changes() warns about a parameter that is overruled", 
     given$age_mat <- c(NA, 5, NA)
     expect_warning(
         with_info_level(signal_ignored_changes(given, list(k_vb = c(TRUE, FALSE, FALSE)))),
-        "values for `k_vb` that are going to be ignored because values for `h`")
+        "The values you specified for `k_vb` will not lead to a re-calculation of `h`")
     expect_warning(
         with_info_level(signal_ignored_changes(given, list(k_vb = c(FALSE, TRUE, FALSE)))),
-        "values for `k_vb` that are going to be ignored because values for `age_mat`")
+        "The values you specified for `k_vb` will not lead to a re-calculation of `age_mat`")
 })
 
 test_that("signal_gear_params_changes() warns about gear parameters", {

--- a/tests/testthat/test-info_signals.R
+++ b/tests/testthat/test-info_signals.R
@@ -254,6 +254,16 @@ test_that("signal_ignored_changes() warns about a parameter that is overruled", 
     given$gamma <- NULL
     expect_silent(
         with_info_level(signal_ignored_changes(given, list(f0 = all_sp))))
+
+    # `k_vb` is overruled by `h` or `age_mat`
+    given$h <- c(20, NA, 30)
+    given$age_mat <- c(NA, 5, NA)
+    expect_warning(
+        with_info_level(signal_ignored_changes(given, list(k_vb = c(TRUE, FALSE, FALSE)))),
+        "values for `k_vb` that are going to be ignored because values for `h`")
+    expect_warning(
+        with_info_level(signal_ignored_changes(given, list(k_vb = c(FALSE, TRUE, FALSE)))),
+        "values for `k_vb` that are going to be ignored because values for `age_mat`")
 })
 
 test_that("signal_gear_params_changes() warns about gear parameters", {

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -388,7 +388,7 @@ test_that("species_params setter is quiet about an overridden parameter (#496)",
     # while the given species parameter setter says so
     params <- NS_params_small
     expect_warning(given_species_params(params)$f0 <- 0.5,
-                   "values for `f0` that are going to be ignored")
+                   "will not lead to a re-calculation of `gamma`")
 })
 
 test_that("given_species_params setter warns when a frozen rate blocks the change (#489)", {
@@ -441,7 +441,7 @@ test_that("the given_species_params diagnostics agree about clearing to NA (#524
     expect_false(any(is.na(given_species_params(params)$gamma)))
     expect_false(any(is.na(given_species_params(params)$f0)))
     expect_warning(given_species_params(params)$f0 <- 0.5,
-                   "values for `f0` that are going to be ignored")
+                   "will not lead to a re-calculation of `gamma`")
     expect_silent(given_species_params(params)$f0 <- NA)
 })
 

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -818,6 +818,37 @@ test_that("get_h_default, get_f0_default and get_ks_default follow documented de
         fc * alpha * h * w_mat^(n - p)
     )
     expect_equal(unname(get_ks_default(params3)), unname(expected_ks))
+
+    # Error message when h = Inf
+    params_inf <- params
+    params_inf@species_params$gamma[] <- NA
+    params_inf@species_params$h[1] <- Inf
+    expect_error(get_gamma_default(params_inf),
+                 "Cannot calculate default `gamma` for species with `h = Inf`")
+    params_inf2 <- params
+    params_inf2@species_params$ks[] <- NA
+    params_inf2@species_params$h[1] <- Inf
+    expect_error(get_ks_default(params_inf2),
+                 "Cannot calculate default `ks` for species with `h = Inf`")
+
+    # get_f0_default under edition 2 matches get_gamma_default with interaction_resource != 1
+    params_ed2 <- params
+    species_params(params_ed2)$interaction_resource <- 0.5
+    params_ed2@species_params$gamma[] <- NA
+    defaults_edition(2)
+    on.exit(defaults_edition(1), add = TRUE)
+    gamma_ed2 <- get_gamma_default(params_ed2)
+    params_ed2@species_params$gamma <- gamma_ed2
+    f0_ed2 <- get_f0_default(params_ed2)
+    expect_equal(unname(f0_ed2), rep(0.6, nrow(species_params(params_ed2))))
+
+    # get_h_default informs when n != p
+    sp_np <- species_params(params)
+    sp_np$h[] <- NA
+    sp_np$n[1] <- 0.7
+    sp_np$p[1] <- 0.8
+    expect_message(with_info_level(get_h_default(sp_np), info_level = 1),
+                   "Because you have n != p")
 })
 
 test_that("species_params S3 class properties work", {

--- a/vignettes/cheatsheet-changing-parameters.Rmd
+++ b/vignettes/cheatsheet-changing-parameters.Rmd
@@ -25,9 +25,6 @@ one to reach for. The guiding principle:
 > mizer propagate the change downwards.** Drop to a lower level only when you
 > deliberately want to override mizer's calculation.
 
-Every setter returns a **new** [`MizerParams`](../reference/MizerParams.html) — always reassign
-(`params <- setResource(params, ...)`).
-
 ---
 
 ## The levels of a mizer model
@@ -37,7 +34,7 @@ layer to reach into:
 
 | Level | What it is | Change it with |
 |---|---|---|
-| **1. Size-independent parameters** | the high-level inputs: per-species scalars (`w_inf`, `beta`, `gamma`, `h`, `erepro`, …), fishing gears, resource scalars, and interactions | [`species_params(params) <-`](../reference/species_params.html), [`gear_params(params) <-`](../reference/gear_params.html), [`resource_params(params) <-`](../reference/resource_params.html), [`setInteraction()`](../reference/setInteraction.html) |
+| **1. Size-independent parameters** | the high-level inputs: per-species scalars (`w_inf`, `beta`, `gamma`, `h`, `erepro`, …), fishing gears, resource scalars, and interactions | [`species_params(params) <-`](../reference/species_params.html), [`gear_params(params) <-`](../reference/gear_params.html), [`resource_params(params) <-`](../reference/resource_params.html), [`interaction_matrix()`](../reference/setInteraction.html) |
 | **2. Size-dependent rates** | arrays over size that mizer **calculates** from those parameters (search volume, metabolic rate, predation kernel, resource capacity, selectivity, …) | the `set…()` functions |
 | **3. Rate functions** | the functions mizer calls to compute the rates during a simulation | [`setRateFunction()`](../reference/setRateFunction.html), [`setComponent()`](../reference/setComponent.html) |
 
@@ -67,7 +64,7 @@ track of which values you **gave** and which it **calculated**.
 | [`calculated_species_params(params)`](../reference/species_params.html) | the parameters mizer derived or defaulted |
 | [`species_params(params)`](../reference/species_params.html) | everything (given, with calculated filling the gaps) |
 
-**Rule (mizer ≥ 3.2): change species parameters with `species_params(params) <-`.**
+**Rule: change species parameters with `species_params(params) <-`.**
 It detects what you changed, records it as *given* (so defaults can no longer
 overwrite it), and triggers recalculation of the derived scalars **and** the
 size-dependent rate arrays that depend on it.
@@ -76,7 +73,7 @@ size-dependent rate arrays that depend on it.
 species_params(params)$beta <- 150   # recorded as given; also rebuilds the predation kernel
 ```
 
-`given_species_params(params) <-` reaches the same model and is preferable in
+`given_species_params(params) <-` makes the same changes and is preferable in
 **interactive** sessions, because it additionally *warns* whenever a change you
 asked for cannot take effect: the parameter is overridden by another one you
 have already given, or it feeds a rate array you set by hand, or it is a gear
@@ -116,12 +113,7 @@ touched — on [`NS_params`](../reference/NS_params.html) it turns 312 given ent
 
 > **Version note.** Older guidance said to avoid `species_params(params) <-`
 > because it bypassed the `given_species_params` protection and skipped
-> recalculation. That was fixed in mizer 3.2. On mizer **< 3.2**, still prefer
-> `given_species_params(params) <-` for edits. On mizer **< 3.3** the two are
-> not interchangeable on a model that specifies sizes as lengths: only
-> `species_params(params) <-` applied the length/weight precedence rule, so a
-> length changed through `given_species_params(params) <-` left the weight at
-> its old value.
+> recalculation. That is now fixed.
 
 Columns come back as named vectors:
 
@@ -174,49 +166,98 @@ parameters `a`, `b`.
 
 Mizer fills in what you did not supply, and the derivations are chained:
 [`age_mat`](../reference/age_mat.html) → `h` → `gamma` and `ks`. Changing one parameter therefore rarely
-changes just that one thing. The three sections below cover the traps this
-creates; for the derivations themselves see
+changes just that one thing.
+
+The three sections below cover the traps this creates; for the mathematical
+derivations themselves see
 [Calculation of Default Parameter Values](default_parameters.html).
 
-### A parameter and its derived partner cancel out
+### Whether a value is given determines whether it is recalculated
+
+For derived parameters, `given_species_params()` distinguishes fixed input from
+a cached calculated value.
+
+**Giving a value switches off the recalculation from another parameter.**
+`given_species_params<-()` warns when you set a parameter that would usually
+be used to recalculate another parameter but this recalculation is
+suppressed because that other parameter has been given explicitly.
+
+| If you have given… | this is ignored |
+|---|---|---|
+| `gamma` | `f0` |
+| `ks` | `fc` |
+| `h` | `age_mat`, `k_vb` |
+| [`age_mat`](../reference/age_mat.html) | `k_vb` |
+
+To let mizer re-calculate a parameter you previously supplied, clear it by setting
+it to `NA` in `given_species_params(params)`.
+
+Finally, `w_inf` is not a purely dynamic parameter. Changing it re-derives
+`w_mat`, `h`, `gamma` and `ks`, but the **size grid is fixed at construction**,
+so enlarging `w_inf` beyond the maximum grid size gives repeated warnings that
+"the maximum weight of a species is larger than the maximum weight of the model".
+To expand the size range, use [`adjustSizeGrid(params, new_max_w = ...)`](../reference/adjustSizeGrid.html) or
+rebuild the model.
+
+### Chained derivations and the cancellation trap
+
+When parameters are not given, mizer calculates them along a dependency chain:
+
+```
+Inputs: [age_mat / k_vb, w_mat, w_min, alpha, f0, fc]
+                         │
+                         ▼
+                      [  h  ] ─────────┬─────────┐
+                         │             │         │
+                         │             │ (with f0, kappa, lambda, kernel)
+                         │             │         │ (with fc, alpha, w_mat)
+                         ▼             ▼         ▼
+                  [ intake_max ]   [ gamma ]   [ ks ]
+```
 
 When `gamma` (the search-volume coefficient) is not supplied, mizer **derives it
 from the target feeding level `f0`** — roughly `gamma ∝ h · f0 / (1 - f0)` — so
-that the feeding level comes out at `f0`. A consequence often missed: raising
-`h` does **not** lower the feeding level, because the derived `gamma`
-compensates and the feeding level stays pinned at `f0`. To make growth more or
-less resource-dependent (a stronger or weaker density dependence, the
-"phantom-jam" feedback), change **`f0`**, not `h`: low `f0` makes juvenile
-growth strongly resource-limited, `f0` near 1 makes it nearly saturated and
-resource-insensitive.
+that the feeding level comes out at `f0`.
+
+A consequence often missed: raising `h` does **not** lower the feeding level,
+because the derived `gamma` compensates and the feeding level stays pinned at
+`f0`. To make growth more or less resource-dependent (a stronger or weaker
+density dependence, the "phantom-jam" feedback), change **`f0`**, not `h`: low
+`f0` makes juvenile growth strongly resource-limited, `f0` near 1 makes it nearly
+saturated and resource-insensitive.
 
 `ks` does the same thing one level down. When it is not supplied it is derived
 as `ks = fc · alpha · h · w_mat^(n - p)`, so raising `h` does **not** bring a
 species closer to starvation: the metabolic coefficient scales with it and the
 critical feeding level stays pinned at `fc`.
 
-| To change… | change | not |
-|---|---|---|
-| the feeding level, how resource-limited growth is | `f0` | `h` |
-| the critical feeding level, how close to starvation a species is | `fc` | `ks`, `h` |
-| growth speed, with both feeding levels held fixed | `h` | — |
+**Intent-first guide:**
+
+| Desired Goal | Change This | Do NOT Change | Why / What Happens |
+|---|---|---|---|
+| the feeding level (resource sensitivity of growth) | `f0` | `h` | Raising `h` auto-scales `gamma`, keeping feeding level at `f0`. |
+| the critical feeding level (starvation risk) | `fc` | `ks`, `h` | Raising `h` auto-scales `ks`, keeping critical level at `fc`. |
+| growth speed across all sizes, holding feeding level fixed | `h` | `f0` | `h` scales maximum intake while feeding levels stay fixed. |
+| bespoke search volume / metabolism | `gamma`, `ks` | `f0`, `fc` | Giving `gamma` or `ks` disconnects the automatic derivation. |
 
 Corollary: `h = Inf` (a deliberately "no-satiation" model) makes the derived
-`gamma` non-finite and throws `search_vol must not contain non-finite values` —
-supply `gamma` explicitly in that case.
+`gamma` and `ks` non-finite and throws an error asking you to supply `gamma` and
+`ks` explicitly.
 
-The chain also runs the other way, which is easy to forget. When `age_mat` is
-given (or `k_vb`, from which mizer estimates it), `h` is *derived* from it:
+**The reverse ripple effect from age at maturity.**
+The chain also runs the other way. When `age_mat` is given (or `k_vb`, from
+which mizer estimates it), `h` is *derived* from it:
 
 ```
 h = (w_mat^(1-n) - w_min^(1-n)) / (age_mat * (1-n) * alpha * (f0 - fc))
 ```
 
-So `f0` and `fc` are not local edits to the feeding level — they move `h`, and
-`h` carries the change on into `gamma` and `ks`. The same goes for `w_mat`,
-which is never just the maturity size: it feeds `h` through the formula above,
-`ks` through the `w_mat^(n - p)` factor, and `w_mat25`. And `beta`/`sigma` feed
-the `gamma` derivation, because that integrates the predation kernel.
+So `f0` and `fc` are not local edits to feeding levels — when `age_mat` is
+given they move `h`, and `h` carries the change on into `gamma` and `ks`. The
+same goes for `w_mat`, which is never just the maturity size: it feeds `h`
+through the formula above, `ks` through the `w_mat^(n - p)` factor, and
+`w_mat25`. And `beta`/`sigma` feed the `gamma` derivation because that
+integrates the predation kernel.
 
 If a user is puzzled that "changing `w_mat` changed my growth curve everywhere",
 this is why. To pin a parameter against the chain, give it explicitly — a given
@@ -237,9 +278,11 @@ forced to 1. So `f0` is the feeding level a species *would* have in that world.
   levels.
 - Setting `interaction_resource` to anything other than 1 leaves `gamma`
   untouched under edition 1, so the reduction falls straight through to the
-  realised feeding level and can starve a species outright.
+  realised feeding level and can starve a species outright. Under
+  `defaults_edition() >= 2`, `interaction_resource` is included in the
+  calibration.
 - The resource scalars that enter the calibration **do** trigger a
-  re-derivation, but only of the values mizer owns. Since mizer 3.3, changing
+  re-derivation. Since mizer 3.3, changing
   `lambda` recalculates every `q` and `gamma` that mizer calculated, and
   changing `kappa` recalculates every calculated `gamma`; the condition
   `q = n + lambda - 2` that makes the feeding level size-independent is
@@ -261,68 +304,13 @@ given_species_params(params)$q <- species_params(params)$q
 resource_params(params)$lambda <- 2.2       # q now stays put
 ```
 
-On mizer **< 3.3** neither refresh happened: the resource arrays were rebuilt but
-`gamma` and `q` were left at the values for the old resource, and had to be set
-to `NA` by hand.
-
-### Whether a value is given determines whether it is recalculated
-
-For derived parameters, `given_species_params()` distinguishes fixed input from
-a cached calculated value. In particular, `setExtMort()` recalculates `z0`
-wherever it is absent or `NA` in `given_species_params()`, even though an older
-calculated value is still present in `species_params()`. Two practical
-consequences:
-
-**Arguments that only feed a default work only while values are missing.**
-`setExtMort()` computes `z0 = z0pre * w_inf^z0exp` for non-given `z0` values.
-If `z0` is present in `given_species_params()` for every species, supplying
-`z0pre` or `z0exp` cannot take effect and gives a warning. `reset = TRUE` does
-not help: it clears the rate array's comment, not the given species parameter.
-To hand `z0` back to the calculation, set it to `NA` in
-`given_species_params()`:
-
-```{r eval=FALSE}
-z0exp <- resource_params(params)$n - 1   # the construction default
-given_species_params(params)$z0 <- 2 * species_params(params)$w_inf^z0exp
-
-# Or hand z0 back to the default calculation.
-given_species_params(params)$z0 <- NA
-```
-
-An explicitly supplied `z0pre` or `z0exp` is used for every non-given `z0` and
-the resulting values are recorded in `given_species_params()`. Values filled
-from the arguments' defaults are not recorded there and will be recalculated
-on the next call.
-
-**Giving a value switches off the calculation that would have used another one.**
-`given_species_params<-()` warns about the first three, `species_params<-()`
-about none of them — another reason to prefer the former interactively:
-
-| If you have given… | this is ignored | warns |
-|---|---|---|
-| `gamma` | `f0` | yes |
-| `ks` | `fc` | yes |
-| `h` | `age_mat` | yes |
-| `h` | `k_vb` | no |
-
-Two more are silent: `h` falls back to **30** when there is no growth
-information at all (no `age_mat`, no `k_vb`), and with `n != p` the derivation
-of `h` is only approximate — mizer says so at message level 1, which is easily
-missed.
-
-Finally, `w_inf` is not a purely dynamic parameter. Changing it re-derives
-`w_mat`, `h`, `gamma` and `ks`, but the **size grid is fixed at construction**,
-so enlarging `w_inf` gives repeated warnings that "the maximum weight of a
-species is larger than the maximum weight of the model". To change the size
-range, rebuild the model rather than edit the parameter.
-
 ---
 
 ## Level 1: fishing gear parameters
 
 Gears, selectivity, and catchability live in `gear_params(params)`, one row per
-gear–species pair (row names `"species, gear"`). Assigning to it **does**
-recompute the fishing arrays.
+gear–species pair (row names `"species, gear"`). Assigning to it recomputes the
+fishing arrays.
 
 ```{r eval=FALSE}
 gp <- gear_params(params)
@@ -337,10 +325,10 @@ setting baseline effort. See the [fishing cheatsheet](cheatsheet-fishing.html).
 
 ## Level 1: resource parameters
 
-The resource works just like the species parameters.
-`resource_params(params)` returns a named list of scalars (`kappa`, `lambda`,
-`r_pp`, `n`, `w_pp_cutoff`) that set up the resource size-spectrum arrays, and —
-like `species_params<-` — assigning to it **rebuilds those arrays** by calling
+The resource works just like the species parameters. `resource_params(params)`
+returns a named list of scalars (`kappa`, `lambda`, `r_pp`, `n`, `w_pp_cutoff`).
+These parameters set up the resource size-spectrum arrays, and — like
+`species_params<-` — assigning to it **rebuilds those arrays** by calling
 [`setResource()`](../reference/setResource.html):
 
 ```{r eval=FALSE}
@@ -368,14 +356,14 @@ level-2 change and is covered under
 
 ## Level 1: the interaction matrix
 
-The species × species interaction matrix is set with `setInteraction()` and read
-with [`getInteraction()`](../reference/getInteraction.html). The resource interaction is the `interaction_resource`
-species-parameter column instead.
+The species × species interaction matrix is read with `interaction_matrix()` and
+set with `interaction_matrix<-` or [`setInteraction()`](../reference/setInteraction.html). The resource interaction
+is the `interaction_resource` species-parameter column instead.
 
 ```{r eval=FALSE}
-inter <- getInteraction(params)
+inter <- interaction_matrix(params)
 inter["Cod", "Herring"] <- 0.5
-params <- setInteraction(params, inter)
+interaction_matrix(params) <- inter        # or params <- setInteraction(params, inter)
 ```
 
 ---

--- a/vignettes/cheatsheet-model-setup.Rmd
+++ b/vignettes/cheatsheet-model-setup.Rmd
@@ -65,11 +65,13 @@ Commonly supplied:
 
 | Column | Meaning |
 |---|---|
+| `w_min` | Egg size (g, default 0.001) |
 | `w_mat` | Maturity weight (g) |
 | `beta` | Preferred predator/prey mass ratio (default 30) |
 | `sigma` | Width of the lognormal predation kernel (default 2) |
 | `k_vb` | von Bertalanffy K — used to derive `h` (and then `gamma`) if `h`/`gamma` absent |
 | `h`, `gamma` | Max intake coefficient and search-volume coefficient (alternative to `k_vb`) |
+| `a`, `b` | Length–weight conversion parameters ($w = a l^b$, defaults 0.006 and 3) |
 | `alpha` | Assimilation efficiency (default 0.6) |
 | `biomass_observed` | Observed biomass, for calibration |
 
@@ -94,8 +96,9 @@ Useful optional arguments to `newMultispeciesParams()`:
 | Argument | Effect |
 |---|---|
 | `interaction` | species × species matrix of dimensionless overlaps in `[0, 1]` (1 = full interaction, the default for every pair); scales encounter and predation mortality |
-| [`gear_params`](../reference/gear_params.html) | fishing gear definitions — columns `gear`, `species`, `sel_func`, `catchability` and the selectivity parameters. Omit it and mizer builds a default knife-edge gear catching every species |
-| `no_w`, `min_w`, `max_w` | size-grid resolution and range (`no_w = 100` by default) |
+| `kappa`, `lambda`, `w_pp_cutoff` | resource spectrum coefficient, exponent, and cutoff size |
+| `no_w` | number of size bins on the logarithmic grid (default 100; the size range is determined automatically from the species parameters) |
+| [`gear_params`](../reference/gear_params.html) | fishing gear definitions (usually omitted and configured later with the [fishing cheatsheet](cheatsheet-fishing.html); defaults to a knife-edge gear catching every species) |
 | [`second_order_w`](../reference/second_order_w.html) | use the second-order size-advection scheme; see the section "Numerical scheme: watch for numerical diffusion" in the [running-simulations cheatsheet](cheatsheet-running-simulations.html) |
 
 Change gears later with `gear_params(params) <- ...` or [`setFishing()`](../reference/setFishing.html) — see the
@@ -108,7 +111,7 @@ Change gears later with `gear_params(params) <- ...` or [`setFishing()`](../refe
 ```{r eval=FALSE}
 summary(params)
 species_params(params)     # given + calculated, one row per species
-getInteraction(params)     # the interaction matrix
+interaction_matrix(params) # the interaction matrix
 gear_params(params)        # the fishing gears
 resource_params(params)    # the resource scalars
 ```
@@ -150,35 +153,19 @@ All fields are optional and you can add fields of your own. mizer also fills in
 
 ---
 
-## Common pitfalls
-
-- Forgetting to reassign the return value ([`steady(params)`](../reference/steady.html) without `params <-`)
-  silently discards the work.
-- Skipping `steady()` after a `match…`/`calibrate…` step leaves the model off
-  its steady state.
-- Editing a species parameter on a bare data frame instead of through
-  `species_params(params) <-` means no dependent quantity is recalculated. See
-  the [changing-parameters cheatsheet](cheatsheet-changing-parameters.html).
-- Passing `max_w = w_inf` to `newMultispeciesParams()` errors, because `w_max`
-  still defaults to `1.5 * w_inf` and the grid then stops below it. To run the
-  grid up to the asymptotic size, give the species parameter data frame a
-  `w_max` column equal to `w_inf` as well.
-
----
-
 ## Quick reference
 
 ```{r eval=FALSE}
 # ── Build ─────────────────────────────────────────────────────────────────────
 species_params <- read.csv(
     system.file("extdata", "NS_species_params.csv", package = "mizer"))
-params <- newMultispeciesParams(species_params, interaction)
+params <- newMultispeciesParams(species_params)
 params <- newTraitParams()  # or newCommunityParams(), newSingleSpeciesParams()
 
 # ── Inspect ───────────────────────────────────────────────────────────────────
 summary(params)
 species_params(params)      # given + calculated, one row per species
-getInteraction(params)      # the interaction matrix
+interaction_matrix(params)  # the interaction matrix
 gear_params(params)         # the fishing gears
 resource_params(params)     # the resource scalars
 


### PR DESCRIPTION
## Summary of Changes

### 1. Skill and Cheatsheet Improvements
- **`inst/skills/change-parameters/SKILL.md` & `vignettes/cheatsheet-changing-parameters.Rmd`**:
  - Reorganised the "Gotchas from the way defaults are calculated" section to present the foundational rule ("Whether a value is given determines whether it is recalculated") first.
  - Repositioned and updated the ASCII dependency diagram into the "Chained derivations and the cancellation trap" subsection, clarifying the role of $f_0$, $f_c$, $\text{age}_{\text{mat}}$, and size parameters.
  - Moved the discussion of $f_0$ and $f_c$ as reference calibration targets to the final subsection.
- **`inst/skills/build-multispecies-model/SKILL.md` & `vignettes/cheatsheet-model-setup.Rmd`**:
  - Clarified parameter documentation and replaced `getInteraction()` with `interaction_matrix()`.

### 2. Code and Defaults Fixes
- **`R/species_params.R`**:
  - `get_f0_default()` now respects `interaction_resource` under `defaults_edition() >= 2`, making it the exact inverse of `get_gamma_default()`.
  - `get_gamma_default()` and `get_ks_default()` provide informative error messages when called on species with `h = Inf`.
- **`R/info_signals.R`**:
  - `given_species_params<-()` warns when `k_vb` is specified on a model where `h` or `age_mat` is already given and will override `k_vb`.
- **`R/MizerParams-class.R`**:
  - `repair_params()` suggests `adjustSizeGrid()` instead of the deprecated `expandSizeGrid()`.
- **`NEWS.md`**: Updated with release notes for the bug fixes and enhancements.
- **Tests**: Added tests for all updated behaviours in `tests/testthat/test-species_params.R` and `tests/testthat/test-info_signals.R`.