### PR TITLE
Improve given species parameter handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -353,6 +353,15 @@ while building or changing a model through a single mechanism controlled by
 
 ## Species, gear and resource parameters
 
+- The two species parameter setters now avoid unnecessary recalculation.
+  `given_species_params<-()` records every non-`NA` value as explicit input,
+  including a value equal to the current calculated value, but does not rebuild
+  the model for that provenance-only change. Changes to observation,
+  direct-runtime and unrelated custom columns also avoid the full `setParams()`
+  sequence. Standard parameters with cached dependants, arguments of active
+  custom predation kernels, demotions to calculated values and unknown columns
+  on extension objects retain the conservative rebuild path.
+
 - Changing a species parameter that feeds a rate array you have set by hand now
   warns you that the change has no effect on the model. Previously
   `given_species_params<-()` recorded the new value in the species parameter

--- a/R/species_params.R
+++ b/R/species_params.R
@@ -33,8 +33,12 @@
 #' When you change species parameters with `species_params<-()`, mizer
 #' automatically detects which parameters you have changed. It records these
 #' changed parameters in `given_species_params` so that they are protected
-#' against being overwritten by future recalculations. It then triggers a
-#' re-calculation of the calculated species parameters.
+#' against being overwritten by future recalculations. It then re-calculates
+#' the quantities that depend on the changed parameters. Changes to observation,
+#' direct-runtime or other custom columns that base mizer does not use to build
+#' a cached quantity do not trigger that recalculation. Unknown columns on an
+#' extension object retain the conservative recalculation path because an
+#' extension setter may use them.
 #'
 #' There are some species parameters that are used to set up the
 #' size-dependent parameters that are used in the mizer model:
@@ -167,9 +171,10 @@
 #' @param object A MizerParams object, a MizerSim object or a data frame
 #' @param params A MizerParams object.
 #' @param value A data frame with the new species parameters.
-#' @param recalculate Whether `species_params<-()` should re-derive the
-#'   calculated species parameters and recalculate all the rates that depend on
-#'   the species parameters. Defaults to `TRUE`. See the section "Setting
+#' @param recalculate Whether `species_params<-()` should be allowed to
+#'   re-derive calculated species parameters and rates that depend on a changed
+#'   parameter. Defaults to `TRUE`; mizer still skips the rebuild when all
+#'   changes are to columns with no cached dependants. See the section "Setting
 #'   species parameters without recalculation" below before setting it to
 #'   `FALSE`.
 #' @param x An object to test with `is.species_params()` or
@@ -219,24 +224,31 @@
 #'   currently stored in the model.
 #'
 #'   `species_params<-()`: Updates the `given_species_params` with any
-#'   parameters you have changed, and then recalculates the full species
-#'   parameter table and the model parameters. With `recalculate = FALSE` it
-#'   only does the recording and stores the parameters you supplied, see the
-#'   section "Setting species parameters without recalculation" below.
+#'   parameters you have changed, and recalculates the full species parameter
+#'   table and model parameters when a changed column has cached dependants.
+#'   With `recalculate = FALSE` it only does the recording and stores the
+#'   parameters you supplied, see the section "Setting species parameters
+#'   without recalculation" below.
 #'
 #'   `given_species_params()`: Data frame containing the species parameter
 #'   values that were supplied explicitly by the user.
 #'
-#'   `given_species_params<-()`: An alternative to `species_params<-()` that
-#'   also triggers a recalculation of other parameters. It arrives at the same
-#'   model, the difference being that `given_species_params<-()` warns when a
-#'   change you asked for cannot take effect, namely when the parameter is
+#'   `given_species_params<-()`: Replaces the authoritative table of parameters
+#'   that are to count as explicit user input. Every non-`NA` entry in `value`
+#'   is recorded as given, even when it is numerically equal to the value
+#'   currently in `species_params()`. This lets you protect a calculated value
+#'   against future recalculation. An `NA` entry, or removal of a column, hands
+#'   a previously given parameter back to mizer's calculation. Dependent
+#'   quantities are recalculated only when the replacement can change them;
+#'   merely marking the current value as given does not rebuild the model.
+#'
+#'   This setter also warns when a change you asked for cannot take effect,
+#'   namely when the parameter is
 #'   overridden by another one you have already given (`f0` by `gamma`, `fc` by
 #'   `ks`, `age_mat` by `h`), when the rate array it feeds has been set by hand
 #'   and so is no longer calculated, or when it is a gear parameter that mizer
-#'   reads from [gear_params()] instead. This is especially useful during
-#'   interactive use, while `species_params<-()` stays quiet about all three and
-#'   so is the better choice in scripts. It has no `recalculate` argument;
+#'   reads from [gear_params()] instead. `species_params<-()` stays quiet about
+#'   all three. `given_species_params<-()` has no `recalculate` argument;
 #'   where you need to record values without recalculating, use
 #'   `species_params<-()` or [record_given_species_params()].
 #'
@@ -351,6 +363,13 @@ species_params.species_params <- function(object, strict = FALSE, ...) {
         return(object)
     }
 
+    changed <- species_param_changes(value, object@species_params)
+    if (!needs_species_recalculation(object, value, changed)) {
+        object@species_params <- value
+        object@time_modified <- lubridate::now()
+        return(object)
+    }
+
     # Deliberately quiet about the changes that will have no impact, either
     # because another given parameter takes precedence or because the rate
     # array they feed has been set by hand. Only `given_species_params<-()`
@@ -384,6 +403,152 @@ rebuild_from_given <- function(object, keep) {
     }
     object@species_params <- new_sp
     return(suppressMessages(setParams(object)))
