### PR TITLE
Bring the model-type articles up to date with the current API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -675,6 +675,24 @@ while building or changing a model through a single mechanism controlled by
 
 ## Documentation
 
+- The "Community Model", "Trait-Based Model" and "The General Mizer
+  Size-spectrum Model" articles have been checked against the current API in the
+  same way. The model description used the deprecated `getResourceRate()` and
+  `getResourceCapacity()`, gave the wrong sign for the exponent in the default
+  external mortality $z0_i = z0_{pre}\,w_{\infty.i}^{n-1}$, said that the
+  investment into reproduction reaches one at `w_max` when since 3.1 that is
+  `w_repro_max`, misspelled `BevertonHoltRDD()`, repeated a sentence three times,
+  and linked to a developer vignette that no longer exists. The trait-based
+  article claimed 100 size bins where `newTraitParams()` now chooses 161.
+
+- The "Multi Species Model" article has been brought up to date with the current
+  API. It used the deprecated `getInteraction()`, said that the `MizerParams`
+  object stores neither abundances nor fishing effort (it stores the initial
+  values of both), described `steady()` as re-tuning `erepro` when it now
+  preserves the `reproduction_level` by default and also rebalances the resource,
+  and contained Rd markup (`\eqn{}` and `[foo()]` links) that does not render in
+  an Rmd article.
+
 - "Extending mizer" and "Guide: Extending mizer" have been merged into a single
   guide at `guide-extend-mizer`, generated from the `extend-mizer` skill; the old
   address redirects. The topic had been split across three documents that each

