### PR TITLE
List missing columns in selectivity function argument error in gear_params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -386,6 +386,10 @@ while building or changing a model through a single mechanism controlled by
   messages when called on a model with `h = Inf`, indicating that `gamma` or
   `ks` must be supplied explicitly.
 
+- `gear_params<-()` and `calc_selectivity()` now list the missing column names
+  in the error message when arguments needed for a selectivity function are
+  missing from the gear parameter data frame.
+
 ## Other new functions
 
 - New `knife_edge_length()` selectivity function that applies a knife-edge cut

--- a/R/setFishing.R
+++ b/R/setFishing.R
@@ -774,9 +774,11 @@ validGearParams <- function(gear_params, species_params) {
         # get args
         arg <- names(formals(gear_params[g, "sel_func"]))
         arg <- arg[!(arg %in% c("w", "species_params", "..."))]
-        if (!all(arg %in% colnames(gear_params))) {
+        missing <- setdiff(arg, colnames(gear_params))
+        if (length(missing) > 0) {
             stop("Some arguments needed for the selectivity function are ",
-                 "missing in the gear parameter dataframe.")
+                 "missing in the gear parameter dataframe: ",
+                 toString(missing), ".")
         }
         # Check that there are no missing values for selectivity parameters
         if (any(is.na(as.list(gear_params[g, arg])))) {
@@ -919,9 +921,11 @@ calc_selectivity <- function(params) {
         arg <- names(formals(sel_func))
         # lop off the arguments that we will supply
         arg <- arg[!(arg %in% c("w", "species_params", "..."))]
-        if (!all(arg %in% colnames(gear_params))) {
+        missing <- setdiff(arg, colnames(gear_params))
+        if (length(missing) > 0) {
             stop("Some arguments needed for the selectivity function are ",
-                 "missing in the gear_params dataframe.")
+                 "missing in the gear_params dataframe: ",
+                 toString(missing), ".")
         }
         # Check that there are no missing values for selectivity parameters
         if (any(is.na(as.list(gear_params[g, arg])))) {

--- a/tests/testthat/test-setFishing.R
+++ b/tests/testthat/test-setFishing.R
@@ -58,6 +58,15 @@ test_that("validGearParams works", {
     gp <- validGearParams(gp, sp)
     expect_identical(gp$species, "species1", ignore_attr = TRUE)
     expect_identical(gp$gear, "g", ignore_attr = TRUE)
+
+    # Missing selectivity function arguments are reported
+    gp <- data.frame(species = "species1", gear = "g", sel_func = "sigmoid_length",
+                     stringsAsFactors = FALSE)
+    expect_error(validGearParams(gp, sp),
+                 "missing in the gear parameter dataframe: l25, l50.")
+    gp$l25 <- 10
+    expect_error(validGearParams(gp, sp),
+                 "missing in the gear parameter dataframe: l50.")
 })
 
 # validEffortVector ----
@@ -269,6 +278,13 @@ test_that("Non-existing species give error", {
     gp$species[[1]] <- "test"
     expect_error(gear_params(params) <- gp,
                  "The gear_params dataframe contains species that do not exist in the model.")
+})
+
+test_that("gear_params<- errors when selectivity arguments are missing", {
+    gp <- data.frame(species = "Cod", gear = "g", sel_func = "sigmoid_length",
+                     stringsAsFactors = FALSE)
+    expect_error(gear_params(params) <- gp,
+                 "missing in the gear parameter dataframe: l25, l50.")
 })
 
 test_that("Can get and set selectivity slot", {
@@ -487,7 +503,7 @@ test_that("calc_selectivity errors for missing or NA selectivity parameters", {
     class(params_missing@gear_params) <- "data.frame"
     params_missing@gear_params$knife_edge_size <- NULL
     expect_error(calc_selectivity(params_missing),
-                 "missing in the gear_params dataframe")
+                 "missing in the gear_params dataframe: knife_edge_size.")
 
     params_na <- knife_edge_selectivity_params_no_length
     params_na@gear_params$knife_edge_size[1] <- NA


### PR DESCRIPTION
## Summary of Changes

When a gear parameter data frame is missing required argument columns for a selectivity function, `gear_params<-()` (via `validGearParams()`) and `calc_selectivity()` now list the specific missing column names in the error message rather than giving a generic error.

- **`R/setFishing.R`**:
  - In `validGearParams()`: format error message to include missing argument names (`"missing in the gear parameter dataframe: <columns>."`).
  - In `calc_selectivity()`: format error message to include missing argument names (`"missing in the gear_params dataframe: <columns>."`).
- **`tests/testthat/test-setFishing.R`**:
  - Added unit tests verifying that missing column names are reported when validating gear parameters, setting `gear_params(params) <- ...`, and calling `calc_selectivity()`.
- **`NEWS.md`**:
  - Documented the change under *Species, gear and resource parameters*.