+}
+
+# Which entries changed between two species parameter tables. A removed column
+# is represented as changed for every species. This deliberately builds on
+# `changed_entries()`, the package's single definition of entry-wise equality.
+species_param_changes <- function(value, old) {
+    no_sp <- nrow(old)
+    cols <- union(names(value), names(old))
+    changed <- lapply(cols, function(col) {
+        if (!col %in% names(value)) {
+            return(rep(TRUE, no_sp))
+        }
+        changed_entries(value[[col]], old[[col]], no_sp)
+    })
+    names(changed) <- cols
+    changed[vapply(changed, any, logical(1))]
+}
+
+# Species parameters for which a numerical change can alter something cached
+# in a MizerParams object. Standard columns not on the leaf list default to the
+# safe choice of recalculating. Unknown columns on a base MizerParams object are
+# leaves, but on an extension object they are conservatively treated as
+# dependencies because an extension setter may read them.
+recalculation_species_params <- function(params, value) {
+    leaf <- c(
+        # Read directly by summaries, calibration or plotting code
+        "biomass_observed", "biomass_cutoff", "number_observed",
+        "number_cutoff", "yield_observed", "catch_observed", "legend_name",
+        "is_background",
+        # Read directly by reproduction-density-dependence functions
+        "erepro", "R_max", "constant_recruitment", "constant_reproduction",
+        "ricker_b", "sheperd_b", "sheperd_c"
+    )
+    required <- setdiff(known_species_params_columns(), leaf)
+
+    # A custom predation kernel can introduce arbitrary species parameters.
+    # Its formal arguments are dependencies even when their names are unknown
+    # to base mizer.
+    types <- unique(c(params@species_params$pred_kernel_type,
+                      value$pred_kernel_type))
+    types <- types[!is.na(types)]
+    for (type in types) {
+        fun <- get0(paste0(type, "_pred_kernel"))
+        if (is.function(fun)) {
+            required <- union(required,
+                              setdiff(names(formals(fun)), c("ppmr", "...")))
+        }
+    }
+
+    if (usesExtensionDispatch(params)) {
+        required <- union(required, names(value))
+    }
+    required
+}
+
+# Decide whether changed entries require the expensive rebuild through
+# setParams(). For the given-parameter setter, `old_given` distinguishes a
+# numerical change from a pure promotion of the current calculated value to an
+# explicitly given value.
+needs_species_recalculation <- function(params, value, changed,
+                                        old_given = NULL) {
+    if (length(changed) == 0) {
+        # A no-op `species_params<-()` call has historically been a way to
+        # rebuild an object after package code changed its slots directly.
+        # Preserve that repair behaviour. A no-op replacement of the given
+        # table, by contrast, changes no model value and needs no rebuild.
+        return(is.null(old_given))
+    }
+    required <- recalculation_species_params(params, value)
+    if (is.null(old_given)) {
+        # `record_given_species_params()` deliberately does not interpret a
+        # missing column as a request to remove it from the given table. Keep
+        # the established rebuild behaviour for such replacements.
+        if (any(!names(changed) %in% names(value))) {
+            return(TRUE)
+        }
+        return(any(names(changed) %in% required))
+    }
+
+    no_sp <- nrow(value)
+    removed <- setdiff(names(old_given), names(value))
+    for (col in removed) {
+        if (any(explicit_species_param_entries(old_given[[col]], no_sp))) {
+            return(TRUE)
+        }
+    }
+
+    for (col in names(changed)) {
+        sel <- changed[[col]]
+        new_explicit <- explicit_species_param_entries(value[[col]], no_sp)
+        old_explicit <- explicit_species_param_entries(old_given[[col]], no_sp)
+
+        # Handing any explicit value back to calculation needs a rebuild.
+        if (any(sel & old_explicit & !new_explicit)) {
+            return(TRUE)
+        }
+        if (!col %in% required) {
+            next
+        }
+
+        # A newly explicit value that equals the current model value changes
+        # provenance only. Every other change to a dependent parameter rebuilds.
+        promotion <- sel & !old_explicit & new_explicit
+        same_as_current <- !changed_entries(value[[col]],
+                                            params@species_params[[col]], no_sp)
+        if (any(sel & !(promotion & same_as_current))) {
+            return(TRUE)
+        }
+    }
+    FALSE
+}
+
+explicit_species_param_entries <- function(x, n) {
+    if (is.null(x)) {
+        return(rep(FALSE, n))
+    }
+    entry_has_value(x, n)
+}
+
+# Apply explicit entries from a given-parameter table to the full species
+# parameter table without deriving anything else. Called only after the change
+# classifier has established that no entry was handed back to calculation.
+merge_given_species_params <- function(sp, given, changed) {
+    no_sp <- nrow(sp)
+    for (col in names(changed)) {
+        if (col == "species") {
+            next
+        }
+        sel <- changed[[col]] &
+            explicit_species_param_entries(given[[col]], no_sp)
+        if (!any(sel)) {
+            next
+        }
+        new <- given[[col]]
+        old <- sp[[col]]
+        if (is.null(old)) {
+            sp <- set_column(sp, col, new)
+        } else if (!is.null(dim(old)) && length(dim(old)) >= 2) {
+            old[sel, ] <- new[sel, , drop = FALSE]
+            sp <- set_column(sp, col, old)
+        } else {
+            old[sel] <- new[sel]
+            sp <- set_column(sp, col, old)
+        }
+    }
+    sp
 }
 
 #' Record the species parameters that have changed
@@ -1158,6 +1323,13 @@ is.given_species_params <- function(x) {
     })
 
     params@given_species_params <- value
+    if (!needs_species_recalculation(params, value, changed,
+                                     old_given = old_given)) {
+        sp <- params@species_params
+        params@species_params <- merge_given_species_params(sp, value, changed)
+        params@time_modified <- lubridate::now()
+        return(params)
+    }
     # The user has edited the given species parameters and not the full table,
     # so it is the model's own species parameters whose columns are carried
     # over where they are not rebuilt from the given ones.

--- a/inst/skills/change-parameters/SKILL.md
+++ b/inst/skills/change-parameters/SKILL.md
@@ -67,12 +67,28 @@ size-dependent rate arrays that depend on it.
 species_params(params)$beta <- 150   # recorded as given; also rebuilds the predation kernel
 ```
 
-`given_species_params(params) <-` makes the same changes and is preferable in
-**interactive** sessions, because it additionally *warns* whenever a change you
-asked for cannot take effect: the parameter is overridden by another one you
-have already given, or it feeds a rate array you set by hand, or it is a gear
-parameter that mizer reads from `gear_params()`. `species_params(params) <-`
-stays quiet about all three, which is what makes it the better one for scripts.
+`given_species_params(params) <-` has a different job: it declares exactly
+which values count as explicit input. Every non-`NA` entry assigned there is
+recorded as given, even if its number is already present in `species_params()`.
+This is how to protect a value that mizer calculated:
+
+```r
+given_species_params(params)$q <- species_params(params)$q
+```
+
+Setting an entry to `NA`, or removing its column, hands it back to mizer's
+calculation. Merely protecting the current value changes its provenance, not
+the current model, so mizer does not rebuild the rate arrays. A changed value
+rebuilds only the quantities that can depend on that parameter; observation,
+direct-runtime and unrelated custom columns do not trigger a full `setParams()`
+call. Unknown columns on an extension object remain conservative and do trigger
+recalculation, because an extension setter may use them.
+
+`given_species_params<-()` also *warns* whenever a change you asked for cannot
+take effect: the parameter is overridden by another one you have already
+given, it feeds a rate array you set by hand, or it is a gear parameter that
+mizer reads from `gear_params()`. `species_params<-()` stays quiet about all
+three.
 
 **Turning the commentary up or down.** Mizer reports the choices it makes —
 defaults it filled in, inputs it adjusted, instructions it could not carry out —
@@ -102,8 +118,10 @@ given_species_params(params) <- gsp
 ```
 
 Handing the **full** `species_params()` table to `given_species_params(params) <-`
-records every calculated value in it as given, freezing parameters you never
-touched — on `NS_params` it turns 312 given entries into 396.
+deliberately records every non-`NA` value in it as given, freezing parameters
+you never touched — on `NS_params` it turns 312 given entries into 396. It does
+not recalculate the current model because all those values already agree with
+it, but future changes will no longer recalculate them.
 
 > **Version note.** Older guidance said to avoid `species_params(params) <-`
 > because it bypassed the `given_species_params` protection and skipped
@@ -561,7 +579,9 @@ whole new ecosystem component.
 
 | I want to change… | Use |
 |---|---|
-| a per-species value (`beta`, `w_mat`, `h`, `erepro`, …) | `species_params(params) <- …` (mizer ≥ 3.2; `given_species_params(params) <-` interactively or on older mizer) |
+| a per-species value (`beta`, `w_mat`, `h`, `erepro`, …) | `species_params(params) <- …` |
+| protect a value mizer has calculated | copy it from `species_params(params)` into `given_species_params(params)` |
+| let mizer calculate a value again | set it to `NA` in `given_species_params(params)` |
 | fishing gears / selectivity / catchability | `gear_params(params) <- …` |
 | baseline effort or selectivity/catchability arrays | `setFishing(params, …)` |
 | the resource (`kappa`, `lambda`, `r_pp`, …) | `resource_params(params) <- …` |

--- a/inst/skills/change-parameters/quick-reference.md
+++ b/inst/skills/change-parameters/quick-reference.md
@@ -3,6 +3,8 @@
 species_params(params)$beta <- 150
 species_params(params)                     # view all (given + calculated)
 calculated_species_params(params)          # only what mizer derived