--- a/vignettes/community_model.Rmd
+++ b/vignettes/community_model.Rmd
@@ -204,8 +204,8 @@ plot(x = w(params), y = pred_mort_final, log = "xy", type = "l",
      xlab = "Size [g]", ylab = "Predation mortality [1/year]")
 ```
 
-Note how we used `w(sim)` to get the vector of sizes to plot along the x-axis and
-how we specified that we wanted to have logarithmic axes.
+Note how we used `w(params)` to get the vector of sizes to plot along the x-axis
+and how we specified that we wanted to have logarithmic axes.
 
 In the long run it is worthwhile to use the ggplot2 package for creating plots,
 so we show also how you would create the above graph with `ggplot()`. For

--- a/vignettes/model_description.qmd
+++ b/vignettes/model_description.qmd
@@ -28,7 +28,8 @@ size-dependent growth and mortality rates of individuals, and it describes how m
 we suggest you start by reading about [the single-species model](single_species_size-spectrum_dynamics.html).
 
 We will not go into detail of how this model is 
-realised in code. Such detail will be provided in the [developer guide](https://sizespectrum.org/mizer/articles/developer_vignette.html). However some details are hidden on this page
+realised in code. Such detail is provided in the vignette on the
+[numerical scheme](numerical_details.html). However some details are hidden on this page
 and you can see them by clicking on links like the following:
 <details>
 And clicking again will hide the details again.
@@ -177,15 +178,13 @@ $$r_R(w)= r_R\, w^{n-1}.$$
 
 $$c_R(w)=\kappa\, w^{-\lambda}.$$
 
-You can retrieve these with `getResourceRate()` and `getResourceCapacity()`
+You can retrieve these with `resource_rate()` and `resource_capacity()`
 respectively. It is also possible to implement other resource dynamics, as
 described in the help page for `setResource()`. The mortality $\mu_R(w)$ is
 due to predation by consumers and is described in the subsection 
 [Resource mortality].
 
-Because the resource spectrum spans a larger range of sizes these sizes
-Because the resource spectrum spans a larger range of sizes these sizes
-Because the resource spectrum spans a larger range of sizes these sizes
+Because the resource spectrum spans a larger range of sizes, these sizes
 are discretized into a different vector of weights
 
 The resource spectrum is then represented by a vector `NResource` such that
@@ -404,8 +403,11 @@ This is calculated with the `getEReproAndGrowth()` function.
 ## Investment into reproduction  {#sec:repro}
 A proportion $\psi_i(w)$ of the energy available for growth and reproduction is
 used for reproduction. This proportion should change from zero below the weight
-$w_{m.i}$ of maturation to one at the maximum weight $w_{max.i}$, where
-all available energy is used for reproduction. This function is changed with
+$w_{m.i}$ of maturation to one at the weight $w_{repro.max.i}$ at which an
+individual invests all its available energy into reproduction. By default this
+is the von Bertalanffy asymptotic size $w_{\infty.i}$; it is set by the
+`w_repro_max` species parameter, which is distinct from the computational
+upper boundary `w_max` of the size grid. This function is changed with
 `setReproduction()`. Mizer provides a default form for the function which you
 can however overrule.
 
@@ -468,7 +470,7 @@ changed with `setExtMort()`. By default mizer assumes that the external
 mortality for each species is a constant $z0_i$ independent of size. The value
 of $z0_i$ is either specified as a species parameter or it is assumed to
 depend allometrically on the maximum size:
-$$z0_i = z0_{pre} w_{\infty.i}^{1-n}.$$
+$$z0_i = z0_{pre}\, w_{\infty.i}^{n-1}.$$
 
 
 ## Fishing mortality
@@ -546,7 +548,7 @@ $$
 where $R_{\max.i}$ is the maximum reproduction rate of each trait class. 
 This final rate of reproduction is calculated with `getRDD()`.
 
-This default *Beverton-Holt* type is implemented by `BervertonHoldRDD()` but
+This default *Beverton-Holt* type is implemented by `BevertonHoltRDD()` but
 mizer also provides alternatives `RickerRDD()`, `SheperdRDD()`, `constantRDD()`
 and `noRDD()`. Also, users are able to write their own functions, e.g.
 *hockey-stick*. See `setReproduction()` for details.

--- a/vignettes/multispecies_model.Rmd
+++ b/vignettes/multispecies_model.Rmd
@@ -61,15 +61,16 @@ A `MizerParams` object stores the:
 * parameters relating to the growth and dynamics of the resource spectrum;
 * fishing gear parameters: selectivity and catchability.
 
-Note that the `MizerParams` class does not store any parameters that can vary
-through time, such as fishing effort or population abundance. These are stored
-in the `MizerSim` class which we will come to later in 
+Besides the model parameters, a `MizerParams` object also holds an *initial
+state*: the initial abundances of the species and of the resource and the
+initial fishing effort. These are the values a simulation starts from. The
+values of the abundances and the effort at all the later times of a simulation
+are stored in the `MizerSim` class which we will come to later in 
 [the section on running a simulation.](running_a_simulation.html#sec:projection)
 
 Although the `MizerParams` class contains a lot of information, it is relatively
 straightforward to set up and use. Objects of class `MizerParams` are created
-using the constructor method `newMultispeciesParams()` (this constructor method
-was called MizerParams() in previous version of mizer). This constructor method
+using the constructor method `newMultispeciesParams()`. This constructor method
 can take many arguments. However, creation is simplified because many of the
 arguments have default values.
 
@@ -135,9 +136,10 @@ range of such selectivity functions and the user just needs to specify their
 parameters for each gear and each species in the `gear_params` data frame. All
 the details can be found on the help page for `setFishing()`.
 
-Fishing effort is not stored in the MizerParams object. Instead, effort is set
-when the simulation is run and can vary through time (see 
-[the section on running a simulation](running_a_simulation.html)).
+The MizerParams object stores only the *initial* fishing effort, which you can
+inspect and change with `initial_effort()`. The effort that is actually used
+during a simulation is set when the simulation is run and can vary through time
+(see [the section on running a simulation](running_a_simulation.html)).
 
 
 ## Example of making `MizerParams` objects {#sec:params_example}
@@ -230,7 +232,10 @@ species_params(params)
 We can see that this returns the original species data.frame (with `w_inf` and
 so on), plus any default values that may not have been included in the original
 data.frame. For example, we can see that there are now columns for `alpha` and
-`h` and `gamma` etc.
+`h` and `gamma` etc. Only a few columns are printed in full; the remaining ones
+are listed by name at the end. If you want to see only the parameters that you
+supplied yourself, without the ones that mizer filled in, use
+`given_species_params(params)`.
 
 Also note how the default fishing gears have been set up. Even though we did
 not provide a gear parameter data frame, the MizerParams object has one that we
@@ -269,11 +274,12 @@ summary(params200)
 
 So far we have created a `MizerParams` object by passing in only the species
 parameter data.frame argument. We did not specify an interaction matrix. The
-interaction matrix \eqn{\theta_{ij}} describes the interaction of each pair of
+interaction matrix $\theta_{ij}$ describes the interaction of each pair of
 species in the model. This can be viewed as a proxy for spatial interaction e.g.
 to model predator-prey interaction that is not size based. The values in the
-interaction matrix are used to scale the encountered food in [getEncounter()]
-and the predation mortality rate in [getPredMort()] (see 
+interaction matrix are used to scale the encountered food in
+[`getEncounter()`](../reference/getEncounter.html) and the predation mortality
+rate in [`getPredMort()`](../reference/getPredMort.html) (see 
 [the section on predator-prey encounter rate](model_description.html#sec:pref) 
 and on [predation mortality](model_description.html#mortality)).
 
@@ -283,7 +289,7 @@ other) to 1 (species overlap perfectly). By default mizer sets all values to 1,
 implying that all species fully interact with each other, i.e. the species are
 spread homogeneously across the model area. 
 ```{r}
