### PR TITLE
Stop the convergence report claiming more than it knows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,8 +58,10 @@ while building or changing a model through a single mechanism controlled by
 - `steady()` and `projectToSteady()` now report the nature of the solution they
   converged to via a `"convergence"` attribute on the returned object (mirroring
   the `"stability"` attribute of `steadyNewton()`). It records whether the run
-  settled on a stable steady state, a limit cycle, or neither, together with the
-  cycle period and relative amplitude when a cycle is found. Limit cycles are
+  dropped below its tolerance (`type = "below_tolerance"` — deliberately not
+  called `"steady"`, because passing the distance test is not a guarantee of a
+  fixed point), settled on a limit cycle, or neither, together with the cycle
+  period and relative amplitude when a cycle is found. Limit cycles are
   detected from a per-species biomass series sampled at the new `t_save`
   resolution (default `dt`), so detection no longer relies on the cycle period
   being commensurate with `t_per`. The relative-amplitude floor for calling an
@@ -113,6 +115,13 @@ while building or changing a model through a single mechanism controlled by
   whatever scale the distance function uses; `residual` measures the thing
   itself, and `steady()` now says when the two disagree — a run declared
   converged whose biomasses are still visibly moving (#495).
+
+- `steady()` and `projectToSteady()` no longer end a successful run by saying
+  "Convergence was achieved in 12 years." They now say what was actually tested
+  — "Reached the convergence tolerance after 12 years." — and report the biomass
+  drift every time rather than only when it is large, because that number is the
+  evidence for whether the state is a fixed point. Code matching the old wording
+  needs updating.
 
 - `matchBiomasses()`, `matchNumbers()` and `matchGrowth()` now say that they
   have moved the model off its steady state, turning an

--- a/R/steady.R
+++ b/R/steady.R
@@ -111,7 +111,11 @@ distanceSSLogN.MizerParams <- function(params, current, previous) {
 #' `distance_func` is called with the state at the end of the previous block and
 #' the state at the end of the current block, i.e. with two states `t_per` years
 #' apart. If the number it returns is less than `tol`, the run stops with
-#' `type = "steady"`. What "distance" means is entirely up to that function:
+#' `type = "below_tolerance"`. The type is deliberately not called `"steady"`:
+#' all it says is that the state stopped moving on the scale of the distance
+#' function, which is not a guarantee that a fixed point has been reached. The
+#' `residual` entry of the `"convergence"` attribute measures that directly.
+#' What "distance" means is entirely up to that function:
 #' the default [distanceSSLogN()] uses the sum of squared changes in log
 #' abundance, while [steady()] instead passes [distanceMaxRelRDI()], which uses
 #' the largest relative change in egg production.
@@ -202,10 +206,15 @@ distanceSSLogN.MizerParams <- function(params, current, previous) {
 #'   In either case the returned object carries an attribute `"convergence"`
 #'   describing the solution the run settled on, a named list with entries:
 #'   \describe{
-#'     \item{`type`}{One of `"steady"` (a stable fixed point), `"cycle"` (a
-#'       limit cycle), `"not_converged"` (still changing at `t_max`) or
-#'       `"extinction"` (a species died out).}
-#'     \item{`converged`}{Logical, `TRUE` for `"steady"` and `"cycle"`.}
+#'     \item{`type`}{One of `"below_tolerance"` (the distance function dropped
+#'       below `tol`, which suggests but does not guarantee a stable fixed
+#'       point — check `residual`), `"cycle"` (a limit cycle),
+#'       `"not_converged"` (still changing at `t_max`) or `"extinction"` (a
+#'       species died out).}
+#'     \item{`settled`}{Logical, `TRUE` for `"below_tolerance"` and `"cycle"`,
+#'       i.e. when the run stopped on a criterion of its own rather than
+#'       running out of time. It says nothing about whether the state reached
+#'       is a fixed point; that is what `residual` is for.}
 #'     \item{`distance`}{The final value returned by `distance_func`.}
 #'     \item{`residual`}{The largest per-capita rate of change, in 1/year, at the
 #'       state that was reached, as returned by [getSteadyResidual()]. Unlike
@@ -386,7 +395,7 @@ projectToSteady.MizerParams <- function(params,
     }
 
     years <- (i - 1) * t_per
-    converged <- FALSE
+    settled <- FALSE
 
     params@initial_n[] <- current$n
     params@initial_n_pp[] <- current$n_pp
@@ -399,37 +408,39 @@ projectToSteady.MizerParams <- function(params,
     residual <- tryCatch(steady_biomass_drift(params, effort = effort),
                          error = function(e) NA_real_)
     residual_txt <- if (is.finite(residual)) {
-        paste0(" A biomass is still changing at up to ",
-               signif(residual, 2), " per year.")
+        paste0(" The biomasses change at up to ", signif(residual, 2),
+               " per year.")
     } else {
         ""
     }
 
     if (!is.null(cycle)) {
         type <- "cycle"
-        converged <- TRUE
+        settled <- TRUE
         signal_info("convergence", paste0(
-            "Converged to a limit cycle of period ",
+            "Settled onto a limit cycle of period ",
             signif(cycle$period, 3), " years (relative amplitude ",
             signif(cycle$amplitude, 2), ") after ", years, " years."),
             unhandled = "show")
     } else if (success) {
-        type <- "steady"
-        converged <- TRUE
+        type <- "below_tolerance"
+        settled <- TRUE
         # The distance function being satisfied only says that the state stopped
-        # moving on that function's own scale. Report the residual alongside it,
-        # and flag the case where the two disagree — a run declared converged
-        # whose biomasses are still visibly moving, which would otherwise be
-        # invisible. This stays an "info": the user asked for convergence at
+        # moving on that function's own scale, so the message says that and no
+        # more. The residual is reported every time, not only when it is large:
+        # it is the evidence for whether this is a fixed point, and a number the
+        # user only ever sees when something has gone wrong is a number they
+        # never learn to look at. Only the instruction to act on it is
+        # conditional. This stays an "info": the user asked for convergence at
         # their `tol` and got it, so nothing they asked for failed to happen.
         caveat <- if (is.finite(residual) && residual > steady_residual_tol()) {
-            paste0(residual_txt, " Reduce `tol` to converge further.")
+            " Reduce `tol` to converge further."
         } else {
             ""
         }
         signal_info("convergence",
-                    paste0("Convergence was achieved in ", years, " years.",
-                           caveat),
+                    paste0("Reached the convergence tolerance after ", years,
+                           " years.", residual_txt, caveat),
                     unhandled = "show")
     } else {
         type <- if (any(extinct)) "extinction" else "not_converged"
@@ -441,7 +452,7 @@ projectToSteady.MizerParams <- function(params,
 
     convergence <- list(
         type = type,
-        converged = converged,
+        settled = settled,
         distance = distance,
         residual = residual,
         years = years,

--- a/inst/skills/analyse-stability/SKILL.md
+++ b/inst/skills/analyse-stability/SKILL.md
@@ -54,9 +54,10 @@ warning. `plot(getSteadyResidual(params))` shows how far off it is — see the
 `calibrate-model` skill.
 
 `steady()` and `projectToSteady()` attach a related `"convergence"` attribute
-recording whether the run settled on a **steady state, a limit cycle, or
-neither**, together with the cycle period and relative amplitude when a cycle is
-found. Limit cycles are detected from the per-species biomass series sampled at
+recording whether the run **dropped below its tolerance** (`type =
+"below_tolerance"`, which suggests but does not prove a fixed point), settled on
+**a limit cycle**, or **neither**, together with the cycle period and relative
+amplitude when a cycle is found. Limit cycles are detected from the per-species biomass series sampled at
 `t_save`; the relative-amplitude floor for calling an oscillation a cycle is the
 `amplitude_tol` argument (default `0.01`), independent of the fixed-point
 tolerance `tol`.

--- a/inst/skills/calibrate-model/SKILL.md
+++ b/inst/skills/calibrate-model/SKILL.md
@@ -58,13 +58,15 @@ and the checks in [Verifying the result](#verifying-the-result):
 
 ```r
 params <- steady(params)
-attr(params, "convergence")$type       # "steady", "cycle", "not_converged", "extinction"
+attr(params, "convergence")$type       # "below_tolerance", "cycle", "not_converged", "extinction"
 attr(params, "convergence")$residual   # largest biomass drift, in 1/year
 plot(getSteadyResidual(params))        # which species, and at which sizes
 ```
 
-`"steady"` with a `residual` above about `0.05` means `tol` was too loose:
-tighten it. `"cycle"` means the dynamics settled onto a limit cycle and the
+`"below_tolerance"` says only that the distance function dropped below `tol`,
+which is not a guarantee of a steady state — that is why the type is not called
+`"steady"`. Always read `residual` alongside it: above about `0.05` it means
+`tol` was too loose, so tighten it. `"cycle"` means the dynamics settled onto a limit cycle and the
 stored state is one point on it — see the `analyse-stability` skill.
 `"not_converged"` means the run ran out of time: raise `t_max`, or get a better
 starting spectrum from `steadySingleSpecies()` first, and reach for

--- a/inst/skills/upgrade-mizer-code/SKILL.md
+++ b/inst/skills/upgrade-mizer-code/SKILL.md
@@ -104,6 +104,8 @@ function` — carry no such quote, so match those rows on the function name.
 | A `match…()` call now reports `"has rescaled the model and so moved it off its steady state"` | the functions say so themselves now | The `match…()` functions announce that they broke the steady state |
 | `expect_named()` on `attr(params, "convergence")` fails | new `residual` field | The convergence attribute gained a `residual` field |
 | `steady()` adds ``"Reduce `tol` to converge further"`` to its convergence message | the state reached is not a fixed point | The convergence attribute gained a `residual` field |
+| `steady()` says `"Reached the convergence tolerance after"` where it used to announce that convergence was achieved | the message says what was actually tested | `steady()` reports the tolerance it reached rather than announcing convergence |
+| An `expect_message()` or a grep for the wording of the `steady()` success message no longer matches | the message was reworded | `steady()` reports the tolerance it reached rather than announcing convergence |
 | `getStability()` or `getLimitCycleSim()` now warns `"This model is not at its steady state"` | they linearise at the stored state | `getStability()` checks that it was given a steady state |
 | `summary(params)` has an extra `"Steady state:"` block | new steadiness verdict | `summary()` reports the steady state |
 | `compareParams()` now reports differences it used to miss | relative tolerance for species parameters | `compareParams()` compares small parameters properly |

--- a/inst/skills/upgrade-mizer-code/references/mizer-3.3.md
+++ b/inst/skills/upgrade-mizer-code/references/mizer-3.3.md
@@ -364,16 +364,45 @@ updating. It reports how far the state reached actually is from a fixed point,
 which the existing `distance` field only approximates — `distance` compares two
 states `t_per` apart on whatever scale the distance function uses.
 
-When the two disagree, `steady()` now appends to its convergence message:
+When the two disagree, `steady()` appends to its convergence message:
 
 ```
-#> Convergence was achieved in 12 years. A biomass is still changing at up to
-#> 0.42 per year. Reduce `tol` to converge further.
+#> Reached the convergence tolerance after 12 years. The biomasses change at up
+#> to 0.42 per year. Reduce `tol` to converge further.
 ```
 
 This is the case where the relative-RDI criterion is satisfied while the spectra
 are still moving. It is a message, not a warning, because convergence at the
 `tol` you asked for did happen.
+
+### `steady()` reports the tolerance it reached rather than announcing convergence
+
+`steady()` and `projectToSteady()` used to end a successful run with
+
+```
+#> Convergence was achieved in 12 years.
+```
+
+They now say what was actually tested — the distance function dropped below
+`tol`, which is not the same thing as having reached a fixed point — and they
+report the biomass drift every time rather than only when it is large:
+
+```
+#> Reached the convergence tolerance after 12 years. The biomasses change at up
+#> to 3.2e-05 per year.
+```
+
+Code that matched the old wording needs the new string: an `expect_message()` in
+an extension package's tests, or a script grepping the output. In a script the
+`"convergence"` attribute is the better check anyway, since `info_level = 0`
+suppresses the message entirely.
+
+The same reasoning renamed two things in that attribute, which is new in this
+release and so breaks nothing: its `type` is `"below_tolerance"` rather than
+`"steady"`, and the logical field saying the run stopped on a criterion of its
+own rather than running out of time is called `settled` rather than `converged`.
+Neither now reads as a promise that the state is a fixed point; `residual` is
+the field that answers that.
 
 ### `getStability()` checks that it was given a steady state
 

--- a/man-roxygen/section_check_steady.R
+++ b/man-roxygen/section_check_steady.R
@@ -6,7 +6,8 @@
 #'   ways the returned object can fail to be one:
 #'
 #'   - the run converged on its own scale while the biomasses are still
-#'     visibly drifting, because `tol` was too loose;
+#'     visibly drifting, because `tol` was too loose (`type =
+#'     "below_tolerance"`, which is why that type is not called `"steady"`);
 #'   - the run reached `t_max` without converging (`type = "not_converged"`);
 #'   - the run settled on a limit cycle (`type = "cycle"`), in which case the
 #'     state stored is one point on that cycle;
@@ -16,7 +17,7 @@
 #'   So treat the result as a claim to be checked rather than as a guarantee:
 #'
 #'   ```r
-#'   attr(params, "convergence")$type      # "steady", "cycle", "not_converged", "extinction"
+#'   attr(params, "convergence")$type      # "below_tolerance", "cycle", "not_converged", "extinction"
 #'   attr(params, "convergence")$residual  # largest biomass drift, in 1/year
 #'   isSteady(params)                      # TRUE if within tolerance
 #'   summary(params)                       # includes the biomass-drift verdict

--- a/man/projectToSteady.Rd
+++ b/man/projectToSteady.Rd
@@ -101,10 +101,15 @@ saved every \code{t_per} years.
 In either case the returned object carries an attribute \code{"convergence"}
 describing the solution the run settled on, a named list with entries:
 \describe{
-\item{\code{type}}{One of \code{"steady"} (a stable fixed point), \code{"cycle"} (a
-limit cycle), \code{"not_converged"} (still changing at \code{t_max}) or
-\code{"extinction"} (a species died out).}
-\item{\code{converged}}{Logical, \code{TRUE} for \code{"steady"} and \code{"cycle"}.}
+\item{\code{type}}{One of \code{"below_tolerance"} (the distance function dropped
+below \code{tol}, which suggests but does not guarantee a stable fixed
+point — check \code{residual}), \code{"cycle"} (a limit cycle),
+\code{"not_converged"} (still changing at \code{t_max}) or \code{"extinction"} (a
+species died out).}
+\item{\code{settled}}{Logical, \code{TRUE} for \code{"below_tolerance"} and \code{"cycle"},
+i.e. when the run stopped on a criterion of its own rather than
+running out of time. It says nothing about whether the state reached
+is a fixed point; that is what \code{residual} is for.}
 \item{\code{distance}}{The final value returned by \code{distance_func}.}
 \item{\code{residual}}{The largest per-capita rate of change, in 1/year, at the
 state that was reached, as returned by \code{\link[=getSteadyResidual]{getSteadyResidual()}}. Unlike
@@ -164,7 +169,11 @@ healthy species is never flagged.
 \code{distance_func} is called with the state at the end of the previous block and
 the state at the end of the current block, i.e. with two states \code{t_per} years
 apart. If the number it returns is less than \code{tol}, the run stops with
-\code{type = "steady"}. What "distance" means is entirely up to that function:
+\code{type = "below_tolerance"}. The type is deliberately not called \code{"steady"}:
+all it says is that the state stopped moving on the scale of the distance
+function, which is not a guarantee that a fixed point has been reached. The
+\code{residual} entry of the \code{"convergence"} attribute measures that directly.
+What "distance" means is entirely up to that function:
 the default \code{\link[=distanceSSLogN]{distanceSSLogN()}} uses the sum of squared changes in log
 abundance, while \code{\link[=steady]{steady()}} instead passes \code{\link[=distanceMaxRelRDI]{distanceMaxRelRDI()}}, which uses
 the largest relative change in egg production.
@@ -237,7 +246,7 @@ on; it does not say that the state reached is a fixed point. There are four
 ways the returned object can fail to be one:
 \itemize{
 \item the run converged on its own scale while the biomasses are still
-visibly drifting, because \code{tol} was too loose;
+visibly drifting, because \code{tol} was too loose (\code{type = "below_tolerance"}, which is why that type is not called \code{"steady"});
 \item the run reached \code{t_max} without converging (\code{type = "not_converged"});
 \item the run settled on a limit cycle (\code{type = "cycle"}), in which case the
 state stored is one point on that cycle;
@@ -247,7 +256,7 @@ state stored is one point on that cycle;
 
 So treat the result as a claim to be checked rather than as a guarantee:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{attr(params, "convergence")$type      # "steady", "cycle", "not_converged", "extinction"
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{attr(params, "convergence")$type      # "below_tolerance", "cycle", "not_converged", "extinction"
 attr(params, "convergence")$residual  # largest biomass drift, in 1/year
 isSteady(params)                      # TRUE if within tolerance
 summary(params)                       # includes the biomass-drift verdict

--- a/man/steady.Rd
+++ b/man/steady.Rd
@@ -122,7 +122,7 @@ on; it does not say that the state reached is a fixed point. There are four
 ways the returned object can fail to be one:
 \itemize{
 \item the run converged on its own scale while the biomasses are still
-visibly drifting, because \code{tol} was too loose;
+visibly drifting, because \code{tol} was too loose (\code{type = "below_tolerance"}, which is why that type is not called \code{"steady"});
 \item the run reached \code{t_max} without converging (\code{type = "not_converged"});
 \item the run settled on a limit cycle (\code{type = "cycle"}), in which case the
 state stored is one point on that cycle;
@@ -132,7 +132,7 @@ state stored is one point on that cycle;
 
 So treat the result as a claim to be checked rather than as a guarantee:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{attr(params, "convergence")$type      # "steady", "cycle", "not_converged", "extinction"
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{attr(params, "convergence")$type      # "below_tolerance", "cycle", "not_converged", "extinction"
 attr(params, "convergence")$residual  # largest biomass drift, in 1/year
 isSteady(params)                      # TRUE if within tolerance
 summary(params)                       # includes the biomass-drift verdict

--- a/tests/testthat/test-steady.R
+++ b/tests/testthat/test-steady.R
@@ -18,29 +18,29 @@ test_that("projectToSteady() works", {
                    "Simulation run did not converge after 0.1 years.")
     expect_message(paramsc <- projectToSteady(params, t_per = 1, dt = 1,
                                               tol = 1000, effort = effort),
-                   "Convergence was achieved")
+                   "Reached the convergence tolerance")
     expect_s4_class(paramsc, "MizerParams")
     expect_identical(paramsc@initial_effort, effort)
     # shouldn't take long the second time we run to steady
     expect_message(projectToSteady(paramsc, t_per = 1, dt = 1, tol = 1000),
-                   "Convergence was achieved")
+                   "Reached the convergence tolerance")
     
     # return sim
     expect_message(sim <- projectToSteady(params, return_sim = TRUE,
                                           t_per = 1, dt = 1, tol = 1000),
-                   "Convergence was achieved")
+                   "Reached the convergence tolerance")
     expect_s4_class(sim, "MizerSim")
     
     # Alternative distance function
     expect_message(paramsc <- projectToSteady(params, t_per = 1, dt = 1,
                                               distance_func = distanceMaxRelRDI,
                                               tol = 10),
-                   "Convergence was achieved")
+                   "Reached the convergence tolerance")
     # shouldn't take long the second time we run to steady
     expect_message(projectToSteady(paramsc, t_per = 1, dt = 1,
                                    distance_func = distanceMaxRelRDI,
                                    tol = 10),
-                   "Convergence was achieved")
+                   "Reached the convergence tolerance")
     
     # Check extinction
     params@psi[1:2, ] <- 0
@@ -198,7 +198,7 @@ test_that("projectToSteady() converges with use_predation_diffusion", {
     initialN(params_d)[1, ] <- initialN(params_d)[1, ] * 3
     expect_message(
         projectToSteady(params_d, t_per = 1, dt = 1, tol = 1000),
-        "Convergence was achieved"
+        "Reached the convergence tolerance"
     )
 })
 
@@ -387,14 +387,14 @@ cd_params <- suppressMessages(
 
 # The "convergence" attribute ------------------------------------------------
 
-test_that("steady() attaches a 'convergence' attribute for a steady state", {
+test_that("steady() attaches a 'convergence' attribute when the distance drops below tol", {
     p <- suppressWarnings(suppressMessages(steady(cd_params, progress_bar = FALSE)))
     conv <- attr(p, "convergence")
     expect_type(conv, "list")
-    expect_named(conv, c("type", "converged", "distance", "residual", "years",
+    expect_named(conv, c("type", "settled", "distance", "residual", "years",
                          "period", "amplitude"))
-    expect_identical(conv$type, "steady")
-    expect_true(conv$converged)
+    expect_identical(conv$type, "below_tolerance")
+    expect_true(conv$settled)
     expect_true(is.na(conv$period))
     expect_true(is.na(conv$amplitude))
     # The residual measures how far the state actually is from a fixed point,
@@ -407,7 +407,7 @@ test_that("the 'convergence' attribute survives return_sim = TRUE", {
     sim <- suppressWarnings(suppressMessages(steady(cd_params, return_sim = TRUE,
                                                     progress_bar = FALSE)))
     expect_s4_class(sim, "MizerSim")
-    expect_identical(attr(sim, "convergence")$type, "steady")
+    expect_identical(attr(sim, "convergence")$type, "below_tolerance")
 })
 
 test_that("projectToSteady() reports non-convergence", {
@@ -419,7 +419,7 @@ test_that("projectToSteady() reports non-convergence", {
     )
     conv <- attr(p, "convergence")
     expect_identical(conv$type, "not_converged")
-    expect_false(conv$converged)
+    expect_false(conv$settled)
 })
 
 test_that("fine t_save sampling does not change the result", {
@@ -450,7 +450,7 @@ test_that("projectToSteady() detects a limit cycle", {
     )
     conv <- attr(p, "convergence")
     expect_identical(conv$type, "cycle")
-    expect_true(conv$converged)
+    expect_true(conv$settled)
     expect_gt(conv$period, 0)
     expect_gt(conv$amplitude, 0.1)
 })

--- a/vignettes/dynamic_stability.Rmd
+++ b/vignettes/dynamic_stability.Rmd
@@ -143,7 +143,7 @@ sim_cycle <- projectToSteady(params, effort = 1.5, t_max = 200, t_per = 0.2,
 attr(sim_cycle, "convergence")
 ```
 
-`projectToSteady()` correctly identifies the attractor as a limit cycle with a period of about `r round(attr(sim_cycle, "convergence")$period, 1)` years and a peak-to-trough biomass amplitude of about `r round(100 * attr(sim_cycle, "convergence")$amplitude)`% of the mean. Applied to a model with a genuine stable steady state (such as the default `params` at effort 0), the function reports `type = "steady"` instead:
+`projectToSteady()` correctly identifies the attractor as a limit cycle with a period of about `r round(attr(sim_cycle, "convergence")$period, 1)` years and a peak-to-trough biomass amplitude of about `r round(100 * attr(sim_cycle, "convergence")$amplitude)`% of the mean. Applied to a model with a genuine stable steady state (such as the default `params` at effort 0), the function reports `type = "below_tolerance"` instead, meaning the state stopped moving on the scale of the distance function:
 
 ```{r pts_steady}
 attr(projectToSteady(params, t_max = 100), "convergence")$type

--- a/vignettes/guide-analyse-stability.qmd
+++ b/vignettes/guide-analyse-stability.qmd
@@ -63,9 +63,10 @@ warning. [`plot(getSteadyResidual(params))`](../reference/plot.html) shows how f
 [guide to reaching steady state and calibrating](guide-calibrate-model.html).
 
 `steady()` and [`projectToSteady()`](../reference/projectToSteady.html) attach a related `"convergence"` attribute
-recording whether the run settled on a **steady state, a limit cycle, or
-neither**, together with the cycle period and relative amplitude when a cycle is
-found. Limit cycles are detected from the per-species biomass series sampled at
+recording whether the run **dropped below its tolerance** (`type =
+"below_tolerance"`, which suggests but does not prove a fixed point), settled on
+**a limit cycle**, or **neither**, together with the cycle period and relative
+amplitude when a cycle is found. Limit cycles are detected from the per-species biomass series sampled at
 `t_save`; the relative-amplitude floor for calling an oscillation a cycle is the
 `amplitude_tol` argument (default `0.01`), independent of the fixed-point
 tolerance `tol`.

--- a/vignettes/guide-calibrate-model.qmd
+++ b/vignettes/guide-calibrate-model.qmd
@@ -64,13 +64,15 @@ and the checks in [Verifying the result](#verifying-the-result):
 
 ```{r eval=FALSE}
 params <- steady(params)
-attr(params, "convergence")$type       # "steady", "cycle", "not_converged", "extinction"
+attr(params, "convergence")$type       # "below_tolerance", "cycle", "not_converged", "extinction"
 attr(params, "convergence")$residual   # largest biomass drift, in 1/year
 plot(getSteadyResidual(params))        # which species, and at which sizes
 ```
 
-`"steady"` with a `residual` above about `0.05` means `tol` was too loose:
-tighten it. `"cycle"` means the dynamics settled onto a limit cycle and the
+`"below_tolerance"` says only that the distance function dropped below `tol`,
+which is not a guarantee of a steady state — that is why the type is not called
+`"steady"`. Always read `residual` alongside it: above about `0.05` it means
+`tol` was too loose, so tighten it. `"cycle"` means the dynamics settled onto a limit cycle and the
 stored state is one point on it — see the [guide to analysing dynamic stability](guide-analyse-stability.html).
 `"not_converged"` means the run ran out of time: raise `t_max`, or get a better
 starting spectrum from `steadySingleSpecies()` first, and reach for

--- a/vignettes/upgrading.qmd
+++ b/vignettes/upgrading.qmd
@@ -396,16 +396,45 @@ updating. It reports how far the state reached actually is from a fixed point,
 which the existing `distance` field only approximates — `distance` compares two
 states `t_per` apart on whatever scale the distance function uses.
 
-When the two disagree, `steady()` now appends to its convergence message:
+When the two disagree, `steady()` appends to its convergence message:
 
 ```
-#> Convergence was achieved in 12 years. A biomass is still changing at up to
-#> 0.42 per year. Reduce `tol` to converge further.
+#> Reached the convergence tolerance after 12 years. The biomasses change at up
+#> to 0.42 per year. Reduce `tol` to converge further.
 ```
 
 This is the case where the relative-RDI criterion is satisfied while the spectra
 are still moving. It is a message, not a warning, because convergence at the
 `tol` you asked for did happen.
+
+### `steady()` reports the tolerance it reached rather than announcing convergence
+
+`steady()` and `projectToSteady()` used to end a successful run with
+
+```
+#> Convergence was achieved in 12 years.
+```
+
+They now say what was actually tested — the distance function dropped below
+`tol`, which is not the same thing as having reached a fixed point — and they
+report the biomass drift every time rather than only when it is large:
+
+```
+#> Reached the convergence tolerance after 12 years. The biomasses change at up
+#> to 3.2e-05 per year.
+```
+
+Code that matched the old wording needs the new string: an `expect_message()` in
+an extension package's tests, or a script grepping the output. In a script the
+`"convergence"` attribute is the better check anyway, since `info_level = 0`
+suppresses the message entirely.
+
+The same reasoning renamed two things in that attribute, which is new in this
+release and so breaks nothing: its `type` is `"below_tolerance"` rather than
+`"steady"`, and the logical field saying the run stopped on a criterion of its
+own rather than running out of time is called `settled` rather than `converged`.
+Neither now reads as a promise that the state is a fixed point; `residual` is
+the field that answers that.
 
 ### `getStability()` checks that it was given a steady state
 


### PR DESCRIPTION
Follow-up to #551. That PR made the documentation stop promising a steady
state; this one makes the code stop promising one.

`steady()` and `projectToSteady()` stop when two states `t_per` apart differ
by less than `tol` on the distance function's own scale. That test cannot
establish a fixed point, but both the `"convergence"` attribute and the
message reported it as if it had. Three renamings, all saying the same thing.

## Changes

- **`type = "steady"` → `type = "below_tolerance"`.** The docs now state
  outright that the type is deliberately not called `"steady"`, and point at
  `residual` as the field that answers the question.

- **The attribute's `converged` field → `settled`**, meaning the run stopped
  on a criterion of its own rather than running out of time (`TRUE` for
  `"below_tolerance"` and `"cycle"`). It is the field most likely to be used
  as a gate — `if (conv$converged) ...` — and as a bare logical it had no
  `type` beside it to qualify what it claimed.

- **The messages.** `"Convergence was achieved in 12 years."` becomes
  `"Reached the convergence tolerance after 12 years."`, and the limit-cycle
  message says "Settled onto" rather than "Converged to".

- **The biomass drift is reported on every successful run**, not only when it
  exceeds the steady-state tolerance:

  ```
  Reached the convergence tolerance after 10.5 years. The biomasses change at up to 0.0031 per year.
  ```

  It is the evidence for whether the state is a fixed point, and a number the
  user only ever sees when something has gone wrong is a number they never
  learn to look at. Only `"Reduce `tol` to converge further."` stays
  conditional. The phrasing matches `steadyNewton()`, which already reports
  its residual unconditionally.

## Upgrading

Only the message wording is a change from a released version — the
`"convergence"` attribute is new in the upcoming release, so the renames
there break nothing. `references/mizer-3.3.md` therefore gets one new
section, `steady() reports the tolerance it reached rather than announcing
convergence`, with two rows in the symptom index; the renames are mentioned
in it as context. The stale example output in the neighbouring `residual`
section, which still quoted the old message, is fixed too.

## Testing

Full suite on this branch: `FAIL 0 | WARN 2 | SKIP 33 | PASS 4468`. Both
warnings are the pre-existing `plotYield(sim2 = )` deprecation at
`test-plots.R:103` and `:1017`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)