+given_species_params(params)$q <- species_params(params)$q  # protect current q
+given_species_params(params)$q <- NA        # let mizer calculate q again
 
 # ── Size-dependent rate arrays ────────────────────────────────────────────────
 params <- setMetabolicRate(params)         # recompute from species params

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -60,14 +60,10 @@ plots) are in the changelog and are not repeated here.
 | `plot(<array>, species = ..., total = TRUE)` gives a bigger total than before | the total is the total of the whole array, not of the selected species | The total is summed on the axis it is plotted against (3.3) |
 | `plotSpectra2()` or `plotSpectraRelative()` with `size_axis = "l"` shows a `Total` line where it used to show none | the total is now formed on the axis being plotted | The total is summed on the axis it is plotted against (3.3) |
 | `plotSpectra2(size_axis = "l", ylim = ..., return_data = TRUE)` returns fewer rows | `ylim` now filters the data there as it does for `plotSpectra()` | The total is summed on the axis it is plotted against (3.3) |
-| New warning that a change to a species or resource parameter "has not taken effect" | the rate it feeds was set by hand and is no longer calculated | A change that cannot take effect now warns (3.3) |
-| That warning appears with `given_species_params<-()` but not with `species_params<-()` | the diagnostics belong to the given species parameter setter | The two species parameter setters divide the diagnostics between them (3.3) |
-| Setting a given species parameter to `NA` now warns that the change has not taken effect | clearing a value counts as a change, and a frozen array blocks it | The two species parameter setters divide the diagnostics between them (3.3) |
-| Adding an all-`NA` species parameter column used to warn and no longer does | nothing acquires a value, so it is not a change | The two species parameter setters divide the diagnostics between them (3.3) |
-| Marking an existing calculated species parameter as given no longer rebuilds all rate arrays | only its provenance changed | Species parameter setters avoid unnecessary recalculation (3.3) |
-| Changing an observation or custom species-parameter column no longer runs every rate setter | the column has no cached dependants in mizer | Species parameter setters avoid unnecessary recalculation (3.3) |
-| `given_species_params()` no longer lists `a` and `b`, or another default, after an unrelated `species_params<-()` call | a filled-in default was mistaken for user input and frozen as given | `species_params<-()` no longer freezes the defaults it fills in (3.3) |
-| A species parameter that used to keep its value now moves when you change another one | it was silently recorded as given and is now calculated again | `species_params<-()` no longer freezes the defaults it fills in (3.3) |
+| New warning that a species or resource parameter change "has not taken effect" | the rate it feeds was set by hand and is no longer calculated | Species parameter setters distinguish edits from declarations (3.3) |
+| `given_species_params<-()` warning behaviour changed: warnings appear only there, clearing a given value can warn, and adding an all-`NA` column does not | it reports actual changes to the authoritative given-value table | Species parameter setters distinguish edits from declarations (3.3) |
+| Marking a current calculated value as given, or changing an observation or custom column, no longer rebuilds all rate arrays | provenance-only and uncached changes need no rebuild | Species parameter setters distinguish edits from declarations (3.3) |
+| `given_species_params()` loses defaults such as `a` and `b`, or a derived value starts moving again | validation-filled defaults are no longer mistaken for user input | Species parameter setters distinguish edits from declarations (3.3) |
 | A message that used to appear no longer does, with `info_level = 0` | `info_level = 0` now silences everything | One report, one switch (3.3) |
 | `expect_message()` on a mizer call fails, or `options(warn = 2)` trips | reports are warnings where they were messages, and are collected until the end of the call | One report, one switch (3.3) |
 | A column read with `$` is now `NULL`, with a warning naming another column | `$` no longer partially matches column names | `$` no longer partially matches (3.3) |
@@ -334,146 +330,45 @@ made mizer repeat the "not consistent" warning at every later parameter change.
 If you worked around this by setting the weight and the length together, you can
 now set either one on its own.
 
-### A change that cannot take effect now warns
+### Species parameter setters distinguish edits from declarations
 
-If you have set a rate array by hand — `metab(params) <- ...`, or any setter
-called with an explicit array — mizer no longer calculates that rate from the
-species parameters. Changing one of the species parameters that used to feed it
-therefore changes the species parameter table but not the model.
-`given_species_params<-()` now warns when that happens:
+The setters now express two different intentions:
 