-getInteraction(params)
+interaction_matrix(params)
 ```
 
 For the North Sea this is not the
@@ -308,10 +314,11 @@ inter
 ```
 
 We can set the interaction matrix in our existing MizerParams object `params`
-with the `setInteraction()` function:
+by assigning to `interaction_matrix()`:
 ```{r}
-params <- setInteraction(params, interaction = inter)
+interaction_matrix(params) <- inter
 ```
+This is equivalent to `params <- setInteraction(params, interaction = inter)`.
 
 Alternatively, instead of changing the interaction matrix in the existing
 MizerParams object, we could have created a new object from scratch with our
@@ -370,20 +377,34 @@ examine the catches by gear.
 Once the `MizerParams` object has been properly set up, it may be the case that
 one wishes put the system in steady state. Sometimes this can be done simply by
 running the model using `project()` until it reaches steady state. However, this
-method is not guaranteed to work, and there is a function called `steady()` that is
-more reliable. The function `steady()` must be supplied with a MizerParams
+method is not guaranteed to work, and there is a function called `steady()` that
+is more reliable. The function `steady()` must be supplied with a MizerParams
 object. It takes that MizerParams object, looks at the initial system state,
-computes the levels of reproduction of the different species, hold them fixed,
+computes the rates of reproduction of the different species, holds them fixed,
 and evolves the system until a steady state is reached (or more precisely, until
 the amount that the population abundances change during a time-step is below
-some small tolerance level). After this, the reproductive efficiency of each
-species is altered so that when the reproduction dynamics are turned back on
-(i.e., when we stop holding recruitment levels fixed), the values of the
-reproduction levels which we held the system fixed at will be realized. The
-steady function is not sure to converge, and the way it re-tunes the
-reproductive efficiency values may not be realistic, but the idea is to alter
-the other parameters in the system until `steady()` does arrive at a steady
-state with sensible reproductive efficiency values.
+some small tolerance level). The resource is rebalanced at the same time, so
+that the state returned is a steady state of the resource as well as of the
+consumers.
+
+After this, the reproduction parameters of each species are re-tuned so that
+when the reproduction dynamics are turned back on (i.e., when we stop holding
+the reproduction rates fixed), the reproduction rates at which we held the
+system fixed will indeed be realised. By default it is the
+`reproduction_level` of each species that is preserved by this re-tuning; the
+`preserve` argument of `steady()` lets you preserve the maximum reproduction
+rate `R_max` or the reproductive efficiency `erepro` instead. See
+`setBevertonHolt()` for an explanation of the reproduction level.
+
+The `steady()` function is not sure to converge, and the way it re-tunes the
+reproduction parameters may not be realistic, but the idea is to alter the other
+parameters in the system until `steady()` does arrive at a steady state with
+sensible parameter values. The returned object carries a `"convergence"`
+attribute that describes what was found (a steady state, a limit cycle, or no
+convergence), and `summary()` reports how far the model is from steady state.
+There is also `steadyNewton()`, which solves for the steady state directly
+instead of by running the dynamics. Calibrating a model to observations is
+discussed in the [guide to calibrating a model](guide-calibrate-model.html).
 
 Now that we know how to create a multispecies model we shall discuss how to 
 [run a multispecies model.](running_a_simulation.html)

--- a/vignettes/trait_model.Rmd
+++ b/vignettes/trait_model.Rmd
@@ -182,9 +182,9 @@ plot(sim1)
 The trophic cascade can be explored by comparing the total abundances of all
 species at size when the community is fished and unfished. As mentioned above,
 we obtain the abundances with  `N(sim)`, which returns a three dimensional array
