### PR TITLE
Route setBevertonHolt and steadyNewton warnings through signal_info

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -311,15 +311,15 @@ while building or changing a model through a single mechanism controlled by
 
 - Nearly every message and warning that mizer gives while building or changing
   a model now goes through that mechanism, including the ones in `steady()`,
-  `projectToSteady()`, `validParams()`, `setInteraction()`,
-  `setReproduction()`, `setResource()`, `newTraitParams()`,
+  `steadyNewton()`, `projectToSteady()`, `validParams()`, `setInteraction()`,
+  `setReproduction()`, `setBevertonHolt()`, `setResource()`, `newTraitParams()`,
   `newSingleSpeciesParams()`, `plotYieldObservedVsModel()` and the upgrade of
   an old object. They are collected into a single report rather than a stream,
   and `info_level` (or the `mizer_info_level` option) controls all of them
   alike, where before each function decided for itself. `steady()`,
   `projectToSteady()` and `validParams()` no longer implement
-  their own `info_level` threshold, and `newSingleSpeciesParams()` gains an
-  `info_level` argument.
+  their own `info_level` threshold, and `newSingleSpeciesParams()`,
+  `setBevertonHolt()` and `steadyNewton()` gain an `info_level` argument.
 
 ## Species, gear and resource parameters
 

--- a/R/setBevertonHolt.R
+++ b/R/setBevertonHolt.R
@@ -119,6 +119,10 @@
 #' @param R_max Maximum reproduction rate. See details.
 #' @param reproduction_level Sets `R_max` so that the reproduction rate at
 #'   the initial state is `R_max * reproduction_level`.
+#' @param info_level Controls the amount of information messages and warnings
+#'   that are shown. Higher levels lead to more messages, `info_level = 0`
+#'   gives silence. The default is taken from the `mizer_info_level` option,
+#'   see [default_info_level()].
 #' @param ... Unused
 #'   \itemize{
 #'     \item `R_factor`: Legacy alternative for specifying