-```r
-params <- NS_params
-metab(params) <- metab(params)      # freeze the metabolic rate
-
-given_species_params(params)$ks <- 2 * species_params(params)$ks
-#> Warning: Your change to the species parameter `ks` has not taken effect
-#> because the metabolic rate has been set manually and so is no longer
-#> calculated from the species parameters. Call
-#> `setMetabolicRate(params, reset = TRUE)` if you want the metabolic rate to
-#> be calculated from the species parameters again.
-```
-
-Previously this was silent: the rate setter did emit a message, but
-`given_species_params<-()` runs `suppressMessages()` over the recalculation to
-quieten the routine chatter, so the message never reached you (#489). The same
-change made through `species_params<-()` stays silent — see *The two species
-parameter setters divide the diagnostics between them* below.
-
-**How this affects existing code:** nothing about the model changes — the
-change did not take effect before either, you just were not told. But code that
-runs under `options(warn = 2)`, or a test using `expect_message()` where the
-report now arrives as a warning, will need adjusting. To act on the warning,
-either put the rate back under the control of the species parameters with the
-`reset = TRUE` call it names, or set the rate array itself instead of the
-species parameter. To silence it, set `options(mizer_info_level = 0)`, which
-also covers the functions that take no `info_level` argument, or pass
-`info_level = 0` to the one call you want quiet.
-
-The resource works the same way. `resource_params(params)$kappa <- ...` on a
-model whose `resource_capacity()` you had set by hand used to change the stored
-`kappa` and nothing else, without saying anything at all; it now warns.
-
-This is the counterpart of the 3.2 change described under *Frozen arrays are
-protected from incidental balancing* below: there, mizer keeps a frozen array
-instead of overwriting it; here, it tells you when a parameter change is
-ignored because an array is frozen.
-
-### The two species parameter setters divide the diagnostics between them
-
-For an ordinary numerical edit the setters usually reach the same current
-model, but they express different intent. `species_params<-()` compares a
-complete table with the old one and records the entries that changed.
-`given_species_params<-()` treats its input as the authoritative declaration of
-what the user supplied, so a value becomes given even when it equals the current
-calculated value. The latter also tells you when a change you asked for cannot
-take effect, while `species_params<-()` does not. There are three such
-diagnostics, and they all sit on the same side of the line:
-
-| You change | and it is ignored because |
+| Setter | Meaning |
 |---|---|
-| `f0`, `fc`, `age_mat` | you have already given `gamma`, `ks`, `h` |
-| any parameter feeding a rate array you set by hand | the array is frozen |
-| `catchability`, `selectivity`, `l50`, `l25`, `sel_func`, `yield_observed` | these belong in `gear_params()` |
+| `species_params<-()` | Edit the complete table. Mizer detects and records only entries whose values changed. |
+| `given_species_params<-()` | Declare the authoritative user input. Every non-`NA` entry is given, even when equal to the current calculated value; `NA` or a removed column hands it back to mizer. |
 
-All three ask the same question about what changed, and setting a value to `NA`
-is part of the answer:
-
-```r
-params <- NS_params
-search_vol(params) <- search_vol(params)   # freeze the search volume
-
-given_species_params(params)$gamma <- NA   # hand `gamma` back to mizer
-#> Warning: Your change to the species parameter `gamma` has not taken effect
-#> because the search volume has been set manually …
-
-given_species_params(params)$z0 <- NA      # a column that was not given
-                                           # anyway: nothing changes, no warning
-```
-
-Clearing a parameter that *was* given is a change, because it asks mizer to go
-back to calculating it, and that instruction is blocked by a frozen array just
-as a new value would be. Adding a column that holds only `NA` is not a change:
-nothing acquires a value. The one thing none of the three reports is a value
-handed back to mizer being overruled by another given parameter — only a value
-that is there can be overruled, so setting `f0` to `NA` on a model that gives
-`gamma` stays silent.
-
-**How this affects existing code:** nothing, which is the point — a script that
-ran clean on 3.2 using `species_params<-()` still runs clean. Use
-`given_species_params<-()` when you are explicitly managing which values count
-as given, or when its extra diagnostics are useful; use `species_params<-()`
-for ordinary edits.
-
-### Species parameter setters avoid unnecessary recalculation
-
-Assigning a species parameter table used to run the complete `setParams()`
-sequence even when no cached quantity could change. This included marking a
-calculated value as given without changing its number, adding observations used
-only by calibration or plotting, and changing a custom column that base mizer
-does not use.
-
-The setters now distinguish numerical changes from provenance changes and know
-which standard parameters feed cached quantities. A current calculated value
-can therefore be protected without rebuilding the model:
+This makes it possible to protect a calculated value without changing the
+current model:
 
 ```r
 given_species_params(params)$q <- species_params(params)$q
 ```
 
-Observation, direct-runtime and unrelated custom columns are stored
-without recalculating all rate arrays. Parameters used by the active predation
-kernel still trigger recalculation, including arguments of a custom kernel.
-Unknown columns on extension-class objects remain conservative because an
-extension setter may use them. Clearing a given value to `NA` also keeps the
-full rebuild path so mizer can derive its replacement.
+The setters rebuild through `setParams()` only when the model can change.
+Provenance-only changes, observations, direct-runtime parameters and unrelated
+custom columns on a base `MizerParams` object are stored without rebuilding all
+rate arrays. Dependent parameters, demotions to calculated values, arguments of
+the active predation kernel and unknown columns on extension objects retain the
+conservative rebuild path. Call `setParams()` explicitly if the intention is to
+repair an object after direct slot manipulation.
 
-Code should not rely on a provenance-only or metadata edit incidentally
-repairing rate arrays after direct slot manipulation. Call `setParams()`
-explicitly when a rebuild is intended.
+`given_species_params<-()` also reports instructions that cannot take effect;
+`species_params<-()` stays quiet. It warns when a parameter is overruled by
+another given parameter, feeds a rate array set by hand, or belongs in
+`gear_params()`. Clearing an actually given value to `NA` counts as a change;
+adding an all-`NA` column does not. A frozen resource array is handled the same
+way. These warnings expose an existing no-op rather than changing the model:
+reset the named array to return it to parameter control, set the array directly,
+or use `options(mizer_info_level = 0)` when the warning is not wanted (#489).
 
-### `species_params<-()` no longer freezes the defaults it fills in
-
-`species_params<-()` records what you changed among the given species
-parameters. It used to also record any default that `validSpeciesParams()`
-filled in and that the model did not already carry, because such a column is
-indistinguishable from one you have just added. The usual victims are the
-length-weight parameters `a` and `b`, which a model built without length data
-does not have:
-
-```r
-params <- NS_params
-species_params(params)$beta <- 150     # nothing to do with a or b
-given_species_params(params)$a         # used to come back as 0.01 for every
-                                       # species; now absent, as it should be
-```
-
-**How this affects existing code:** a parameter that was silently frozen this
-way now stays calculated, so it responds to later changes and shows up in
-`calculated_species_params()` rather than `given_species_params()`. If you were
-relying on the frozen value, set it explicitly — a value you supply yourself is
-recorded as given exactly as before, including in a column that is new to the
-model (#496).
+Finally, defaults added while validating a `species_params<-()` assignment are
+no longer mistaken for values the user supplied. In particular, an unrelated
+edit no longer freezes newly filled `a` and `b` values. Such values can now move
+again when their inputs change and appear in `calculated_species_params()`
+rather than `given_species_params()`. Set a value explicitly if it should remain
+fixed (#496).
 
 ### One report, one switch
 
@@ -745,7 +640,8 @@ If you have a model in which you set `search_vol` by hand and then let mizer
 fill in a missing `gamma` or `f0`, that model's species parameters were wrong
 and change with this release. Note that the recalculated `gamma` still has no
 effect on the model while the search volume stays frozen — mizer now warns you
-about that separately, see "A change that cannot take effect now warns" above.
+about that separately, see "Species parameter setters distinguish edits from
+declarations" above.
 Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
 the control of the species parameters.
 

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -64,6 +64,8 @@ plots) are in the changelog and are not repeated here.
 | That warning appears with `given_species_params<-()` but not with `species_params<-()` | the diagnostics belong to the given species parameter setter | The two species parameter setters divide the diagnostics between them (3.3) |
 | Setting a given species parameter to `NA` now warns that the change has not taken effect | clearing a value counts as a change, and a frozen array blocks it | The two species parameter setters divide the diagnostics between them (3.3) |
 | Adding an all-`NA` species parameter column used to warn and no longer does | nothing acquires a value, so it is not a change | The two species parameter setters divide the diagnostics between them (3.3) |
+| Marking an existing calculated species parameter as given no longer rebuilds all rate arrays | only its provenance changed | Species parameter setters avoid unnecessary recalculation (3.3) |
+| Changing an observation or custom species-parameter column no longer runs every rate setter | the column has no cached dependants in mizer | Species parameter setters avoid unnecessary recalculation (3.3) |
 | `given_species_params()` no longer lists `a` and `b`, or another default, after an unrelated `species_params<-()` call | a filled-in default was mistaken for user input and frozen as given | `species_params<-()` no longer freezes the defaults it fills in (3.3) |
 | A species parameter that used to keep its value now moves when you change another one | it was silently recorded as given and is now calculated again | `species_params<-()` no longer freezes the defaults it fills in (3.3) |
 | A message that used to appear no longer does, with `info_level = 0` | `info_level = 0` now silences everything | One report, one switch (3.3) |
@@ -379,9 +381,13 @@ ignored because an array is frozen.
 
 ### The two species parameter setters divide the diagnostics between them
 
-`species_params<-()` and `given_species_params<-()` reach the same model. The
-difference is that `given_species_params<-()` tells you when a change you asked
-for cannot take effect, and `species_params<-()` does not. There are three such
+For an ordinary numerical edit the setters usually reach the same current
+model, but they express different intent. `species_params<-()` compares a
+complete table with the old one and records the entries that changed.
+`given_species_params<-()` treats its input as the authoritative declaration of
+what the user supplied, so a value becomes given even when it equals the current
+calculated value. The latter also tells you when a change you asked for cannot
+take effect, while `species_params<-()` does not. There are three such
 diagnostics, and they all sit on the same side of the line:
 
 | You change | and it is ignored because |
@@ -415,8 +421,36 @@ that is there can be overruled, so setting `f0` to `NA` on a model that gives
 
 **How this affects existing code:** nothing, which is the point — a script that
 ran clean on 3.2 using `species_params<-()` still runs clean. Use
-`given_species_params<-()` interactively, where the diagnostics are worth
-having, and `species_params<-()` in scripts.
+`given_species_params<-()` when you are explicitly managing which values count
+as given, or when its extra diagnostics are useful; use `species_params<-()`
+for ordinary edits.
+
+### Species parameter setters avoid unnecessary recalculation
+
+Assigning a species parameter table used to run the complete `setParams()`
+sequence even when no cached quantity could change. This included marking a
+calculated value as given without changing its number, adding observations used
+only by calibration or plotting, and changing a custom column that base mizer
+does not use.
+
+The setters now distinguish numerical changes from provenance changes and know
+which standard parameters feed cached quantities. A current calculated value
+can therefore be protected without rebuilding the model:
+
+```r
+given_species_params(params)$q <- species_params(params)$q
+```
+
+Observation, direct-runtime and unrelated custom columns are stored
+without recalculating all rate arrays. Parameters used by the active predation
+kernel still trigger recalculation, including arguments of a custom kernel.
+Unknown columns on extension-class objects remain conservative because an
+extension setter may use them. Clearing a given value to `NA` also keeps the
+full rebuild path so mizer can derive its replacement.
+
+Code should not rely on a provenance-only or metadata edit incidentally
+repairing rate arrays after direct slot manipulation. Call `setParams()`
+explicitly when a rebuild is intended.
 
 ### `species_params<-()` no longer freezes the defaults it fills in
 

--- a/man/species_params.Rd
+++ b/man/species_params.Rd
@@ -39,9 +39,10 @@ calculated_species_params(params)
 
 \item{...}{Other arguments passed to methods.}
 
-\item{recalculate}{Whether \verb{species_params<-()} should re-derive the
-calculated species parameters and recalculate all the rates that depend on
-the species parameters. Defaults to \code{TRUE}. See the section "Setting
+\item{recalculate}{Whether \verb{species_params<-()} should be allowed to
+re-derive calculated species parameters and rates that depend on a changed
+parameter. Defaults to \code{TRUE}; mizer still skips the rebuild when all
+changes are to columns with no cached dependants. See the section "Setting
 species parameters without recalculation" below before setting it to
 \code{FALSE}.}
 
@@ -57,24 +58,31 @@ species parameters without recalculation" below before setting it to
 currently stored in the model.
 
 \verb{species_params<-()}: Updates the \code{given_species_params} with any
-parameters you have changed, and then recalculates the full species
-parameter table and the model parameters. With \code{recalculate = FALSE} it
-only does the recording and stores the parameters you supplied, see the
-section "Setting species parameters without recalculation" below.
+parameters you have changed, and recalculates the full species parameter
+table and model parameters when a changed column has cached dependants.
+With \code{recalculate = FALSE} it only does the recording and stores the
+parameters you supplied, see the section "Setting species parameters
+without recalculation" below.
 
 \code{given_species_params()}: Data frame containing the species parameter
 values that were supplied explicitly by the user.
 
-\verb{given_species_params<-()}: An alternative to \verb{species_params<-()} that
-also triggers a recalculation of other parameters. It arrives at the same
-model, the difference being that \verb{given_species_params<-()} warns when a
-change you asked for cannot take effect, namely when the parameter is
+\verb{given_species_params<-()}: Replaces the authoritative table of parameters
+that are to count as explicit user input. Every non-\code{NA} entry in \code{value}
+is recorded as given, even when it is numerically equal to the value
+currently in \code{species_params()}. This lets you protect a calculated value
+against future recalculation. An \code{NA} entry, or removal of a column, hands
+a previously given parameter back to mizer's calculation. Dependent
+quantities are recalculated only when the replacement can change them;
+merely marking the current value as given does not rebuild the model.
+
+This setter also warns when a change you asked for cannot take effect,
+namely when the parameter is
 overridden by another one you have already given (\code{f0} by \code{gamma}, \code{fc} by
 \code{ks}, \code{age_mat} by \code{h}), when the rate array it feeds has been set by hand
 and so is no longer calculated, or when it is a gear parameter that mizer
-reads from \code{\link[=gear_params]{gear_params()}} instead. This is especially useful during
-interactive use, while \verb{species_params<-()} stays quiet about all three and
-so is the better choice in scripts. It has no \code{recalculate} argument;
+reads from \code{\link[=gear_params]{gear_params()}} instead. \verb{species_params<-()} stays quiet about
+all three. \verb{given_species_params<-()} has no \code{recalculate} argument;
 where you need to record values without recalculating, use
 \verb{species_params<-()} or \code{\link[=record_given_species_params]{record_given_species_params()}}.
 
@@ -123,8 +131,12 @@ set to default values. You can retrieve the given species parameters with
 When you change species parameters with \verb{species_params<-()}, mizer
 automatically detects which parameters you have changed. It records these
 changed parameters in \code{given_species_params} so that they are protected
-against being overwritten by future recalculations. It then triggers a
-re-calculation of the calculated species parameters.
+against being overwritten by future recalculations. It then re-calculates
+the quantities that depend on the changed parameters. Changes to observation,
+direct-runtime or other custom columns that base mizer does not use to build
+a cached quantity do not trigger that recalculation. Unknown columns on an
+extension object retain the conservative recalculation path because an
+extension setter may use them.
 
 There are some species parameters that are used to set up the
 size-dependent parameters that are used in the mizer model:

--- a/tests/testthat/test-species_params.R
+++ b/tests/testthat/test-species_params.R
@@ -773,6 +773,123 @@ test_that("given_species_params setter preserves columns mizer does not calculat
                  seq_len(nrow(species_params(params))), ignore_attr = TRUE)
 })
 
+test_that("given_species_params can protect an unchanged calculated value", {
+    params <- NS_params_small
+    params@given_species_params$q <- NULL
+    current_q <- species_params(params)$q
+
+    # Make a deliberately inconsistent, unfrozen array. A rebuild would repair
+    # it, so retaining it demonstrates that this provenance-only change does
+    # not call setParams().
+    params@search_vol[] <- 2 * params@search_vol
+    search_vol_before <- params@search_vol
+
+    given_species_params(params)$q <- current_q
+
+    expect_equal(given_species_params(params)$q, current_q,
+                 ignore_attr = TRUE)
+    expect_false("q" %in% names(calculated_species_params(params)))
+    expect_equal(params@search_vol, search_vol_before, ignore_attr = TRUE)
+
+    # The promotion has an effect on future recalculations: q no longer follows
+    # a change in the resource exponent.
+    resource_params(params)$lambda <- resource_params(params)$lambda + 0.1
+    expect_equal(species_params(params)$q, current_q, ignore_attr = TRUE)
+})
+
+test_that("the full species_params table can be declared given without rebuilding", {
+    params <- NS_params_small
+    params@search_vol[] <- 2 * params@search_vol
+    search_vol_before <- params@search_vol
+    sp <- species_params(params)
+
+    given_species_params(params) <- sp
+
+    given <- given_species_params(params)
+    for (col in names(sp)) {
+        if (is.atomic(sp[[col]]) && is.null(dim(sp[[col]]))) {
+            supplied <- !is.na(sp[[col]])
+            expect_equal(given[[col]][supplied], sp[[col]][supplied],
+                         ignore_attr = TRUE, info = col)
+        }
+    }
+    expect_equal(params@search_vol, search_vol_before, ignore_attr = TRUE)
+})
+
+test_that("leaf and custom species parameters do not rebuild the model", {
+    params <- NS_params_small
+    params@search_vol[] <- 2 * params@search_vol
+    search_vol_before <- params@search_vol
+    observed <- seq_len(nrow(species_params(params))) * 100
+
+    species_params(params)$biomass_observed <- observed
+    expect_equal(species_params(params)$biomass_observed, observed,
+                 ignore_attr = TRUE)
+    expect_equal(params@search_vol, search_vol_before, ignore_attr = TRUE)
+
+    species_params(params)$my_unused_parameter <- observed / 10
+    expect_equal(species_params(params)$my_unused_parameter, observed / 10,
+                 ignore_attr = TRUE)
+    expect_equal(params@search_vol, search_vol_before, ignore_attr = TRUE)
+
+    # The authoritative setter also merges a changed leaf value into the full
+    # table without rebuilding unrelated arrays.
+    given_species_params(params)$biomass_observed <- observed * 2
+    expect_equal(species_params(params)$biomass_observed, observed * 2,
+                 ignore_attr = TRUE)
+    expect_equal(params@search_vol, search_vol_before, ignore_attr = TRUE)
+})
+
+test_that("dependent changes and demotions still rebuild the model", {
+    params <- NS_params_small
+    params@given_species_params$q <- NULL
+    params@search_vol[] <- 2 * params@search_vol
+    search_vol_before <- params@search_vol
+
+    species_params(params)$q <- species_params(params)$q + 0.1
+    expect_false(isTRUE(all.equal(params@search_vol, search_vol_before,
+                                  check.attributes = FALSE)))
+
+    # A demotion must derive the replacement even when the old value happens
+    # to be the current species-parameter value.
+    params <- NS_params_small
+    old_gamma <- species_params(params)$gamma
+    given <- given_species_params(params)
+    given$f0 <- rep(0.2, nrow(given))
+    given$gamma <- NA
+    suppressWarnings(given_species_params(params) <- given)
+    expect_true(any(species_params(params)$gamma != old_gamma))
+})
+
+test_that("custom predation-kernel arguments require recalculation", {
+    fun_name <- "dependency_test_pred_kernel"
+    assign(fun_name, function(ppmr, custom_shape) ppmr^custom_shape,
+           envir = .GlobalEnv)
+    on.exit(rm(list = fun_name, envir = .GlobalEnv), add = TRUE)
+
+    params <- NS_params_small
+    sp <- species_params(params)
+    sp$pred_kernel_type <- "dependency_test"
+    sp$custom_shape <- rep(-1, nrow(sp))
+    species_params(params) <- sp
+
+    required <- recalculation_species_params(params, species_params(params))
+    expect_in("custom_shape", required)
+})
+
+test_that("extension objects treat unknown species parameters conservatively", {
+    class_name <- "SpeciesParamsDependencyTestParams"
+    if (!methods::isClass(class_name)) {
+        methods::setClass(class_name, contains = "MizerParams")
+    }
+    params <- methods::as(NS_params_small, class_name)
+    sp <- species_params(params)
+    sp$extension_parameter <- seq_len(nrow(sp))
+
+    required <- recalculation_species_params(params, sp)
+    expect_in("extension_parameter", required)
+})
+
 test_that("given_species_params setter can add new explicit columns", {
     params <- NS_params_small
     sp <- given_species_params(params)

--- a/vignettes/guide-change-parameters.Rmd
+++ b/vignettes/guide-change-parameters.Rmd
@@ -73,12 +73,28 @@ size-dependent rate arrays that depend on it.
 species_params(params)$beta <- 150   # recorded as given; also rebuilds the predation kernel
 ```
 
-`given_species_params(params) <-` makes the same changes and is preferable in
-**interactive** sessions, because it additionally *warns* whenever a change you
-asked for cannot take effect: the parameter is overridden by another one you
-have already given, or it feeds a rate array you set by hand, or it is a gear
-parameter that mizer reads from `gear_params()`. `species_params(params) <-`
-stays quiet about all three, which is what makes it the better one for scripts.
+`given_species_params(params) <-` has a different job: it declares exactly
+which values count as explicit input. Every non-`NA` entry assigned there is
+recorded as given, even if its number is already present in `species_params()`.
+This is how to protect a value that mizer calculated:
+
+```{r eval=FALSE}
+given_species_params(params)$q <- species_params(params)$q
+```
+
+Setting an entry to `NA`, or removing its column, hands it back to mizer's
+calculation. Merely protecting the current value changes its provenance, not
+the current model, so mizer does not rebuild the rate arrays. A changed value
+rebuilds only the quantities that can depend on that parameter; observation,
+direct-runtime and unrelated custom columns do not trigger a full [`setParams()`](../reference/setParams.html)
+call. Unknown columns on an extension object remain conservative and do trigger
+recalculation, because an extension setter may use them.
+
+`given_species_params<-()` also *warns* whenever a change you asked for cannot
+take effect: the parameter is overridden by another one you have already
+given, it feeds a rate array you set by hand, or it is a gear parameter that
+mizer reads from `gear_params()`. `species_params<-()` stays quiet about all
+three.
 
 **Turning the commentary up or down.** Mizer reports the choices it makes —
 defaults it filled in, inputs it adjusted, instructions it could not carry out —
@@ -108,8 +124,10 @@ given_species_params(params) <- gsp
 ```
 
 Handing the **full** `species_params()` table to `given_species_params(params) <-`
-records every calculated value in it as given, freezing parameters you never
-touched — on [`NS_params`](../reference/NS_params.html) it turns 312 given entries into 396.
+deliberately records every non-`NA` value in it as given, freezing parameters
+you never touched — on [`NS_params`](../reference/NS_params.html) it turns 312 given entries into 396. It does
+not recalculate the current model because all those values already agree with
+it, but future changes will no longer recalculate them.
 
 > **Version note.** Older guidance said to avoid `species_params(params) <-`
 > because it bypassed the `given_species_params` protection and skipped
@@ -418,7 +436,7 @@ params <- setParams(params)                       # rebuild ALL rate arrays at o
 params <- setParams(params, reset = TRUE)         # ...and thaw every frozen one
 ```
 
-Note that [`setParams()`](../reference/setParams.html) does not touch the resource: the resource rate,
+Note that `setParams()` does not touch the resource: the resource rate,
 capacity, level and dynamics belong to `setResource()`, and passing one of its
 arguments to `setParams()` is an error.
 
@@ -583,7 +601,9 @@ whole new ecosystem component.
 
 | I want to change… | Use |
 |---|---|
-| a per-species value (`beta`, `w_mat`, `h`, `erepro`, …) | [`species_params(params) <- …`](../reference/species_params.html) (mizer ≥ 3.2; [`given_species_params(params) <-`](../reference/species_params.html) interactively or on older mizer) |
+| a per-species value (`beta`, `w_mat`, `h`, `erepro`, …) | [`species_params(params) <- …`](../reference/species_params.html) |
+| protect a value mizer has calculated | copy it from [`species_params(params)`](../reference/species_params.html) into [`given_species_params(params)`](../reference/species_params.html) |
+| let mizer calculate a value again | set it to `NA` in [`given_species_params(params)`](../reference/species_params.html) |
 | fishing gears / selectivity / catchability | [`gear_params(params) <- …`](../reference/gear_params.html) |
 | baseline effort or selectivity/catchability arrays | [`setFishing(params, …)`](../reference/setFishing.html) |
 | the resource (`kappa`, `lambda`, `r_pp`, …) | [`resource_params(params) <- …`](../reference/resource_params.html) |
@@ -604,6 +624,8 @@ whole new ecosystem component.
 species_params(params)$beta <- 150
 species_params(params)                     # view all (given + calculated)
 calculated_species_params(params)          # only what mizer derived
+given_species_params(params)$q <- species_params(params)$q  # protect current q
+given_species_params(params)$q <- NA        # let mizer calculate q again
 
 # ── Size-dependent rate arrays ────────────────────────────────────────────────
 params <- setMetabolicRate(params)         # recompute from species params

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -250,9 +250,13 @@ ignored because an array is frozen.
 
 ### The two species parameter setters divide the diagnostics between them
 
-`species_params<-()` and `given_species_params<-()` reach the same model. The
-difference is that `given_species_params<-()` tells you when a change you asked
-for cannot take effect, and `species_params<-()` does not. There are three such
+For an ordinary numerical edit the setters usually reach the same current
+model, but they express different intent. `species_params<-()` compares a
+complete table with the old one and records the entries that changed.
+`given_species_params<-()` treats its input as the authoritative declaration of
+what the user supplied, so a value becomes given even when it equals the current
+calculated value. The latter also tells you when a change you asked for cannot
+take effect, while `species_params<-()` does not. There are three such
 diagnostics, and they all sit on the same side of the line:
 
 | You change | and it is ignored because |
@@ -286,8 +290,36 @@ that is there can be overruled, so setting `f0` to `NA` on a model that gives
 
 **How this affects existing code:** nothing, which is the point — a script that
 ran clean on 3.2 using `species_params<-()` still runs clean. Use
-`given_species_params<-()` interactively, where the diagnostics are worth
-having, and `species_params<-()` in scripts.
+`given_species_params<-()` when you are explicitly managing which values count
+as given, or when its extra diagnostics are useful; use `species_params<-()`
+for ordinary edits.
+
+### Species parameter setters avoid unnecessary recalculation
+
+Assigning a species parameter table used to run the complete [`setParams()`](../reference/setParams.html)
+sequence even when no cached quantity could change. This included marking a
+calculated value as given without changing its number, adding observations used
+only by calibration or plotting, and changing a custom column that base mizer
+does not use.
+
+The setters now distinguish numerical changes from provenance changes and know
+which standard parameters feed cached quantities. A current calculated value
+can therefore be protected without rebuilding the model:
+
+```{r eval=FALSE}
+given_species_params(params)$q <- species_params(params)$q
+```
+
+Observation, direct-runtime and unrelated custom columns are stored
+without recalculating all rate arrays. Parameters used by the active predation
+kernel still trigger recalculation, including arguments of a custom kernel.
+Unknown columns on extension-class objects remain conservative because an
+extension setter may use them. Clearing a given value to `NA` also keeps the
+full rebuild path so mizer can derive its replacement.
+
+Code should not rely on a provenance-only or metadata edit incidentally
+repairing rate arrays after direct slot manipulation. Call `setParams()`
+explicitly when a rebuild is intended.
 
 ### `species_params<-()` no longer freezes the defaults it fills in
 
@@ -630,7 +662,7 @@ rebuilds. Values calculated from the default `z0pre = 0.6` and
 
 ### `setParams()` rejects arguments it does not use
 
-[`setParams()`](../reference/setParams.html) passes its `...` on to the rate setters, each of which declares
+`setParams()` passes its `...` on to the rate setters, each of which declares
 its own `...` as unused. Any argument that none of them recognises was
 therefore accepted and ignored without a word. It is now an error, and the
 error says where the argument belongs when it belongs somewhere:

--- a/vignettes/upgrading.Rmd
+++ b/vignettes/upgrading.Rmd
@@ -203,146 +203,45 @@ made mizer repeat the "not consistent" warning at every later parameter change.
 If you worked around this by setting the weight and the length together, you can
 now set either one on its own.
 
-### A change that cannot take effect now warns
+### Species parameter setters distinguish edits from declarations
 
-If you have set a rate array by hand — [`metab(params) <- ...`](../reference/setMetabolicRate.html), or any setter
-called with an explicit array — mizer no longer calculates that rate from the
-species parameters. Changing one of the species parameters that used to feed it
-therefore changes the species parameter table but not the model.
-`given_species_params<-()` now warns when that happens:
+The setters now express two different intentions:
 
-```{r eval=FALSE}
-params <- NS_params
-metab(params) <- metab(params)      # freeze the metabolic rate
-
-given_species_params(params)$ks <- 2 * species_params(params)$ks
-#> Warning: Your change to the species parameter `ks` has not taken effect
-#> because the metabolic rate has been set manually and so is no longer
-#> calculated from the species parameters. Call
-#> `setMetabolicRate(params, reset = TRUE)` if you want the metabolic rate to
-#> be calculated from the species parameters again.
-```
-
-Previously this was silent: the rate setter did emit a message, but
-`given_species_params<-()` runs `suppressMessages()` over the recalculation to
-quieten the routine chatter, so the message never reached you (#489). The same
-change made through `species_params<-()` stays silent — see *The two species
-parameter setters divide the diagnostics between them* below.
-
-**How this affects existing code:** nothing about the model changes — the
-change did not take effect before either, you just were not told. But code that
-runs under `options(warn = 2)`, or a test using `expect_message()` where the
-report now arrives as a warning, will need adjusting. To act on the warning,
-either put the rate back under the control of the species parameters with the
-`reset = TRUE` call it names, or set the rate array itself instead of the
-species parameter. To silence it, set `options(mizer_info_level = 0)`, which
-also covers the functions that take no `info_level` argument, or pass
-`info_level = 0` to the one call you want quiet.
-
-The resource works the same way. [`resource_params(params)$kappa <- ...`](../reference/resource_params.html) on a
-model whose `resource_capacity()` you had set by hand used to change the stored
-`kappa` and nothing else, without saying anything at all; it now warns.
-
-This is the counterpart of the 3.2 change described under *Frozen arrays are
-protected from incidental balancing* below: there, mizer keeps a frozen array
-instead of overwriting it; here, it tells you when a parameter change is
-ignored because an array is frozen.
-
-### The two species parameter setters divide the diagnostics between them
-
-For an ordinary numerical edit the setters usually reach the same current
-model, but they express different intent. `species_params<-()` compares a
-complete table with the old one and records the entries that changed.
-`given_species_params<-()` treats its input as the authoritative declaration of
-what the user supplied, so a value becomes given even when it equals the current
-calculated value. The latter also tells you when a change you asked for cannot
-take effect, while `species_params<-()` does not. There are three such
-diagnostics, and they all sit on the same side of the line:
-
-| You change | and it is ignored because |
+| Setter | Meaning |
 |---|---|
-| `f0`, `fc`, [`age_mat`](../reference/age_mat.html) | you have already given `gamma`, `ks`, `h` |
-| any parameter feeding a rate array you set by hand | the array is frozen |
-| [`catchability`](../reference/setFishing.html), [`selectivity`](../reference/setFishing.html), `l50`, `l25`, `sel_func`, `yield_observed` | these belong in [`gear_params()`](../reference/gear_params.html) |
+| `species_params<-()` | Edit the complete table. Mizer detects and records only entries whose values changed. |
+| `given_species_params<-()` | Declare the authoritative user input. Every non-`NA` entry is given, even when equal to the current calculated value; `NA` or a removed column hands it back to mizer. |
 
-All three ask the same question about what changed, and setting a value to `NA`
-is part of the answer:
-
-```{r eval=FALSE}
-params <- NS_params
-search_vol(params) <- search_vol(params)   # freeze the search volume
-
-given_species_params(params)$gamma <- NA   # hand `gamma` back to mizer
-#> Warning: Your change to the species parameter `gamma` has not taken effect
-#> because the search volume has been set manually …
-
-given_species_params(params)$z0 <- NA      # a column that was not given
-                                           # anyway: nothing changes, no warning
-```
-
-Clearing a parameter that *was* given is a change, because it asks mizer to go
-back to calculating it, and that instruction is blocked by a frozen array just
-as a new value would be. Adding a column that holds only `NA` is not a change:
-nothing acquires a value. The one thing none of the three reports is a value
-handed back to mizer being overruled by another given parameter — only a value
-that is there can be overruled, so setting `f0` to `NA` on a model that gives
-`gamma` stays silent.
-
-**How this affects existing code:** nothing, which is the point — a script that
-ran clean on 3.2 using `species_params<-()` still runs clean. Use
-`given_species_params<-()` when you are explicitly managing which values count
-as given, or when its extra diagnostics are useful; use `species_params<-()`
-for ordinary edits.
-
-### Species parameter setters avoid unnecessary recalculation
-
-Assigning a species parameter table used to run the complete [`setParams()`](../reference/setParams.html)
-sequence even when no cached quantity could change. This included marking a
-calculated value as given without changing its number, adding observations used
-only by calibration or plotting, and changing a custom column that base mizer
-does not use.
-
-The setters now distinguish numerical changes from provenance changes and know
-which standard parameters feed cached quantities. A current calculated value
-can therefore be protected without rebuilding the model:
+This makes it possible to protect a calculated value without changing the
+current model:
 
 ```{r eval=FALSE}
 given_species_params(params)$q <- species_params(params)$q
 ```
 
-Observation, direct-runtime and unrelated custom columns are stored
-without recalculating all rate arrays. Parameters used by the active predation
-kernel still trigger recalculation, including arguments of a custom kernel.
-Unknown columns on extension-class objects remain conservative because an
-extension setter may use them. Clearing a given value to `NA` also keeps the
-full rebuild path so mizer can derive its replacement.
+The setters rebuild through [`setParams()`](../reference/setParams.html) only when the model can change.
+Provenance-only changes, observations, direct-runtime parameters and unrelated
+custom columns on a base [`MizerParams`](../reference/MizerParams.html) object are stored without rebuilding all
+rate arrays. Dependent parameters, demotions to calculated values, arguments of
+the active predation kernel and unknown columns on extension objects retain the
+conservative rebuild path. Call `setParams()` explicitly if the intention is to
+repair an object after direct slot manipulation.
 
-Code should not rely on a provenance-only or metadata edit incidentally
-repairing rate arrays after direct slot manipulation. Call `setParams()`
-explicitly when a rebuild is intended.
+`given_species_params<-()` also reports instructions that cannot take effect;
+`species_params<-()` stays quiet. It warns when a parameter is overruled by
+another given parameter, feeds a rate array set by hand, or belongs in
+[`gear_params()`](../reference/gear_params.html). Clearing an actually given value to `NA` counts as a change;
+adding an all-`NA` column does not. A frozen resource array is handled the same
+way. These warnings expose an existing no-op rather than changing the model:
+reset the named array to return it to parameter control, set the array directly,
+or use `options(mizer_info_level = 0)` when the warning is not wanted (#489).
 
-### `species_params<-()` no longer freezes the defaults it fills in
-
-`species_params<-()` records what you changed among the given species
-parameters. It used to also record any default that `validSpeciesParams()`
-filled in and that the model did not already carry, because such a column is
-indistinguishable from one you have just added. The usual victims are the
-length-weight parameters `a` and `b`, which a model built without length data
-does not have:
-
-```{r eval=FALSE}
-params <- NS_params
-species_params(params)$beta <- 150     # nothing to do with a or b
-given_species_params(params)$a         # used to come back as 0.01 for every
-                                       # species; now absent, as it should be
-```
-
-**How this affects existing code:** a parameter that was silently frozen this
-way now stays calculated, so it responds to later changes and shows up in
-[`calculated_species_params()`](../reference/species_params.html) rather than [`given_species_params()`](../reference/species_params.html). If you were
-relying on the frozen value, set it explicitly — a value you supply yourself is
-recorded as given exactly as before, including in a column that is new to the
-model (#496).
+Finally, defaults added while validating a `species_params<-()` assignment are
+no longer mistaken for values the user supplied. In particular, an unrelated
+edit no longer freezes newly filled `a` and `b` values. Such values can now move
+again when their inputs change and appear in [`calculated_species_params()`](../reference/species_params.html)
+rather than [`given_species_params()`](../reference/species_params.html). Set a value explicitly if it should remain
+fixed (#496).
 
 ### One report, one switch
 
@@ -406,7 +305,7 @@ recomputing.
 
 ### `getProportionOfLargeFish()` on a `MizerParams` object was wrong
 
-The [`MizerParams`](../reference/MizerParams.html) method multiplied the species x size abundance array by the
+The `MizerParams` method multiplied the species x size abundance array by the
 vector of weights, which R recycles down the columns of the array rather than
 along the size axis, so every species but the first was weighted by the wrong
 sizes. Only the `MizerParams` method was affected; the [`MizerSim`](../reference/MizerSim.html) method was
@@ -614,7 +513,8 @@ If you have a model in which you set `search_vol` by hand and then let mizer
 fill in a missing `gamma` or `f0`, that model's species parameters were wrong
 and change with this release. Note that the recalculated `gamma` still has no
 effect on the model while the search volume stays frozen — mizer now warns you
-about that separately, see "A change that cannot take effect now warns" above.
+about that separately, see "Species parameter setters distinguish edits from
+declarations" above.
 Call `setSearchVolume(params, reset = TRUE)` to put the search volume back under
 the control of the species parameters.
 
@@ -702,7 +602,7 @@ among the setters that `setParams()` calls, which it always did.
 Twelve accessors that read a parameter or rate array back out of a `MizerParams` object had
 two interchangeable names. The bare name is now the one to use — it is the one
 that also has a replacement function, so the pair reads the same way in both
-directions (`catchability(params)` and `catchability(params) <- value`,
+directions ([`catchability(params)`](../reference/setFishing.html) and `catchability(params) <- value`,
 [`reproduction_level(params)`](../reference/setBevertonHolt.html) and `reproduction_level(params) <- value`). The
 `get`-prefixed names are soft-deprecated and warn:
 
@@ -876,7 +776,7 @@ an input, and the size-dependent arrays are computed from it.
 
 #### Assigning to `resource_params()` now updates the resource arrays
 
-Previously, assigning to `resource_params()` — or to one of its components, such
+Previously, assigning to [`resource_params()`](../reference/resource_params.html) — or to one of its components, such
 as `resource_params(params)$kappa <- ...` — only stored the new scalar values.
 The size-dependent carrying capacity (`cc_pp`) and replenishment rate (`rr_pp`)
 were left unchanged until you next called `setResource()`.


### PR DESCRIPTION
## Summary

- make `given_species_params<-()` authoritative: every non-`NA` value is recorded as explicitly given, even when it equals the current calculated value
- avoid rebuilding the model for provenance-only changes and for observation, direct-runtime, and unrelated custom columns
- retain recalculation for dependent changes, demotions back to calculated values, active custom predation-kernel arguments, and unknown extension parameters
- preserve the historical no-op `species_params<-()` repair behaviour
- update help, parameter-change guidance, upgrade notes, generated articles, and NEWS

## Motivation

Previously, `given_species_params<-()` only retained values that differed from `species_params()`. A user therefore could not mark an already-current calculated value as given and protect it from later recalculation. Both species-parameter setters also ran the full `setParams()` sequence when the change could not affect any cached quantity.

This change separates provenance from numerical change. Protecting the current value updates the given-parameter table without rebuilding the model, while changes that can affect derived parameters or cached arrays continue down the conservative recalculation path.

## User impact

Users can now protect a calculated value explicitly, for example:

```r
given_species_params(params)$q <- species_params(params)$q
```

Setting the corresponding given entry to `NA`, or removing its column, hands it back to mizer's calculation. Assigning the full species table deliberately marks all non-`NA` entries as given without recalculating an otherwise unchanged model.

## Validation

- `Rscript -e 'devtools::load_all(quiet = TRUE); devtools::test(filter = "species_params", stop_on_failure = TRUE)'`
- 333 assertions passed; 0 failures, warnings, or skips
- `git diff --check`