### PR TITLE
Stress that steady() and projectToSteady() may not return a steady state

### DIFF
--- a/R/steady.R
+++ b/R/steady.R
@@ -71,6 +71,12 @@ distanceSSLogN.MizerParams <- function(params, current, previous) {
 #' successive time steps is less than `tol`. You determine how the distance is
 #' calculated.
 #'
+#' Because reproduction stays dynamic here, the run can only ever end up on an
+#' attractor of the dynamics, and that need not be a fixed point: it may stop on
+#' a limit cycle, on a species going extinct, or simply at `t_max`. So the state
+#' it leaves behind is not necessarily a steady state; see the section below on
+#' how to check.
+#'
 #' @details
 #' # How the run is organised
 #'
@@ -165,6 +171,8 @@ distanceSSLogN.MizerParams <- function(params, current, previous) {
 #' The reported `period` is a multiple of `t_save`, so it is only resolved to
 #' that accuracy; reduce `t_save` if you need the period more precisely.
 #'
+#' @template section_check_steady
+#'
 #' @inheritParams steady
 #' @param effort The fishing effort to be used throughout the simulation.
 #'   This is validated by [validEffortVector()] and can therefore be `NULL`, a
@@ -210,7 +218,8 @@ distanceSSLogN.MizerParams <- function(params, current, previous) {
 #'       peak-to-trough biomass amplitude; otherwise `NA`.}
 #'   }
 #'   This mirrors how [steadyNewton()] attaches an `"stability"` attribute.
-#' @seealso [distanceSSLogN()], [distanceMaxRelRDI()], [steadyNewton()],
+#' @seealso [steady()], [isSteady()], [getSteadyResidual()],
+#'   [distanceSSLogN()], [distanceMaxRelRDI()], [steadyNewton()],
 #'   [getStability()]
 #' @export
 projectToSteady <- function(params,
@@ -553,6 +562,12 @@ find_first_acf_peak <- function(ac, threshold) {
 #' resource and other components constant until the size spectra no longer
 #' change much (or until time `t_max` is reached, if earlier).
 #'
+#' Holding those constant is what makes the search reliable, but it does not
+#' make the result certain: the state that is stored is only as close to a fixed
+#' point as `tol` and `t_max` allowed, and the run may instead have stopped on a
+#' limit cycle or on a species going extinct. Check the result rather than
+#' assuming it; see the section below.
+#'
 #' If the model use Beverton-Holt reproduction then the reproduction parameters
 #' are set to values that give the level of reproduction observed in that
 #' steady state. The `preserve` argument can be used to specify which of the
@@ -610,12 +625,16 @@ find_first_acf_peak <- function(ac, threshold) {
 #'   [default_info_level()].
 #' @param method The numerical method to use for the consumer density update.
 #'   See [project()].
+#' @template section_check_steady
+#'
 #' @return If `return_sim = FALSE`, a `MizerParams` object with the initial
 #'   state replaced by the steady state. If `return_sim = TRUE`, a `MizerSim`
 #'   object containing the intermediate states saved every `t_per` years. The
 #'   returned object carries a `"convergence"` attribute describing the solution
 #'   found (steady state, limit cycle, or non-convergence); see
-#'   [projectToSteady()].
+#'   [projectToSteady()]. Check it: convergence is not guaranteed.
+#' @seealso [projectToSteady()], [steadySingleSpecies()], [steadyNewton()],
+#'   [isSteady()], [getSteadyResidual()], [getStability()]
 #' @export
 #' @examples
 #' \donttest{

--- a/R/steadyNewton.R
+++ b/R/steadyNewton.R
@@ -104,7 +104,8 @@
 #' @param ... Unused.
 #' @return A \linkS4class{MizerParams} object with the initial state set to the
 #'   steady state.
-#' @seealso [steady()], [steadySingleSpecies()], [getStability()]
+#' @seealso [steady()], [steadySingleSpecies()], [getStability()],
+#'   [isSteady()], [getSteadyResidual()]
 #' @export
 #' @examples
 #' \donttest{

--- a/inst/skills/calibrate-model/SKILL.md
+++ b/inst/skills/calibrate-model/SKILL.md
@@ -49,6 +49,31 @@ rate at the new steady state — use the `preserve` argument to choose whether
 `reproduction_level` (default), `R_max`, or `erepro` is held fixed during that
 re-tuning.
 
+**`steady()` returning is not proof that the model is steady.** Its stopping
+test is the relative change in egg production over `t_per`, a proxy for the
+drift itself, and the run can also stop on a limit cycle, on a species going
+extinct, or simply at `t_max`. All four outcomes return a `MizerParams` object
+that looks the same. What distinguishes them is the `"convergence"` attribute,
+and the checks in [Verifying the result](#verifying-the-result):
+
+```r
+params <- steady(params)
+attr(params, "convergence")$type       # "steady", "cycle", "not_converged", "extinction"
+attr(params, "convergence")$residual   # largest biomass drift, in 1/year
+plot(getSteadyResidual(params))        # which species, and at which sizes
+```
+
+`"steady"` with a `residual` above about `0.05` means `tol` was too loose:
+tighten it. `"cycle"` means the dynamics settled onto a limit cycle and the
+stored state is one point on it — see the `analyse-stability` skill.
+`"not_converged"` means the run ran out of time: raise `t_max`, or get a better
+starting spectrum from `steadySingleSpecies()` first, and reach for
+`steadyNewton()` when the fixed point is dynamically unstable. `"extinction"`
+means a species is dying out, which is a modelling problem — see [Diagnosing
+calibration problems](#diagnosing-calibration-problems). `steady()` says all of
+this in its messages too, but `info_level = 0` suppresses those, so in a script
+the attribute is the reliable check.
+
 ## The calibration loop
 
 Do this only if you have observations. Observed biomasses live in the
@@ -171,10 +196,9 @@ and analyse the results with the `analyse-and-plot` skill.
   and trophic mechanics.
 - **Biomass matches but growth is wrong (or vice versa).** Alternate
   `matchGrowth()` and `matchBiomasses()`, re-running `steady()` between them.
-- **`steady()` said it converged but the results still drift.** Its convergence
-  test is the relative change in egg production over `t_per`, which is a proxy.
-  Check `attr(params, "convergence")$residual`, or `summary(params)`, for how far
-  the state actually is from a fixed point, and reduce `steady()`'s `tol` if it is
+- **`steady()` said it converged but the results still drift.** Check
+  `attr(params, "convergence")$residual`, or `summary(params)`, for how far the
+  state actually is from a fixed point, and reduce `steady()`'s `tol` if it is
   too large. `steady()` warns when the two disagree.
 - **Results move even though nothing was changed.** The model was not at its
   steady state to begin with. `plot(getSteadyResidual(params))` shows which

--- a/man-roxygen/section_check_steady.R
+++ b/man-roxygen/section_check_steady.R
@@ -1,0 +1,39 @@
+#' @section What you get back may not be a steady state:
+#'
+#'   The stopping criterion is a proxy. It says that two states `t_per` years
+#'   apart differ by less than `tol` on whatever scale the criterion is measured
+#'   on; it does not say that the state reached is a fixed point. There are four
+#'   ways the returned object can fail to be one:
+#'
+#'   - the run converged on its own scale while the biomasses are still
+#'     visibly drifting, because `tol` was too loose;
+#'   - the run reached `t_max` without converging (`type = "not_converged"`);
+#'   - the run settled on a limit cycle (`type = "cycle"`), in which case the
+#'     state stored is one point on that cycle;
+#'   - the run stopped because a species was going extinct
+#'     (`type = "extinction"`).
+#'
+#'   So treat the result as a claim to be checked rather than as a guarantee:
+#'
+#'   ```r
+#'   attr(params, "convergence")$type      # "steady", "cycle", "not_converged", "extinction"
+#'   attr(params, "convergence")$residual  # largest biomass drift, in 1/year
+#'   isSteady(params)                      # TRUE if within tolerance
+#'   summary(params)                       # includes the biomass-drift verdict
+#'   plot(getSteadyResidual(params))       # which species, and at which sizes
+#'   ```
+#'
+#'   The first four say *whether* the model is steady, the last says *where* it
+#'   is not, which is the one to reach for when it is not: a model that is off
+#'   steady state is usually off in one species or one part of the size range,
+#'   and the plot names it. See [getSteadyResidual()] for why the verdict is
+#'   phrased in terms of biomass drift rather than the largest per-capita rate.
+#'
+#'   The messages this function prints say the same thing — a converged run
+#'   whose biomasses are still moving reports the drift and adds "Reduce `tol`
+#'   to converge further." — but they are suppressed by `info_level = 0`, so in
+#'   a script the `"convergence"` attribute is the reliable check.
+#'
+#'   Finally, a genuine fixed point need not be a *stable* one. Use
+#'   [getStability()] to find out, and [steadyNewton()] to converge onto a fixed
+#'   point that the dynamics themselves would run away from.

--- a/man/projectToSteady.Rd
+++ b/man/projectToSteady.Rd
@@ -125,6 +125,12 @@ Run the full dynamics, as in \code{\link[=project]{project()}}, but stop once th
 down sufficiently, in the sense that the distance between states at
 successive time steps is less than \code{tol}. You determine how the distance is
 calculated.
+
+Because reproduction stays dynamic here, the run can only ever end up on an
+attractor of the dynamics, and that need not be a fixed point: it may stop on
+a limit cycle, on a species going extinct, or simply at \code{t_max}. So the state
+it leaves behind is not necessarily a steady state; see the section below on
+how to check.
 }
 \section{How the run is organised}{
 The simulation is not run in one go but is broken into blocks of \code{t_per}
@@ -222,7 +228,50 @@ The reported \code{period} is a multiple of \code{t_save}, so it is only resolve
 that accuracy; reduce \code{t_save} if you need the period more precisely.
 }
 
+\section{What you get back may not be a steady state}{
+
+
+The stopping criterion is a proxy. It says that two states \code{t_per} years
+apart differ by less than \code{tol} on whatever scale the criterion is measured
+on; it does not say that the state reached is a fixed point. There are four
+ways the returned object can fail to be one:
+\itemize{
+\item the run converged on its own scale while the biomasses are still
+visibly drifting, because \code{tol} was too loose;
+\item the run reached \code{t_max} without converging (\code{type = "not_converged"});
+\item the run settled on a limit cycle (\code{type = "cycle"}), in which case the
+state stored is one point on that cycle;
+\item the run stopped because a species was going extinct
+(\code{type = "extinction"}).
+}
+
+So treat the result as a claim to be checked rather than as a guarantee:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{attr(params, "convergence")$type      # "steady", "cycle", "not_converged", "extinction"
+attr(params, "convergence")$residual  # largest biomass drift, in 1/year
+isSteady(params)                      # TRUE if within tolerance
+summary(params)                       # includes the biomass-drift verdict
+plot(getSteadyResidual(params))       # which species, and at which sizes
+}\if{html}{\out{</div>}}
+
+The first four say \emph{whether} the model is steady, the last says \emph{where} it
+is not, which is the one to reach for when it is not: a model that is off
+steady state is usually off in one species or one part of the size range,
+and the plot names it. See \code{\link[=getSteadyResidual]{getSteadyResidual()}} for why the verdict is
+phrased in terms of biomass drift rather than the largest per-capita rate.
+
+The messages this function prints say the same thing — a converged run
+whose biomasses are still moving reports the drift and adds "Reduce \code{tol}
+to converge further." — but they are suppressed by \code{info_level = 0}, so in
+a script the \code{"convergence"} attribute is the reliable check.
+
+Finally, a genuine fixed point need not be a \emph{stable} one. Use
+\code{\link[=getStability]{getStability()}} to find out, and \code{\link[=steadyNewton]{steadyNewton()}} to converge onto a fixed
+point that the dynamics themselves would run away from.
+}
+
 \seealso{
+\code{\link[=steady]{steady()}}, \code{\link[=isSteady]{isSteady()}}, \code{\link[=getSteadyResidual]{getSteadyResidual()}},
 \code{\link[=distanceSSLogN]{distanceSSLogN()}}, \code{\link[=distanceMaxRelRDI]{distanceMaxRelRDI()}}, \code{\link[=steadyNewton]{steadyNewton()}},
 \code{\link[=getStability]{getStability()}}
 }

--- a/man/steady.Rd
+++ b/man/steady.Rd
@@ -88,7 +88,7 @@ state replaced by the steady state. If \code{return_sim = TRUE}, a \code{MizerSi
 object containing the intermediate states saved every \code{t_per} years. The
 returned object carries a \code{"convergence"} attribute describing the solution
 found (steady state, limit cycle, or non-convergence); see
-\code{\link[=projectToSteady]{projectToSteady()}}.
+\code{\link[=projectToSteady]{projectToSteady()}}. Check it: convergence is not guaranteed.
 }
 \description{
 The steady state is found by running the dynamics while keeping reproduction,
@@ -96,6 +96,12 @@ resource and other components constant until the size spectra no longer
 change much (or until time \code{t_max} is reached, if earlier).
 }
 \details{
+Holding those constant is what makes the search reliable, but it does not
+make the result certain: the state that is stored is only as close to a fixed
+point as \code{tol} and \code{t_max} allowed, and the run may instead have stopped on a
+limit cycle or on a species going extinct. Check the result rather than
+assuming it; see the section below.
+
 If the model use Beverton-Holt reproduction then the reproduction parameters
 are set to values that give the level of reproduction observed in that
 steady state. The \code{preserve} argument can be used to specify which of the
@@ -107,6 +113,48 @@ preserved while the capacity is recomputed to keep it steady. If the resource
 capacity had been set manually (frozen), it is rebalanced and thereby
 unfrozen.
 }
+\section{What you get back may not be a steady state}{
+
+
+The stopping criterion is a proxy. It says that two states \code{t_per} years
+apart differ by less than \code{tol} on whatever scale the criterion is measured
+on; it does not say that the state reached is a fixed point. There are four
+ways the returned object can fail to be one:
+\itemize{
+\item the run converged on its own scale while the biomasses are still
+visibly drifting, because \code{tol} was too loose;
+\item the run reached \code{t_max} without converging (\code{type = "not_converged"});
+\item the run settled on a limit cycle (\code{type = "cycle"}), in which case the
+state stored is one point on that cycle;
+\item the run stopped because a species was going extinct
+(\code{type = "extinction"}).
+}
+
+So treat the result as a claim to be checked rather than as a guarantee:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{attr(params, "convergence")$type      # "steady", "cycle", "not_converged", "extinction"
+attr(params, "convergence")$residual  # largest biomass drift, in 1/year
+isSteady(params)                      # TRUE if within tolerance
+summary(params)                       # includes the biomass-drift verdict
+plot(getSteadyResidual(params))       # which species, and at which sizes
+}\if{html}{\out{</div>}}
+
+The first four say \emph{whether} the model is steady, the last says \emph{where} it
+is not, which is the one to reach for when it is not: a model that is off
+steady state is usually off in one species or one part of the size range,
+and the plot names it. See \code{\link[=getSteadyResidual]{getSteadyResidual()}} for why the verdict is
+phrased in terms of biomass drift rather than the largest per-capita rate.
+
+The messages this function prints say the same thing — a converged run
+whose biomasses are still moving reports the drift and adds "Reduce \code{tol}
+to converge further." — but they are suppressed by \code{info_level = 0}, so in
+a script the \code{"convergence"} attribute is the reliable check.
+
+Finally, a genuine fixed point need not be a \emph{stable} one. Use
+\code{\link[=getStability]{getStability()}} to find out, and \code{\link[=steadyNewton]{steadyNewton()}} to converge onto a fixed
+point that the dynamics themselves would run away from.
+}
+
 \examples{
 \donttest{
 params <- newTraitParams()
@@ -114,4 +162,8 @@ species_params(params)$gamma[5] <- 3000
 params <- steady(params)
 plotSpectra(params)
 }
+}
+\seealso{
+\code{\link[=projectToSteady]{projectToSteady()}}, \code{\link[=steadySingleSpecies]{steadySingleSpecies()}}, \code{\link[=steadyNewton]{steadyNewton()}},
+\code{\link[=isSteady]{isSteady()}}, \code{\link[=getSteadyResidual]{getSteadyResidual()}}, \code{\link[=getStability]{getStability()}}
 }

--- a/man/steadyNewton.Rd
+++ b/man/steadyNewton.Rd
@@ -136,5 +136,6 @@ plotSpectra(params)
 }
 }
 \seealso{
-\code{\link[=steady]{steady()}}, \code{\link[=steadySingleSpecies]{steadySingleSpecies()}}, \code{\link[=getStability]{getStability()}}
+\code{\link[=steady]{steady()}}, \code{\link[=steadySingleSpecies]{steadySingleSpecies()}}, \code{\link[=getStability]{getStability()}},
+\code{\link[=isSteady]{isSteady()}}, \code{\link[=getSteadyResidual]{getSteadyResidual()}}
 }

--- a/vignettes/guide-calibrate-model.Rmd
+++ b/vignettes/guide-calibrate-model.Rmd
@@ -55,6 +55,31 @@ rate at the new steady state — use the `preserve` argument to choose whether
 [`reproduction_level`](../reference/setBevertonHolt.html) (default), `R_max`, or `erepro` is held fixed during that
 re-tuning.
 
+**`steady()` returning is not proof that the model is steady.** Its stopping
+test is the relative change in egg production over `t_per`, a proxy for the
+drift itself, and the run can also stop on a limit cycle, on a species going
+extinct, or simply at `t_max`. All four outcomes return a `MizerParams` object
+that looks the same. What distinguishes them is the `"convergence"` attribute,
+and the checks in [Verifying the result](#verifying-the-result):
+
+```{r eval=FALSE}
+params <- steady(params)
+attr(params, "convergence")$type       # "steady", "cycle", "not_converged", "extinction"
+attr(params, "convergence")$residual   # largest biomass drift, in 1/year
+plot(getSteadyResidual(params))        # which species, and at which sizes
+```
+
+`"steady"` with a `residual` above about `0.05` means `tol` was too loose:
+tighten it. `"cycle"` means the dynamics settled onto a limit cycle and the
+stored state is one point on it — see the [guide to analysing dynamic stability](guide-analyse-stability.html).
+`"not_converged"` means the run ran out of time: raise `t_max`, or get a better
+starting spectrum from `steadySingleSpecies()` first, and reach for
+`steadyNewton()` when the fixed point is dynamically unstable. `"extinction"`
+means a species is dying out, which is a modelling problem — see [Diagnosing
+calibration problems](#diagnosing-calibration-problems). `steady()` says all of
+this in its messages too, but `info_level = 0` suppresses those, so in a script
+the attribute is the reliable check.
+
 ---
 
 ## The calibration loop
@@ -185,10 +210,9 @@ and analyse the results with the [guide to analysing and plotting mizer results]
   and trophic mechanics.
 - **Biomass matches but growth is wrong (or vice versa).** Alternate
   `matchGrowth()` and `matchBiomasses()`, re-running `steady()` between them.
-- **`steady()` said it converged but the results still drift.** Its convergence
-  test is the relative change in egg production over `t_per`, which is a proxy.
-  Check `attr(params, "convergence")$residual`, or `summary(params)`, for how far
-  the state actually is from a fixed point, and reduce `steady()`'s `tol` if it is
+- **`steady()` said it converged but the results still drift.** Check
+  `attr(params, "convergence")$residual`, or `summary(params)`, for how far the
+  state actually is from a fixed point, and reduce `steady()`'s `tol` if it is
   too large. `steady()` warns when the two disagree.
 - **Results move even though nothing was changed.** The model was not at its
   steady state to begin with. [`plot(getSteadyResidual(params))`](../reference/plot.html) shows which


### PR DESCRIPTION
## The problem

`steady()` and `projectToSteady()` return a `MizerParams` object that looks the same whether the run reached a fixed point, settled on a **limit cycle**, ran out of time at `t_max`, or stopped because a species was going **extinct**. On top of that, the stopping test is a proxy — the relative change in RDI over `t_per`, not the drift itself — so even a `"steady"` verdict can sit on a state whose biomasses are visibly moving.

Everything needed to tell these apart already exists: the `"convergence"` attribute (including the `residual` field, re-measured in `steady()` on the restored model), `isSteady()`, `getSteadyResidual()`, and the drift line in `summary()`. What was missing was the signposting. `steady()` had **no `@seealso` at all**; `projectToSteady()`'s listed only the distance functions, `steadyNewton()` and `getStability()`. Neither linked to `isSteady()` or `getSteadyResidual()`, and the `"convergence"` attribute was documented under *Value* as a neutral data structure with no instruction to look at it.

## The change

**A shared roxygen section**, `man-roxygen/section_check_steady.R`, included by both functions so the prose lives in one place. It gives the four ways the returned object can fail to be a fixed point, then the checks to run, ending on `plot(getSteadyResidual(params))` for *where* a model is unsteady as against `isSteady()`/`summary()` for *whether* — the distinction `R/getSteadyResidual.R` already draws. It notes that the messages are suppressed by `info_level = 0`, so in a script the attribute is the reliable check, and that a genuine fixed point need not be a stable one (`getStability()`, `steadyNewton()`).

**A lead-in in each function's own voice.** `steady()` holds reproduction, resource and other components constant, which makes the search reliable but leaves the result only as close to a fixed point as `tol` and `t_max` allowed. `projectToSteady()` keeps reproduction dynamic and so can only ever land on an attractor, which need not be a fixed point.

**`@seealso` extended** on `steady()`, `projectToSteady()` and `steadyNewton()` to include `isSteady()` and `getSteadyResidual()`.

**`inst/skills/calibrate-model/SKILL.md`**: the point was made only in the troubleshooting list, always framed as a later `match…()` step knocking the model off — never as `steady()` itself not having got there — and the limit-cycle and non-converged outcomes were not mentioned in that skill at all. It is now in the main flow, right after the `steady()` function table, saying what each `convergence$type` means and what to do about each, cross-linked to the existing "Verifying the result" section. The sentence it now duplicates was trimmed from the troubleshooting entry. `vignettes/guide-calibrate-model.Rmd` regenerated with `build_guides()`.

Deliberately not claimed: that `preserve = "R_max"`/`"erepro"` can break steadiness. `setBevertonHolt()` preserves RDD by construction, so it does not.

## Verification

- `devtools::document()` — the template expands into `man/steady.Rd` and `man/projectToSteady.Rd`, and the new cross-references resolve.
- `build_guides()` — link check passes; only `guide-calibrate-model.Rmd` changed.
- `devtools::test(filter = "steady")` — 124 pass, 0 fail (27 skips are the usual `MIZER_TEST_EXPERIMENTAL` gates).

Documentation only; no behaviour changes, hence no `NEWS.md` or `upgrade-mizer-code` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)