-with dimensions time x species x size. Here we have 76 time steps (75 from the
-simulation plus one which stores the initial population), 10 species and 100
-sizes:
+with dimensions time x species x size. Here we have `r dim(N(sim0))[1]` time
+steps (75 from the simulation plus one which stores the initial population),
+`r dim(N(sim0))[2]` species and `r dim(N(sim0))[3]` sizes:
 
 ```{r label=trait_dim_n}
 dim(N(sim0))


### PR DESCRIPTION
Checked all four "Model types" articles by knitting each against the current build and cross-checking the prose against the `upgrade-mizer-code` references for 3.0–3.3.

## The General Mizer Size-spectrum Model (`model_description.qmd`)

- **The default external mortality had the exponent the wrong way round.** It read $z0_i = z0_{pre}\,w_{\infty.i}^{1-n}$, but the code uses `z0exp = n - 1`. Checked numerically: `0.6 * 33^(-1/3) = 0.187`, which is exactly the `z0` mizer assigns to Sprat.
- **`w_max` vs `w_repro_max`.** $\psi_i(w)$ was said to reach one at "the maximum weight $w_{max.i}$". Since 3.1 that is `w_repro_max` (defaulting to `w_inf`), and `w_max` is purely the computational grid boundary — the exact distinction 3.1 introduced.
- `getResourceRate()` / `getResourceCapacity()` → `resource_rate()` / `resource_capacity()` (deprecated in 2.4.0).
- `BervertonHoldRDD()` → `BevertonHoltRDD()`. (`SheperdRDD()` alongside it really is spelled that way in mizer, so it stays.)
- A sentence in the resource section appeared three times in a row.
- The "developer guide" link pointed at `articles/developer_vignette.html`, which returns 404 and has no redirect in `_pkgdown.yml`. Retargeted at `numerical_details.html`, the article that now covers how the model is realised numerically.

## Multi Species Model

- `getInteraction()` has been deprecated since 2.4.0 and was emitting a deprecation warning into the rendered article. Now `interaction_matrix()`, and the section leads with `interaction_matrix(params) <- inter` with `setInteraction()` named as the equivalent.
- "the `MizerParams` class does not store any parameters that can vary through time, such as fishing effort or population abundance" is wrong — `initial_n`, `initial_n_pp` and `initial_effort` are slots, and the `summary()` output shown a few paragraphs later prints an effort per gear. Same for "Fishing effort is not stored in the MizerParams object".
- The `steady()` description predates the `preserve` argument: the default now preserves the `reproduction_level` rather than re-tuning `erepro`, and the resource is rebalanced too. Rewritten with pointers to `preserve`, the `"convergence"` attribute, `steadyNewton()` and the calibration guide.
- `\eqn{}` and `[foo()]` are Rd markup and do not render in an Rmd article. Verified against the built `docs/articles/multispecies_model.html`: the equation was silently swallowed and the links came out as literal bracketed text.
- Noted that `species_params()` now prints a summary view and that `given_species_params()` shows only what the user supplied; dropped a stale parenthetical about `MizerParams()` being the old constructor name.

## Trait-Based Model

- "10 species and **100** sizes" is stale — `newTraitParams()` derives `no_w` from the size range and chooses **161** here. Replaced the hardcoded dimensions with inline R so they cannot go stale again.

## Community Model

- The text says `w(sim)` where the code above it uses `w(params)`.

## Not changed

`single_species_size-spectrum_dynamics.Rmd` needed nothing: it knits clean and already uses the current API throughout (`biomass =` / `per_log_size =` rather than `power`, `given_species_params()`, `psi()`, `addPlot()`, `w_repro_max`).

Also verified as still current and left alone: `newCommunityParams()`'s `z0`/`alpha`/`f0`/`h`/`knife_edge_size`/`reproduction` arguments, `get_initial_n()`, `min_w_max`/`max_w_max` as the non-deprecated `newTraitParams()` spellings, `w_inf` as the essential species parameter with `w_max` defaulting to `1.5 * w_inf`, and the `knife_edge_size` default of `w_mat`.

## Testing

Re-knitted both `.Rmd` files and rendered the `.qmd` through quarto; all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPLySpXhp7GexR52dtwi4P