### PR TITLE
docs & refactor: Modernize info signalling mechanism

### DIFF
--- a/.claude/skills/info-signals.md
+++ b/.claude/skills/info-signals.md
@@ -101,12 +101,13 @@ Reports are given **on exit**, collapsed by content, and joined with `"\n"`, so
 the idioms differ from testing a plain `message()`:
 
 ```r
-# A message ends in a newline; a warning does not.
-expect_message(with_info_level(signal_info("a", "note", level = 1)), "^note\n$")
-expect_warning(with_info_level(signal_frozen("metab", "frozen")), "^frozen$")
+# Identical reports collapse to one line; two different things said about the
+# same `var` are both kept. Assert on both if a change should produce both.
+expect_message(with_info_level(signal_info("a", "note", level = 1)), "note")
+expect_warning(with_info_level(signal_frozen("metab", "frozen")), "frozen")
 
 # Messages and warnings are reported separately, so nest the expectations.
-expect_warning(expect_message(with_info_level({...}), "^info\n$"), "^frozen$")
+expect_warning(expect_message(with_info_level({...}), "info"), "frozen")
 
 # Set the option with withr so it is restored.
 withr::local_options(mizer_info_level = 0)

--- a/R/info_signals.R
+++ b/R/info_signals.R
@@ -33,7 +33,7 @@
 #' @return A single number, or `NA` to leave the reporting to a handler further
 #'   out.
 #' @export
-#' @concept info signaling functions
+#' @concept info signalling functions
 #' @examples
 #' default_info_level()
 #'
@@ -104,7 +104,7 @@ default_info_level <- function(fallback = 3) {
 #'
 #' @return The value of `expr`.
 #' @export
-#' @concept info signaling functions
+#' @concept info signalling functions
 #' @examples
 #' # Wrap the body of a function that reports, and everything raised inside it
 #' # is collected and given together once the call has finished.
@@ -214,7 +214,7 @@ with_info_level <- function(expr, info_level = default_info_level(),
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
 #' @export
-#' @concept info signaling functions
+#' @concept info signalling functions
 #' @examples
 #' # With nothing collecting, a `"drop"` report says nothing at all ...
 #' signal_info("h", "Using a default for `h`.")
@@ -266,7 +266,7 @@ signal_info <- function(var, message, level = 3,
 #' @param message The message to give the user.
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept info signaling functions
+#' @concept info signalling functions
 signal_frozen <- function(var, message) {
     signal_info(var, message, level = 1, severity = "warning",
                 unhandled = "show", class = "info_about_frozen")
@@ -294,7 +294,7 @@ signal_frozen <- function(var, message) {
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
 #' @export
-#' @concept info signaling functions
+#' @concept info signalling functions
 #' @examples
 #' with_info_level(
 #'     signal_not_recalculated("metab", "metabolic rate",
@@ -328,7 +328,7 @@ signal_not_recalculated <- function(var, quantity, reset_call,
 #'
 #' @return A named list of lists with entries `quantity`, `reset_call`,
 #'   `params` and `derived_from`.
-#' @concept info signaling functions
+#' @concept info signalling functions
 frozen_rate_params <- function() {
     list(
         intake_max = list(
@@ -397,7 +397,7 @@ frozen_rate_params <- function() {
 #'   that the user changed.
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept info signaling functions
+#' @concept info signalling functions
 signal_frozen_changes <- function(params, changed) {
     if (length(changed) == 0) {
         return(invisible(NULL))
@@ -458,7 +458,7 @@ overridden_species_params <- function() {
 #'   [given_species_params<-()].
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept info signaling functions
+#' @concept info signalling functions
 signal_ignored_changes <- function(given, changed) {
     for (par in names(overridden_species_params())) {
         if (!(par %in% names(changed))) {
@@ -502,7 +502,7 @@ signal_ignored_changes <- function(given, changed) {
 #'   character vector of the changed column names.
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept info signaling functions
+#' @concept info signalling functions
 signal_gear_params_changes <- function(changed) {
     changed <- if (is.character(changed)) changed else names(changed)
     gear_pars <- c("catchability", "selectivity", "l50", "l25", "sel_func")

--- a/R/info_signals.R
+++ b/R/info_signals.R
@@ -39,7 +39,7 @@ info_reporting$active <- FALSE
 #' @return A single number, or `NA` to leave the reporting to a handler further
 #'   out.
 #' @export
-#' @concept helper
+#' @concept info signaling functions
 #' @examples
 #' default_info_level()
 #'
@@ -110,7 +110,7 @@ default_info_level <- function(fallback = 3) {
 #'
 #' @return The value of `expr`.
 #' @export
-#' @concept helper
+#' @concept info signaling functions
 #' @examples
 #' # Wrap the body of a function that reports, and everything raised inside it
 #' # is collected and given together once the call has finished.
@@ -214,7 +214,7 @@ with_info_level <- function(expr, info_level = default_info_level(),
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
 #' @export
-#' @concept helper
+#' @concept info signaling functions
 #' @examples
 #' # With nothing collecting, a `"drop"` report says nothing at all ...
 #' signal_info("h", "Using a default for `h`.")
@@ -266,7 +266,7 @@ signal_info <- function(var, message, level = 3,
 #' @param message The message to give the user.
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept helper
+#' @concept info signaling functions
 signal_frozen <- function(var, message) {
     signal_info(var, message, level = 1, severity = "warning",
                 unhandled = "show", class = "info_about_frozen")
@@ -294,7 +294,7 @@ signal_frozen <- function(var, message) {
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
 #' @export
-#' @concept helper
+#' @concept info signaling functions
 #' @examples
 #' with_info_level(
 #'     signal_not_recalculated("metab", "metabolic rate",
@@ -328,7 +328,7 @@ signal_not_recalculated <- function(var, quantity, reset_call,
 #'
 #' @return A named list of lists with entries `quantity`, `reset_call`,
 #'   `params` and `derived_from`.
-#' @concept helper
+#' @concept info signaling functions
 frozen_rate_params <- function() {
     list(
         intake_max = list(
@@ -397,7 +397,7 @@ frozen_rate_params <- function() {
 #'   that the user changed.
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept helper
+#' @concept info signaling functions
 signal_frozen_changes <- function(params, changed) {
     if (length(changed) == 0) {
         return(invisible(NULL))
@@ -458,7 +458,7 @@ overridden_species_params <- function() {
 #'   [given_species_params<-()].
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept helper
+#' @concept info signaling functions
 signal_ignored_changes <- function(given, changed) {
     for (par in names(overridden_species_params())) {
         if (!(par %in% names(changed))) {
@@ -502,7 +502,7 @@ signal_ignored_changes <- function(given, changed) {
 #'   character vector of the changed column names.
 #'
 #' @return `NULL` invisibly. Called for its side effect of signalling.
-#' @concept helper
+#' @concept info signaling functions
 signal_gear_params_changes <- function(changed) {
     changed <- if (is.character(changed)) changed else names(changed)
     gear_pars <- c("catchability", "selectivity", "l50", "l25", "sel_func")

--- a/R/info_signals.R
+++ b/R/info_signals.R
@@ -1,13 +1,7 @@
 # Machinery for the information that mizer gives the user while it is setting
 # up or changing a model. See `with_info_level()` for a description.
 
-# Package-local state recording whether a `with_info_level()` handler is
-# already collecting. It is what makes the handlers nest: the outermost one
-# does the reporting and the inner ones step aside, so that a function can wrap
-# its body without having to know whether its caller has done the same. It is
-# always restored on exit, including when the expression throws.
-info_reporting <- new.env(parent = emptyenv())
-info_reporting$active <- FALSE
+
 
 #' The default level of information that mizer gives
 #'
@@ -139,7 +133,7 @@ with_info_level <- function(expr, info_level = default_info_level(),
     # muffling anything. A caller that wants to drop a particular report has
     # to install a handler for it even so.
     if (!silent && length(except) == 0 &&
-        (info_reporting$active ||
+        (isTRUE(getOption("mizer_info_reporting_active")) ||
          !is.numeric(info_level) || length(info_level) != 1 ||
          is.na(info_level))) {
         return(expr)
@@ -164,18 +158,24 @@ with_info_level <- function(expr, info_level = default_info_level(),
     # early. A function can then wrap its whole body in `with_info_level()`
     # even though it returns from the middle of it, which is what makes this
     # usable as a wrapper around an existing function.
-    was_active <- info_reporting$active
-    info_reporting$active <- TRUE
+    old_opt <- options(mizer_info_reporting_active = TRUE)
     on.exit({
-        info_reporting$active <- was_active
+        options(old_opt)
         severities <- vapply(reports, `[[`, character(1), "severity")
         messages <- vapply(reports, `[[`, character(1), "message")
         if (any(severities == "info")) {
-            message(paste(messages[severities == "info"], collapse = "\n"))
+            msgs <- unname(messages[severities == "info"])
+            if (length(msgs) > 1) {
+                names(msgs) <- c(rep("i", length(msgs)))
+            }
+            inform(msgs)
         }
         if (any(severities == "warning")) {
-            warning(paste(messages[severities == "warning"], collapse = "\n"),
-                    call. = FALSE)
+            msgs <- unname(messages[severities == "warning"])
+            if (length(msgs) > 1) {
+                names(msgs) <- c(rep("!", length(msgs)))
+            }
+            rlang::warn(msgs)
         }
     }, add = TRUE)
     withCallingHandlers(expr, info_about_default = collect_info)

--- a/inst/skills/change-parameters/SKILL.md
+++ b/inst/skills/change-parameters/SKILL.md
@@ -90,7 +90,9 @@ given, it feeds a rate array you set by hand, or it is a gear parameter that
 mizer reads from `gear_params()`. `species_params<-()` stays quiet about all
 three.
 
-**Turning the commentary up or down.** Mizer reports the choices it makes —
+### Turning the commentary up or down
+
+Mizer reports the choices it makes —
 defaults it filled in, inputs it adjusted, instructions it could not carry out —
 at a level set by `info_level`. Most `set…()` and `new…()` functions take it as
 an argument; for the ones that do not, including `species_params(params) <-` and

--- a/man/default_info_level.Rd
+++ b/man/default_info_level.Rd
@@ -45,4 +45,4 @@ old <- options(mizer_info_level = 1)
 default_info_level()
 options(old)
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/default_info_level.Rd
+++ b/man/default_info_level.Rd
@@ -45,4 +45,4 @@ old <- options(mizer_info_level = 1)
 default_info_level()
 options(old)
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/frozen_rate_params.Rd
+++ b/man/frozen_rate_params.Rd
@@ -27,4 +27,4 @@ left with the message that the setter itself gives, see
 influence is the worse mistake, because it warns about a change that did
 take effect.
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/frozen_rate_params.Rd
+++ b/man/frozen_rate_params.Rd
@@ -27,4 +27,4 @@ left with the message that the setter itself gives, see
 influence is the worse mistake, because it warns about a change that did
 take effect.
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/signal_frozen.Rd
+++ b/man/signal_frozen.Rd
@@ -34,4 +34,4 @@ trait-based and community models, and those arrays differ from the formula
 for the lifetime of the model. See \code{\link[=signal_frozen_changes]{signal_frozen_changes()}}, which decides
 this from the species parameters the user changed.
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/signal_frozen.Rd
+++ b/man/signal_frozen.Rd
@@ -34,4 +34,4 @@ trait-based and community models, and those arrays differ from the formula
 for the lifetime of the model. See \code{\link[=signal_frozen_changes]{signal_frozen_changes()}}, which decides
 this from the species parameters the user changed.
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/signal_frozen_changes.Rd
+++ b/man/signal_frozen_changes.Rd
@@ -24,4 +24,4 @@ longer follows the species parameters" into a warning the user sees at the
 moment they make the change. It is one of the diagnostics that only
 \code{\link[=given_species_params<-]{given_species_params<-()}} gives, see there.
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/signal_frozen_changes.Rd
+++ b/man/signal_frozen_changes.Rd
@@ -24,4 +24,4 @@ longer follows the species parameters" into a warning the user sees at the
 moment they make the change. It is one of the diagnostics that only
 \code{\link[=given_species_params<-]{given_species_params<-()}} gives, see there.
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/signal_gear_params_changes.Rd
+++ b/man/signal_gear_params_changes.Rd
@@ -27,4 +27,4 @@ which is what this reports. But it feeds no rate, so a value in the species
 parameters is not lost: \code{\link[=get_yield_observed]{get_yield_observed()}} falls back to it for any
 species that has no observation among the gear parameters.
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/signal_gear_params_changes.Rd
+++ b/man/signal_gear_params_changes.Rd
@@ -27,4 +27,4 @@ which is what this reports. But it feeds no rate, so a value in the species
 parameters is not lost: \code{\link[=get_yield_observed]{get_yield_observed()}} falls back to it for any
 species that has no observation among the gear parameters.
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/signal_ignored_changes.Rd
+++ b/man/signal_ignored_changes.Rd
@@ -30,4 +30,4 @@ species that were \emph{given} a value, not about every species whose value
 changed: clearing a value to \code{NA} is a change, but not one this has anything
 to say about.
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/signal_ignored_changes.Rd
+++ b/man/signal_ignored_changes.Rd
@@ -30,4 +30,4 @@ species that were \emph{given} a value, not about every species whose value
 changed: clearing a value to \code{NA} is a change, but not one this has anything
 to say about.
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/signal_info.Rd
+++ b/man/signal_info.Rd
@@ -64,4 +64,4 @@ signal_info("h", "Using a default for `h`.", unhandled = "show")
 # `with_info_level()`, which is what decides whether to show it.
 with_info_level(signal_info("h", "Using a default for `h`."))
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/signal_info.Rd
+++ b/man/signal_info.Rd
@@ -64,4 +64,4 @@ signal_info("h", "Using a default for `h`.", unhandled = "show")
 # `with_info_level()`, which is what decides whether to show it.
 with_info_level(signal_info("h", "Using a default for `h`."))
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/signal_not_recalculated.Rd
+++ b/man/signal_not_recalculated.Rd
@@ -43,4 +43,4 @@ with_info_level(
                             "setMetabolicRate(params, reset = TRUE)")
 )
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/signal_not_recalculated.Rd
+++ b/man/signal_not_recalculated.Rd
@@ -43,4 +43,4 @@ with_info_level(
                             "setMetabolicRate(params, reset = TRUE)")
 )
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/man/with_info_level.Rd
+++ b/man/with_info_level.Rd
@@ -87,4 +87,4 @@ myConstructor(1, info_level = 1)
 # `info_level = 0` is silence.
 myConstructor(1, info_level = 0)
 }
-\concept{info signaling functions}
+\concept{info signalling functions}

--- a/man/with_info_level.Rd
+++ b/man/with_info_level.Rd
@@ -87,4 +87,4 @@ myConstructor(1, info_level = 1)
 # `info_level = 0` is silence.
 myConstructor(1, info_level = 0)
 }
-\concept{helper}
+\concept{info signaling functions}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -374,6 +374,27 @@ reference:
   - starts_with("mizer")
   - projectRDD
   - -mizer
+- title: Info signaling functions
+  description: >
+    Mizer tells the user about choices it makes on their behalf, such as filling
+    in defaults or adjusting inputs, by raising information signals. These are 
+    collected and reported together at a verbosity set by the `info_level` argument. 
+    This allows the user to suppress routine chatter while keeping important 
+    warnings. See the [guide to changing parameters](https://sizespectrum.org/mizer/articles/guide-change-parameters.html#turning-the-commentary-up-or-down) 
+    for how a user controls this, and the [guide to creating an extension package](https://sizespectrum.org/mizer/articles/guide-create-extension-package.html#telling-the-user-what-your-package-decided) 
+    for how an extension developer should use this system so their reports are collected 
+    along with mizer's own.
+  contents:
+  - with_info_level
+  - default_info_level
+  - signal_info
+  - signal_not_recalculated
+  - signal_frozen
+  - signal_frozen_changes
+  - signal_ignored_changes
+  - signal_gear_params_changes
+  - frozen_rate_params
+  - has_concept("info signaling functions")
 - title: Internal helper functions
   description: Utility functions used internally by mizer that may also be useful
     for users building extensions or working with model objects directly.

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -374,16 +374,16 @@ reference:
   - starts_with("mizer")
   - projectRDD
   - -mizer
-- title: Info signaling functions
+- title: Info signalling functions
   description: >
     Mizer tells the user about choices it makes on their behalf, such as filling
-    in defaults or adjusting inputs, by raising information signals. These are 
-    collected and reported together at a verbosity set by the `info_level` argument. 
-    This allows the user to suppress routine chatter while keeping important 
-    warnings. See the [guide to changing parameters](https://sizespectrum.org/mizer/articles/guide-change-parameters.html#turning-the-commentary-up-or-down) 
-    for how a user controls this, and the [guide to creating an extension package](https://sizespectrum.org/mizer/articles/guide-create-extension-package.html#telling-the-user-what-your-package-decided) 
-    for how an extension developer should use this system so their reports are collected 
-    along with mizer's own.
+    in defaults or adjusting inputs, by raising information signals. These are
+    collected and reported together at a verbosity set by the `info_level`
+    argument. This allows the user to suppress routine chatter while keeping
+    important warnings. See the [guide to changing parameters](https://sizespectrum.org/mizer/articles/guide-change-parameters.html#turning-the-commentary-up-or-down)
+    for how a user controls this, and the [guide to creating an extension package](https://sizespectrum.org/mizer/articles/guide-create-extension-package.html#telling-the-user-what-your-package-decided)
+    for how an extension developer should use this system so their reports are
+    collected along with mizer's own.
   contents:
   - with_info_level
   - default_info_level
@@ -394,7 +394,7 @@ reference:
   - signal_ignored_changes
   - signal_gear_params_changes
   - frozen_rate_params
-  - has_concept("info signaling functions")
+  - has_concept("info signalling functions")
 - title: Internal helper functions
   description: Utility functions used internally by mizer that may also be useful
     for users building extensions or working with model objects directly.

--- a/tests/testthat/test-info_signals.R
+++ b/tests/testthat/test-info_signals.R
@@ -1,12 +1,32 @@
 # with_info_level() ----
 
 test_that("with_info_level() collects information into a single message", {
-    expect_message(
+    withr::local_options(cli.unicode = TRUE)
+    emitted <- NULL
+    withCallingHandlers(
         with_info_level({
             signal_info("a", "first", level = 1)
             signal_info("b", "second")
         }),
-        "first.*second")
+        message = function(cnd) {
+            emitted <<- conditionMessage(cnd)
+            cnd_muffle(cnd)
+        })
+    expect_identical(emitted, "ℹ first\nℹ second")
+})
+
+test_that("with_info_level() collects warnings into a bulleted list", {
+    emitted <- NULL
+    withCallingHandlers(
+        with_info_level({
+            signal_frozen("metab", "first")
+            signal_frozen("search_vol", "second")
+        }),
+        warning = function(cnd) {
+            emitted <<- conditionMessage(cnd)
+            cnd_muffle(cnd)
+        })
+    expect_identical(emitted, "! first\n! second")
 })
 
 test_that("with_info_level() collapses repeats but keeps distinct reports", {

--- a/tests/testthat/test-info_signals.R
+++ b/tests/testthat/test-info_signals.R
@@ -6,7 +6,7 @@ test_that("with_info_level() collects information into a single message", {
             signal_info("a", "first", level = 1)
             signal_info("b", "second")
         }),
-        "first\nsecond")
+        "first.*second")
 })
 
 test_that("with_info_level() collapses repeats but keeps distinct reports", {
@@ -16,14 +16,14 @@ test_that("with_info_level() collapses repeats but keeps distinct reports", {
             signal_info("a", "same", level = 1)
             signal_info("a", "same", level = 1)
         }),
-        "^same\n$")
+        "^same$")
     # ... but two things said about one quantity are both kept.
     expect_message(
         with_info_level({
             signal_info("a", "first", level = 1)
             signal_info("a", "second", level = 1)
         }),
-        "^first\nsecond\n$")
+        "first.*second")
 })
 
 test_that("with_info_level() drops information above the info level", {
@@ -32,7 +32,7 @@ test_that("with_info_level() drops information above the info level", {
             signal_info("a", "important", level = 1)
             signal_info("b", "chatter", level = 3)
         }),
-        "^important\n$")
+        "^important$")
     # info_level = 0 is silence
     expect_silent(
         with_info_level(info_level = 0, signal_info("a", "important",
@@ -60,7 +60,7 @@ test_that("with_info_level() handlers nest, the outermost one reporting", {
         with_info_level({
             with_info_level(signal_info("a", "inner", level = 1))
         }),
-        "^inner\n$")
+        "^inner$")
     # The inner info level does not apply, the outer one does
     expect_silent(
         with_info_level(info_level = 0, {
@@ -79,14 +79,14 @@ test_that("with_info_level() handlers nest, the outermost one reporting", {
                                                         level = 1))
             signal_info("b", "loud", level = 1)
         }),
-        "^loud\n$")
+        "^loud$")
     # `NA` asks for the same deferral explicitly
     expect_message(
         with_info_level({
             with_info_level(info_level = NA, signal_info("a", "inner",
                                                          level = 1))
         }),
-        "^inner\n$")
+        "^inner$")
 })
 
 test_that("with_info_level() reports when the expression returns early", {
@@ -97,14 +97,14 @@ test_that("with_info_level() reports when the expression returns early", {
             signal_info("b", "never", level = 1)  # nocov
         })
     }
-    expect_message(expect_identical(f(), "returned"), "^early\n$")
+    expect_message(expect_identical(f(), "returned"), "^early$")
 })
 
 test_that("with_info_level() releases the nesting flag when expr fails", {
     expect_error(with_info_level(stop("boom")), "boom")
-    expect_false(info_reporting$active)
+    expect_false(isTRUE(getOption("mizer_info_reporting_active")))
     expect_message(with_info_level(signal_info("a", "after", level = 1)),
-                   "^after\n$")
+                   "^after$")
 })
 
 test_that("the mizer_info_level option sets the default", {
@@ -141,7 +141,7 @@ test_that("signal_info() says nothing when unhandled unless asked to", {
 
 test_that("signal_info() reports at the requested severity", {
     expect_message(with_info_level(signal_info("a", "note", level = 1)),
-                   "^note\n$")
+                   "^note$")
     expect_warning(
         with_info_level(signal_info("a", "alarm", level = 1,
                                     severity = "warning")),
@@ -156,7 +156,7 @@ test_that("with_info_level() copes with a condition that has no fields", {
     # An extension package may raise the condition itself
     expect_message(
         with_info_level(signal("bare", class = "info_about_default")),
-        "^bare\n$")
+        "^bare$")
     expect_silent(
         with_info_level(info_level = 0,
                         signal("bare", class = "info_about_default")))
@@ -180,7 +180,7 @@ test_that("with_info_level() reports frozen signals as a warning", {
                 signal_info("a", "info", level = 1)
                 signal_frozen("metab", "frozen")
             }),
-            "^info\n$"),
+            "^info$"),
         "^frozen$")
     # and `info_level = 0` still silences both
     expect_silent(

--- a/vignettes/guide-change-parameters.qmd
+++ b/vignettes/guide-change-parameters.qmd
@@ -96,7 +96,9 @@ given, it feeds a rate array you set by hand, or it is a gear parameter that
 mizer reads from `gear_params()`. `species_params<-()` stays quiet about all
 three.
 
-**Turning the commentary up or down.** Mizer reports the choices it makes —
+### Turning the commentary up or down
+
+Mizer reports the choices it makes —
 defaults it filled in, inputs it adjusted, instructions it could not carry out —
 at a level set by `info_level`. Most `set…()` and `new…()` functions take it as
 an argument; for the ones that do not, including `species_params(params) <-` and

--- a/vignettes/guide-understand-size-spectrum-dynamics.qmd
+++ b/vignettes/guide-understand-size-spectrum-dynamics.qmd
@@ -73,7 +73,6 @@ different ways:
 | **Encounter → feeding level → growth** of species $i$ | all **prey** small enough for $i$ to eat | prey mass $w_p$ (mass gained) | the abundance of $i$'s **prey** — bottom-up |
 | **Predation mortality** on species $i$ | all **predators** big enough to eat $i$ | nothing (deaths counted, not mass) | the abundance of $i$'s **predators** — top-down |
 
-
 Same kernel $\phi$, same search volume $\gamma$, same interaction matrix
 $\theta$; even the satiation factor is shared, since a satiated predator both
 stops gaining mass and stops killing. The only differences are which variable is
@@ -134,7 +133,6 @@ edge, and leave only by growing out through the top edge or by dying. So
 
 That is the whole content of the McKendrick–von Foerster equation. The quantity
 doing the growing-in and growing-out is the **flux** $J_i(w)$: the rate
-
 (individuals per year) at which fish of species $i$ grow past size $w$. It is
 just density times speed, $g_i(w) N_i(w)$ — how many fish are sitting at that
 size, times how fast they are moving through it. The dying term is
@@ -182,7 +180,6 @@ fewer consumers. Diagnose with [`plotFeedingLevel()`](../reference/plotFeedingLe
 predation mortality $\mu_p$ on their prey sizes rises → prey abundance falls →
 which relieves predation on whatever the prey were eating. Diagnose with
 [`plotPredMort()`](../reference/plotPredMort.html) and [`plotDiet()`](../reference/plotDiet.html).
-
 
 The loops act on **different sizes of the same species at the same time**. A fish
 is prey early and predator late, so a change can travel up the spectrum through
@@ -307,7 +304,6 @@ $\psi$ rising to 1 at `w_repro_max`, so growth halts there. This is what turns
 the species spectrum into a dome: growth decelerating towards `w_repro_max` piles
 individuals up (see the traffic-jam effect below) and then mortality removes
 them.
-
 
 ---
 


### PR DESCRIPTION
This PR improves the info signalling mechanism in mizer:

1. **Documentation updates**:
   - Replaced `@concept helper` with `@concept info signaling functions` for the info signal functions.
   - Grouped these functions logically in `pkgdown/_pkgdown.yml` under their own section with anchor links to relevant guides.
   - Promoted info signaling text in the `change-parameters` skill to a markdown header and rebuilt the  vignettes.

2. **Refactoring the mechanism**:
   - Eliminated the global state `info_reporting` environment and replaced it with idiomatic R `options()` state tracking.
   - Replaced base `message()` and `warning()` loops with `rlang::inform` and `rlang::warn`, formatting grouped reports as elegant bulleted lists.
   - Stripped hardcoded trailing newlines from testing regexes and updated the testing guidelines in the skill docs.

All tests pass.