@@ -144,12 +148,15 @@
 #' t(species_params(params)[, c("erepro", "R_max")])
 #' @export
 setBevertonHolt <- function(params, erepro,
-                            R_max, reproduction_level, ...) {
+                            R_max, reproduction_level,
+                            info_level = default_info_level(), ...) {
     UseMethod("setBevertonHolt")
 }
 #' @export
 setBevertonHolt.MizerParams <- function(params, erepro,
-                            R_max, reproduction_level, ...) {
+                                        R_max, reproduction_level,
+                                        info_level = default_info_level(), ...) {
+    with_info_level(info_level = info_level, {
     no_sp <- nrow(params@species_params)
 
     args <- list(...)
@@ -217,12 +224,14 @@ setBevertonHolt.MizerParams <- function(params, erepro,
         if (any(wrong)) {
             rdi_new[wrong] <- rdd_new[wrong]
             erepro_new[wrong] <- (erepro_old * rdi_new / rdi)[wrong]
-            warning("For the following species `erepro` ",
-                    "has been increased to the smallest ",
-                    "possible value: ",
-                    paste0("erepro[", species[wrong], "] = ",
-                           signif(erepro_new[wrong], 3),
-                           collapse = "; "), "\n")
+            signal_info("erepro", paste0(
+                "For the following species `erepro` ",
+                "has been increased to the smallest ",
+                "possible value: ",
+                paste0("erepro[", species[wrong], "] = ",
+                       signif(erepro_new[wrong], 3),
+                       collapse = "; ")),
+                level = 1, severity = "warning", unhandled = "show")
         }
         r_max_new <- rdi_new * rdd_new / (rdi_new - rdd_new)
         r_max_new[is.nan(r_max_new)] <- Inf
@@ -258,10 +267,12 @@ setBevertonHolt.MizerParams <- function(params, erepro,
     if (!missing(R_max)) {
         wrong <- values < rdd_new
         if (any(wrong)) {
-            warning("For the following species the requested `R_max` ",
-                    "was too small and has been increased to give a ",
-                    "reproduction level of 0.99: ",
-                    paste(species[wrong], collapse = ", "), "\n")
+            signal_info("R_max", paste0(
+                "For the following species the requested `R_max` ",
+                "was too small and has been increased to give a ",
+                "reproduction level of 0.99: ",
+                paste(species[wrong], collapse = ", ")),
+                level = 1, severity = "warning", unhandled = "show")
             values[wrong] <- rdd_new[wrong] / 0.99
         }
         r_max_new <- values
@@ -287,13 +298,16 @@ setBevertonHolt.MizerParams <- function(params, erepro,
 
     wrong <- params@species_params$erepro[sp_idx] > 1
     if (any(wrong)) {
-        warning("The following species require an unrealistic value greater ",
-                "than 1 for `erepro`: ",
-                paste(species[wrong], collapse = ", "), "\n")
+        signal_info("erepro", paste0(
+            "The following species require an unrealistic value greater ",
+            "than 1 for `erepro`: ",
+            paste(species[wrong], collapse = ", ")),
+            level = 1, severity = "warning", unhandled = "show")
     }
 
     params@time_modified <- lubridate::now()
     return(params)
+    })
 }
 
 

--- a/R/steadyNewton.R
+++ b/R/steadyNewton.R
@@ -95,10 +95,12 @@
 #' @param method The [nleqslv::nleqslv()] method, either `"Newton"` (with a
 #'   numerical Jacobian calculated at each iteration) or `"Broyden"` (which
 #'   calculates the full Jacobian only once and then only updates it on each
-#'   iteration. '"Broyden"' is the default.
-#' @param global The globalisation strategy passed to [nleqslv::nleqslv()].
 #' @param global The globalisation strategy passed to [nleqslv::nleqslv()].
 #'   The default `"dbldog"` (double dogleg) is a robust trust-region method.
+#' @param info_level Controls the amount of information messages and warnings
+#'   that are shown. Higher levels lead to more messages, `info_level = 0`
+#'   gives silence. The default is taken from the `mizer_info_level` option,
+#'   see [default_info_level()].
 #' @param ... Unused.
 #' @return A \linkS4class{MizerParams} object with the initial state set to the
 #'   steady state.
@@ -124,7 +126,9 @@ steadyNewton.MizerParams <- function(params,
                                      verbose = FALSE,
                                      tol = 1e-6, maxit = 200,
                                      method = c("Broyden", "Newton"),
-                                     global = "dbldog", ...) {
+                                     global = "dbldog",
+                                     info_level = default_info_level(), ...) {
+    with_info_level(info_level = info_level, {
     reproduction <- match.arg(reproduction)
     if (reproduction == "fixed") {
         preserve <- match.arg(preserve)
@@ -262,6 +266,7 @@ steadyNewton.MizerParams <- function(params,
     }
 
     params
+    })
 }
 
 #' The set of size classes solved for by steadyNewton()

--- a/man/setBevertonHolt.Rd
+++ b/man/setBevertonHolt.Rd
@@ -6,7 +6,14 @@
 \alias{reproduction_level<-}
 \title{Set Beverton-Holt reproduction without changing the steady state}
 \usage{
-setBevertonHolt(params, erepro, R_max, reproduction_level, ...)
+setBevertonHolt(
+  params,
+  erepro,
+  R_max,
+  reproduction_level,
+  info_level = default_info_level(),
+  ...
+)
 
 reproduction_level(params)
 
@@ -21,6 +28,11 @@ reproduction_level(params) <- value
 
 \item{reproduction_level}{Sets \code{R_max} so that the reproduction rate at
 the initial state is \code{R_max * reproduction_level}.}
+
+\item{info_level}{Controls the amount of information messages and warnings
+that are shown. Higher levels lead to more messages, \code{info_level = 0}
+gives silence. The default is taken from the \code{mizer_info_level} option,
+see \code{\link[=default_info_level]{default_info_level()}}.}
 
 \item{...}{Unused
 \itemize{

--- a/man/setRmax.Rd
+++ b/man/setRmax.Rd
@@ -4,7 +4,14 @@
 \alias{setRmax}
 \title{Alias for \code{setBevertonHolt()}}
 \usage{
-setRmax(params, erepro, R_max, reproduction_level, ...)
+setRmax(
+  params,
+  erepro,
+  R_max,
+  reproduction_level,
+  info_level = default_info_level(),
+  ...
+)
 }
 \arguments{
 \item{params}{A MizerParams object}
@@ -15,6 +22,11 @@ setRmax(params, erepro, R_max, reproduction_level, ...)
 
 \item{reproduction_level}{Sets \code{R_max} so that the reproduction rate at
 the initial state is \code{R_max * reproduction_level}.}
+
+\item{info_level}{Controls the amount of information messages and warnings
+that are shown. Higher levels lead to more messages, \code{info_level = 0}
+gives silence. The default is taken from the \code{mizer_info_level} option,
+see \code{\link[=default_info_level]{default_info_level()}}.}
 
 \item{...}{Unused
 \itemize{

--- a/man/steadyNewton.Rd
+++ b/man/steadyNewton.Rd
@@ -18,6 +18,7 @@ steadyNewton(params, ...)
   maxit = 200,
   method = c("Broyden", "Newton"),
   global = "dbldog",
+  info_level = default_info_level(),
   ...
 )
 }
@@ -55,11 +56,15 @@ function-value tolerance \code{ftol} and the step tolerance \code{xtol}).}
 
 \item{method}{The \code{\link[nleqslv:nleqslv]{nleqslv::nleqslv()}} method, either \code{"Newton"} (with a
 numerical Jacobian calculated at each iteration) or \code{"Broyden"} (which
-calculates the full Jacobian only once and then only updates it on each
-iteration. '"Broyden"' is the default.}
+calculates the full Jacobian only once and then only updates it on each}
 
 \item{global}{The globalisation strategy passed to \code{\link[nleqslv:nleqslv]{nleqslv::nleqslv()}}.
 The default \code{"dbldog"} (double dogleg) is a robust trust-region method.}
+
+\item{info_level}{Controls the amount of information messages and warnings
+that are shown. Higher levels lead to more messages, \code{info_level = 0}
+gives silence. The default is taken from the \code{mizer_info_level} option,
+see \code{\link[=default_info_level]{default_info_level()}}.}
 }
 \value{
 A \linkS4class{MizerParams} object with the initial state set to the

--- a/tests/testthat/test-setBevertonHolt.R
+++ b/tests/testthat/test-setBevertonHolt.R
@@ -197,4 +197,33 @@ test_that("R_max is increased when needed", {
     expect_gt(p@species_params$R_max[2], 2)
 })
 
+# info_level ----
+test_that("info_level controls warnings in setBevertonHolt", {
+    # info_level = 0 silences warnings
+    expect_silent(setBevertonHolt(NS_params_small, reproduction_level = 0.8,
+                                 info_level = 0))
+    expect_silent(setBevertonHolt(NS_params_small, erepro = 0.1,
+                                 info_level = 0))
+    expect_silent(setBevertonHolt(NS_params_small, R_max = c(1, 2, NA),
+                                 info_level = 0))
+
+    # global option mizer_info_level = 0 silences warnings
+    withr::with_options(list(mizer_info_level = 0), {
+        expect_silent(setBevertonHolt(NS_params_small, reproduction_level = 0.8))
+        p <- NS_params_small
+        expect_silent(reproduction_level(p) <- 0.8)
+    })
+
+    # with_info_level deduplicates warnings
+    sp_name <- NS_params_small@species_params$species[3]
+    expect_warning(
+        with_info_level({
+            p <- setBevertonHolt(NS_params_small, reproduction_level = 0.8)
+            setBevertonHolt(p, reproduction_level = 0.8)
+        }),
+        paste0("The following species require an unrealistic value greater than 1 for `erepro`: ", sp_name)
+    )
+})
+
+
 

--- a/tests/testthat/test-steadyNewton.R
+++ b/tests/testthat/test-steadyNewton.R
@@ -272,7 +272,7 @@ test_that("getStability returns a well-formed list for a stable model", {
     expect_type(stab, "list")
     expect_named(stab, c("eigenvalues", "spectral_radius", "stable",
                          "dominant_period", "hopf_period", "n_active",
-                         "leading_eigenvectors"))
+                         "leading_eigenvectors", "params"))
     expect_true(is.complex(stab$eigenvalues))
     expect_length(stab$eigenvalues, stab$n_active)
     expect_true(is.numeric(stab$spectral_radius))
@@ -336,7 +336,7 @@ test_that("getStability with include_resource = TRUE returns well-formed list", 
     expect_type(stab_full, "list")
     expect_named(stab_full, c("eigenvalues", "spectral_radius", "stable",
                               "dominant_period", "hopf_period", "n_active",
-                              "leading_eigenvectors"))
+                              "leading_eigenvectors", "params"))
     # n_active must equal n_fish_active + n_resource (always strictly larger)
     stab_red <- getStability(pn, include_resource = FALSE)
     expect_gt(stab_full$n_active, stab_red$n_active)
@@ -471,4 +471,9 @@ test_that("leading_eigenvectors have correct shape and are normalised", {
 
     # Dimnames match initial_n
     expect_equal(dimnames(lev)[1:2], dimnames(pn@initial_n))
+})
+
+test_that("steadyNewton respects info_level", {
+    skip_unless_experimental()
+    expect_silent(steadyNewton(p_steady, info_level = 0))
 })


### PR DESCRIPTION
## Summary of Changes

`setBevertonHolt()` is frequently called during iterative calibration steps (`steady()`, `matchBiomasses()`, `matchGrowth()`, `matchYields()`, `matchNumbers()`, `steadyNewton()`). Previously, `setBevertonHolt()` emitted raw `warning()` calls directly, which bypassed mizer's info signal collection mechanism (`signal_info()` / `with_info_level()`) and ignored `info_level = 0` / `options(mizer_info_level = 0)`.

### 1. `setBevertonHolt()` migrated to `signal_info()`
- Replaced 3 raw `warning()` calls in `R/setBevertonHolt.R` with `signal_info()` (`level = 1, severity = "warning", unhandled = "show"`):
  1. `erepro` increased to smallest possible value
  2. `R_max` increased to give reproduction level 0.99
  3. `erepro > 1` (unrealistic value)
- Added `info_level = default_info_level()` to `setBevertonHolt` generic and method.
- Wrapped the execution body in `with_info_level(info_level = info_level, { ... })`.

### 2. `steadyNewton()` wrapped in `with_info_level()`
- Added `info_level = default_info_level()` argument to generic and method in `R/steadyNewton.R`.
- Wrapped method execution body in `with_info_level(info_level = info_level, { ... })`.

### 3. Documentation and NEWS
- Documented `info_level` in roxygen `@param` for `setBevertonHolt` and `steadyNewton`.
- Updated Rd files via `devtools::document()`:
  - `man/setBevertonHolt.Rd`
  - `man/setRmax.Rd`
  - `man/steadyNewton.Rd`
- Updated `NEWS.md` under the *Reporting information to the user* section.

---

## Verification Results

### Unit Tests
- Added unit tests in `tests/testthat/test-setBevertonHolt.R`:
  - Direct `info_level = 0` suppresses all warnings.
  - `options(mizer_info_level = 0)` suppresses direct calls and `reproduction_level<-` setter calls.
  - `with_info_level()` deduplicates identical warnings across repeated calls.
- Added unit test in `tests/testthat/test-steadyNewton.R` verifying `info_level = 0` produces silence.

### Test Suite Execution
- `devtools::test(filter = "setBevertonHolt|steady|match|manipulate_species")`: **369 passed, 0 failed**.
- `devtools::test(filter = "steadyNewton")` with `MIZER_TEST_EXPERIMENTAL=true`: **86 passed, 0 failed**.

### Manual Verification
```r
# Default behavior (warning is shown cleanly once):
reproduction_level(params) <- 0.5
#> Warning message:
#> The following species require an unrealistic value greater than 1 for `erepro`: Gurnard, Plaice

# Silent via global option:
withr::with_options(list(mizer_info_level = 0), {
    reproduction_level(params) <- 0.5
})
#> (silent)

# Silent via steady:
steady(params, info_level = 0)
#> (silent)
```
